### PR TITLE
User profile setup

### DIFF
--- a/app/src/main/java/com/example/cinet/AuthState.kt
+++ b/app/src/main/java/com/example/cinet/AuthState.kt
@@ -5,6 +5,7 @@ import com.example.cinet.data.model.UserProfile
 sealed class AuthState {
     object Loading : AuthState()
     object Unauthenticated : AuthState()
+    data class ProfileSetup(val userProfile: UserProfile) : AuthState()
     data class Authenticated(val userProfile: UserProfile) : AuthState()
     data class Error(val message: String) : AuthState()
 }

--- a/app/src/main/java/com/example/cinet/MainActivity.kt
+++ b/app/src/main/java/com/example/cinet/MainActivity.kt
@@ -33,7 +33,10 @@ class MainActivity : ComponentActivity() {
                 NavigationHandler(
                     authState = authState,
                     onSignOut = { authViewModel.signOut() },
-                    onRetry = { authViewModel.retryProfileLoad() }
+                    onRetry = { authViewModel.retryProfileLoad() },
+                    onSaveProfile = { nickname, major, pronouns ->
+                        authViewModel.saveProfile(nickname, major, pronouns)
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/example/cinet/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/NavigationHandler.kt
@@ -36,11 +36,15 @@ enum class Screen(val label: String, val icon: ImageVector) {
 fun NavigationHandler(
     authState: AuthState,
     onSignOut: () -> Unit,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onSaveProfile: (String, String, String) -> Unit
 ) {
     when (authState) {
         is AuthState.Loading -> LoadingScreen()
         is AuthState.Unauthenticated -> LoginScreen()
+        is AuthState.ProfileSetup -> ProfileSetupScreen(
+            onSaveProfile = onSaveProfile
+        )
         is AuthState.Error -> ErrorScreen(
             message = authState.message,
             onRetry = onRetry

--- a/app/src/main/java/com/example/cinet/ProfileSetupScreen.kt
+++ b/app/src/main/java/com/example/cinet/ProfileSetupScreen.kt
@@ -1,0 +1,154 @@
+package com.example.cinet
+
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private val pronounOptions = listOf(
+    "He/Him",
+    "She/Her",
+    "They/Them",
+    "Ze/Zir",
+    "Xe/Xem",
+    "Prefer not to say",
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileSetupScreen(
+    onSaveProfile: (nickname: String, major: String, pronouns: String) -> Unit
+) {
+    var nickname by remember { mutableStateOf("") }
+    var major by remember { mutableStateOf("") }
+    var selectedPronouns by remember { mutableStateOf(pronounOptions.first()) }
+    var pronounsExpanded by remember { mutableStateOf(false) }
+    var nicknameError by remember { mutableStateOf(false) }
+    var majorError by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Set up your profile",
+                style = MaterialTheme.typography.headlineMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "This is how other students will see you",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+
+            OutlinedTextField(
+                value = nickname,
+                onValueChange = {
+                    nickname = it
+                    nicknameError = false
+                },
+                label = { Text("Nickname") },
+                singleLine = true,
+                isError = nicknameError,
+                supportingText = if (nicknameError) {
+                    { Text("Nickname is required") }
+                } else null,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = major,
+                onValueChange = {
+                    major = it
+                    majorError = false
+                },
+                label = { Text("Major") },
+                singleLine = true,
+                isError = majorError,
+                supportingText = if (majorError) {
+                    { Text("Major is required") }
+                } else null,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ExposedDropdownMenuBox(
+                expanded = pronounsExpanded,
+                onExpandedChange = { pronounsExpanded = it },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = selectedPronouns,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Pronouns") },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = pronounsExpanded)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                )
+                ExposedDropdownMenu(
+                    expanded = pronounsExpanded,
+                    onDismissRequest = { pronounsExpanded = false }
+                ) {
+                    pronounOptions.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = {
+                                selectedPronouns = option
+                                pronounsExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Button(
+                onClick = {
+                    nicknameError = nickname.isBlank()
+                    majorError = major.isBlank()
+                    if (!nicknameError && !majorError) {
+                        onSaveProfile(nickname.trim(), major.trim(), selectedPronouns)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Continue")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/Setting.kt
+++ b/app/src/main/java/com/example/cinet/Setting.kt
@@ -10,6 +10,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 
+/* just need to change from false to
+true with a button click
+ */
+object AppSettings {
+    var isDarkMap: Boolean
+    by mutableStateOf(true)
+}
 @Composable
 fun SettingScreen(
     onBack: () -> Unit,

--- a/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
+++ b/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
@@ -8,6 +8,7 @@ data class UserProfile(
     val email: String = "",
     val nickname: String = "",
     val major: String = "",
+    val pronouns: String = "",
     val photoUrl: String = "",
     @ServerTimestamp val createdAt: Date? = null,
     @ServerTimestamp val lastLoginAt: Date? = null,

--- a/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
@@ -42,14 +42,39 @@ class FirestoreRepository(
         }
     }
 
+    suspend fun saveProfileDetails(
+        nickname: String,
+        major: String,
+        pronouns: String,
+    ): Result<UserProfile> {
+        return try {
+            val user = auth.currentUser ?: error("No signed-in user.")
+            val docRef = db.collection(FirestoreCollections.USERS).document(user.uid)
+
+            val profileUpdate = mapOf(
+                "nickname" to nickname,
+                "major"    to major,
+                "pronouns" to pronouns,
+            )
+
+            docRef.set(profileUpdate, SetOptions.merge()).await()
+
+            val snapshot = docRef.get().await()
+            val profile = snapshot.toObject(UserProfile::class.java)
+                ?: return Result.failure(Exception("Failed to parse UserProfile"))
+
+            Result.success(profile)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     suspend fun loadCurrentUserProfile(): UserProfile? {
         val uid = auth.currentUser?.uid ?: error("No signed-in user.")
-
         val snapshot = db.collection(FirestoreCollections.USERS)
             .document(uid)
             .get()
             .await()
-
         return snapshot.toObject(UserProfile::class.java)
     }
 
@@ -76,7 +101,6 @@ class FirestoreRepository(
         val snapshot = db.collection(FirestoreCollections.EVENTS)
             .get()
             .await()
-
         return snapshot.documents.mapNotNull { it.toObject(CampusEvent::class.java) }
     }
 }

--- a/app/src/main/java/com/example/cinet/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/example/cinet/viewmodels/AuthViewModel.kt
@@ -3,6 +3,7 @@ package com.example.cinet.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.example.cinet.data.model.UserProfile
 import com.example.cinet.data.remote.FirestoreRepository
 import com.example.cinet.ui.AuthState
 import com.google.firebase.auth.FirebaseAuth
@@ -35,12 +36,28 @@ class AuthViewModel(
     }
 
     fun retryProfileLoad() {
-        val user = auth.currentUser ?: return
         viewModelScope.launch {
             _authState.value = AuthState.Loading
             repository.createOrLoadUserProfile()
+                .onSuccess { resolveState(it) }
+                .onFailure { _authState.value = AuthState.Error(it.message ?: "Unknown error") }
+        }
+    }
+
+    fun saveProfile(nickname: String, major: String, pronouns: String) {
+        viewModelScope.launch {
+            _authState.value = AuthState.Loading
+            repository.saveProfileDetails(nickname, major, pronouns)
                 .onSuccess { _authState.value = AuthState.Authenticated(it) }
                 .onFailure { _authState.value = AuthState.Error(it.message ?: "Unknown error") }
+        }
+    }
+
+    private fun resolveState(profile: UserProfile) {
+        _authState.value = if (profile.nickname.isBlank()) {
+            AuthState.ProfileSetup(profile)
+        } else {
+            AuthState.Authenticated(profile)
         }
     }
 
@@ -53,7 +70,7 @@ class AuthViewModel(
                 viewModelScope.launch {
                     _authState.value = AuthState.Loading
                     repository.createOrLoadUserProfile()
-                        .onSuccess { _authState.value = AuthState.Authenticated(it) }
+                        .onSuccess { resolveState(it) }
                         .onFailure { _authState.value = AuthState.Error(it.message ?: "Unknown error") }
                 }
             }


### PR DESCRIPTION
## User Profile Setup

### What this PR does
Adds a profile setup screen that appears after first login, requiring new users to enter their nickname, major, and pronouns before accessing the app. Returning users with an existing nickname skip directly to the main app.

### Changes
- Add `pronouns` field to `UserProfile` model
- Add `ProfileSetup` state to `AuthState` sealed class
- Update `AuthViewModel` to detect new users (blank nickname) and route them to profile setup instead of main app
- Add `saveProfile()` to `AuthViewModel` and `saveProfileDetails()` to `FirestoreRepository`
- Add `ProfileSetupScreen` composable with nickname, major, and pronouns dropdown fields with validation
- Update `NavigationHandler` to handle `ProfileSetup` auth state
- Update `MainActivity` to pass `onSaveProfile` callback through

### Notes
- Pronouns options: He/Him, She/Her, They/Them, Ze/Zir, Xe/Xem, Prefer not to say
- Nickname and major are required fields — users cannot proceed without filling them out
- `nickname` and `major` are intentionally excluded from the login upsert in `FirestoreRepository` so they are never overwritten on subsequent logins
- Whoever is going to code into Settings.kt can use `ProfileSetupScreen.kt` as a reference for building the profile edit form — same UI, pre-filled with existing values from `UserProfile`