### PR TITLE
Google auth and user profiles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,10 +57,13 @@ secrets {
 
 dependencies {
     implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
     implementation("androidx.credentials:credentials:1.3.0")
     implementation("androidx.credentials:credentials-play-services-auth:1.3.0")
+    implementation("com.google.android.gms:play-services-auth:21.2.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/java/com/example/cinet/AuthState.kt
+++ b/app/src/main/java/com/example/cinet/AuthState.kt
@@ -1,0 +1,10 @@
+package com.example.cinet.ui
+
+import com.example.cinet.data.model.UserProfile
+
+sealed class AuthState {
+    object Loading : AuthState()
+    object Unauthenticated : AuthState()
+    data class Authenticated(val userProfile: UserProfile) : AuthState()
+    data class Error(val message: String) : AuthState()
+}

--- a/app/src/main/java/com/example/cinet/LoginScreen.kt
+++ b/app/src/main/java/com/example/cinet/LoginScreen.kt
@@ -1,0 +1,160 @@
+package com.example.cinet
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.ApiException
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.GoogleAuthProvider
+import com.example.cinet.BuildConfig
+
+@Composable
+fun LoginScreen() {
+    val context = LocalContext.current
+    val auth = FirebaseAuth.getInstance()
+    var isLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+            try {
+                val account = task.getResult(ApiException::class.java)
+                val credential = GoogleAuthProvider.getCredential(account.idToken, null)
+                isLoading = true
+                auth.signInWithCredential(credential)
+                    .addOnCompleteListener { authTask ->
+                        isLoading = false
+                        if (!authTask.isSuccessful) {
+                            errorMessage = authTask.exception?.message ?: "Sign-in failed"
+                        }
+                    }
+            } catch (e: ApiException) {
+                errorMessage = e.message ?: "Google sign-in failed"
+            }
+        }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "CINet",
+                style = MaterialTheme.typography.headlineLarge
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Sign in to continue",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(48.dp))
+            if (isLoading) {
+                CircularProgressIndicator()
+            } else {
+                Button(
+                    onClick = {
+                        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                            .requestIdToken(BuildConfig.WEB_CLIENT_ID)
+                            .requestEmail()
+                            .build()
+                        val client = GoogleSignIn.getClient(context, gso)
+                        launcher.launch(client.signInIntent)
+                    }
+                ) {
+                    Text("Sign in with Google")
+                }
+            }
+            errorMessage?.let {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun LoadingScreen() {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            CircularProgressIndicator()
+        }
+    }
+}
+
+@Composable
+fun ErrorScreen(
+    message: String,
+    onRetry: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Something went wrong",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onRetry) {
+                Text("Retry")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/MainActivity.kt
+++ b/app/src/main/java/com/example/cinet/MainActivity.kt
@@ -4,30 +4,37 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.activity.viewModels
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.example.cinet.data.remote.FirestoreRepository
 import com.example.cinet.ui.theme.CINetTheme
+import com.example.cinet.viewmodels.AuthViewModel
+import com.example.cinet.viewmodels.AuthViewModelFactory
 
 class MainActivity : ComponentActivity() {
+
+    private val repository by lazy { FirestoreRepository() }
+
+    private val authViewModel: AuthViewModel by viewModels {
+        AuthViewModelFactory(repository)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // Create a Notification Channel for this app which is required to make notifications appear
         NotificationHelper.createChannel(this)
-
-        // Requests Notification Permission, required for android 13+
         if (!PermissionManager.hasAllPermissions(this)) {
             PermissionManager.requestAllPermissions(this)
         }
-
         enableEdgeToEdge()
         setContent {
             CINetTheme {
-                // State to keep track of the current screen
-                NavigationHandler()
+                val authState by authViewModel.authState.collectAsState()
+                NavigationHandler(
+                    authState = authState,
+                    onSignOut = { authViewModel.signOut() },
+                    onRetry = { authViewModel.retryProfileLoad() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/cinet/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/NavigationHandler.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.example.cinet.ui.AuthState
 
-// Page types
 enum class Screen(val label: String, val icon: ImageVector) {
     Home("Home", Icons.Default.Home),
     Notifications("Notifications", Icons.Default.Notifications),
@@ -33,7 +33,26 @@ enum class Screen(val label: String, val icon: ImageVector) {
 }
 
 @Composable
-fun NavigationHandler() {
+fun NavigationHandler(
+    authState: AuthState,
+    onSignOut: () -> Unit,
+    onRetry: () -> Unit
+) {
+    when (authState) {
+        is AuthState.Loading -> LoadingScreen()
+        is AuthState.Unauthenticated -> LoginScreen()
+        is AuthState.Error -> ErrorScreen(
+            message = authState.message,
+            onRetry = onRetry
+        )
+        is AuthState.Authenticated -> MainScaffold(
+            onSignOut = onSignOut
+        )
+    }
+}
+
+@Composable
+private fun MainScaffold(onSignOut: () -> Unit) {
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Home) }
 
     Scaffold(
@@ -50,7 +69,8 @@ fun NavigationHandler() {
                                 maxLines = 1,
                                 softWrap = false,
                                 style = MaterialTheme.typography.labelSmall
-                                ) },
+                            )
+                        },
                         icon = {
                             Icon(
                                 imageVector = screen.icon,
@@ -62,30 +82,30 @@ fun NavigationHandler() {
             }
         }
     ) { innerPadding ->
-            // Main content area that swaps between screens
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                when (currentScreen) {
-                    Screen.Home -> HomeScreen(
-                        onMapClick = { currentScreen = Screen.Map },
-                        onSettingsClick = { currentScreen = Screen.Settings }
-                    )
-                    Screen.Notifications -> NotificationScreen(
-                        onBack = { currentScreen = Screen.Home }
-                    )
-                    Screen.Map -> CampusMapScreen(
-                        onBack = { currentScreen = Screen.Home }
-                    )
-                    Screen.Calendar -> CalendarScreen(
-                        onBack = { currentScreen = Screen.Home }
-                    )
-                    Screen.Settings -> SettingScreen(
-                        onBack = { currentScreen = Screen.Home }
-                    )
-                }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            when (currentScreen) {
+                Screen.Home -> HomeScreen(
+                    onMapClick = { currentScreen = Screen.Map },
+                    onSettingsClick = { currentScreen = Screen.Settings }
+                )
+                Screen.Notifications -> NotificationScreen(
+                    onBack = { currentScreen = Screen.Home }
+                )
+                Screen.Map -> CampusMapScreen(
+                    onBack = { currentScreen = Screen.Home }
+                )
+                Screen.Calendar -> CalendarScreen(
+                    onBack = { currentScreen = Screen.Home }
+                )
+                Screen.Settings -> SettingScreen(
+                    onBack = { currentScreen = Screen.Home },
+                    onSignOut = onSignOut
+                )
             }
+        }
     }
 }

--- a/app/src/main/java/com/example/cinet/Setting.kt
+++ b/app/src/main/java/com/example/cinet/Setting.kt
@@ -7,8 +7,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
-@Composable //dummy screen for demo nav (slightly diff from maps to differentiate)
-fun SettingScreen(onBack: () -> Unit) {
+@Composable
+fun SettingScreen(
+    onBack: () -> Unit,
+    onSignOut: () -> Unit
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
@@ -18,6 +21,10 @@ fun SettingScreen(onBack: () -> Unit) {
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = onBack) {
             Text("Back to Home")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onSignOut) {
+            Text("Sign out")
         }
     }
 }

--- a/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
+++ b/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
@@ -5,8 +5,9 @@ import java.util.Date
 
 data class UserProfile(
     val uid: String = "",
-    val displayName: String = "",
     val email: String = "",
+    val nickname: String = "",
+    val major: String = "",
     val photoUrl: String = "",
     @ServerTimestamp val createdAt: Date? = null,
     @ServerTimestamp val lastLoginAt: Date? = null,

--- a/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
+++ b/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
@@ -1,11 +1,13 @@
 package com.example.cinet.data.model
 
-import com.google.firebase.Timestamp
+import com.google.firebase.firestore.ServerTimestamp
+import java.util.Date
 
 data class UserProfile(
     val uid: String = "",
     val displayName: String = "",
     val email: String = "",
-    val photoUrl: String? = null,
-    val createdAt: Timestamp? = null,
+    val photoUrl: String = "",
+    @ServerTimestamp val createdAt: Date? = null,
+    @ServerTimestamp val lastLoginAt: Date? = null,
 )

--- a/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
@@ -21,7 +21,6 @@ class FirestoreRepository(
 
             val loginUpdate = mapOf(
                 "uid"         to user.uid,
-                "displayName" to (user.displayName ?: "Unknown User"),
                 "email"       to (user.email ?: ""),
                 "photoUrl"    to (user.photoUrl?.toString() ?: ""),
                 "lastLoginAt" to FieldValue.serverTimestamp(),

--- a/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
@@ -5,28 +5,42 @@ import com.example.cinet.data.model.CampusEvent
 import com.example.cinet.data.model.UserProfile
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
 
 class FirestoreRepository(
     private val db: FirebaseFirestore = FirebaseFirestore.getInstance(),
     private val auth: FirebaseAuth = FirebaseAuth.getInstance(),
 ) {
-    suspend fun saveCurrentUserProfile() {
-        val user = auth.currentUser ?: error("No signed-in user.")
+    suspend fun createOrLoadUserProfile(): Result<UserProfile> {
+        return try {
+            val user = auth.currentUser ?: error("No signed-in user.")
+            val docRef = db.collection(FirestoreCollections.USERS).document(user.uid)
 
-        val profile = UserProfile(
-            uid = user.uid,
-            displayName = user.displayName ?: "Unknown User",
-            email = user.email ?: "",
-            photoUrl = user.photoUrl?.toString(),
-            createdAt = Timestamp.now(),
-        )
+            val loginUpdate = mapOf(
+                "uid"         to user.uid,
+                "displayName" to (user.displayName ?: "Unknown User"),
+                "email"       to (user.email ?: ""),
+                "photoUrl"    to (user.photoUrl?.toString() ?: ""),
+                "lastLoginAt" to FieldValue.serverTimestamp(),
+            )
 
-        db.collection(FirestoreCollections.USERS)
-            .document(user.uid)
-            .set(profile)
-            .await()
+            docRef.set(loginUpdate, SetOptions.merge()).await()
+
+            val snapshot = docRef.get().await()
+            if (snapshot.getTimestamp("createdAt") == null) {
+                docRef.update("createdAt", FieldValue.serverTimestamp()).await()
+            }
+
+            val profile = snapshot.toObject(UserProfile::class.java)
+                ?: return Result.failure(Exception("Failed to parse UserProfile"))
+
+            Result.success(profile)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
     suspend fun loadCurrentUserProfile(): UserProfile? {
@@ -64,8 +78,6 @@ class FirestoreRepository(
             .get()
             .await()
 
-        return snapshot.documents.mapNotNull { document ->
-            document.toObject(CampusEvent::class.java)
-        }
+        return snapshot.documents.mapNotNull { it.toObject(CampusEvent::class.java) }
     }
 }

--- a/app/src/main/java/com/example/cinet/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/example/cinet/viewmodels/AuthViewModel.kt
@@ -1,0 +1,76 @@
+package com.example.cinet.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.cinet.data.remote.FirestoreRepository
+import com.example.cinet.ui.AuthState
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class AuthViewModel(
+    private val repository: FirestoreRepository
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "AuthViewModel"
+    }
+
+    private val auth = FirebaseAuth.getInstance()
+
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Loading)
+    val authState: StateFlow<AuthState> = _authState.asStateFlow()
+
+    private var authStateListener: FirebaseAuth.AuthStateListener? = null
+
+    init {
+        observeAuthState()
+    }
+
+    fun signOut() {
+        auth.signOut()
+    }
+
+    fun retryProfileLoad() {
+        val user = auth.currentUser ?: return
+        viewModelScope.launch {
+            _authState.value = AuthState.Loading
+            repository.createOrLoadUserProfile()
+                .onSuccess { _authState.value = AuthState.Authenticated(it) }
+                .onFailure { _authState.value = AuthState.Error(it.message ?: "Unknown error") }
+        }
+    }
+
+    private fun observeAuthState() {
+        authStateListener = FirebaseAuth.AuthStateListener { firebaseAuth ->
+            val user = firebaseAuth.currentUser
+            if (user == null) {
+                _authState.value = AuthState.Unauthenticated
+            } else {
+                viewModelScope.launch {
+                    _authState.value = AuthState.Loading
+                    repository.createOrLoadUserProfile()
+                        .onSuccess { _authState.value = AuthState.Authenticated(it) }
+                        .onFailure { _authState.value = AuthState.Error(it.message ?: "Unknown error") }
+                }
+            }
+        }
+        auth.addAuthStateListener(authStateListener!!)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        authStateListener?.let { auth.removeAuthStateListener(it) }
+    }
+}
+
+class AuthViewModelFactory(
+    private val repository: FirestoreRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
+        AuthViewModel(repository) as T
+}


### PR DESCRIPTION
## Google Auth + Firestore User Profile Integration

### What this PR does
Implements Firebase Authentication with Google Sign-In and connects it to Firestore user profile management.

### Changes
- Add `AuthState` sealed class to represent Loading, Authenticated, Unauthenticated, and Error states
- Add `AuthViewModel` with `AuthStateListener` to observe Firebase auth state and drive navigation
- Add `LoginScreen`, `LoadingScreen`, and `ErrorScreen` composables
- Update `FirestoreRepository` with `createOrLoadUserProfile()` using `SetOptions.merge()` to safely upsert on login without overwriting existing user data
- Update `UserProfile` model to match Firestore schema — adds `nickname`, `major`, `lastLoginAt`, removes `displayName`
- Update `MainActivity` to wire `AuthViewModel` into `NavigationHandler`
- Update `NavigationHandler` to branch on `AuthState`
- Update `SettingScreen` to expose `onSignOut` callback

### Notes
- `nickname` and `major` are intentionally excluded from the login upsert — they are user-set fields and must not be overwritten on login
- SHA-1 debug fingerprint has been registered in Firebase Console
- Requires API 34 emulator with Play Store for Google Sign-In to work