### PR TITLE
User social improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -56,6 +57,7 @@ secrets {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
     implementation(platform("com.google.firebase:firebase-bom:34.11.0"))
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,15 @@
         android:theme="@style/Theme.CINet"
         tools:replace="android:fullBackupContent,android:dataExtractionRules,android:allowBackup">
 
+
+        <receiver
+            android:name=".ClassReminderReceiver"
+            android:exported="false"
+            />
+        <receiver
+            android:name=".AssignmentReminderReceiver"
+            android:exported="false" />
+
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />

--- a/app/src/main/java/CalendarFirestoreRepository.kt
+++ b/app/src/main/java/CalendarFirestoreRepository.kt
@@ -11,201 +11,139 @@ class CalendarFirestoreRepository(
 ) {
 
     private fun getUid(): String {
-        // All data is stored under users/{uid}/..., so every operation depends
-        // on having a currently authenticated Firebase user.
         val uid = auth.currentUser?.uid
             ?: throw IllegalStateException("No signed-in user found.")
-
         Log.d("FirestoreDebug", "Current UID: $uid")
         return uid
     }
 
     suspend fun loadClasses(): List<ClassItem> {
         val uid = getUid()
-
         android.util.Log.d("FirestoreDebug", "Loading classes from users/$uid/classes")
-
-        val snapshot = db.collection("users")
-            .document(uid)
-            .collection("classes")
-            .get()
-            .await() // Converts Firebase Task → coroutine suspend call
-
+        val snapshot = db.collection("users").document(uid).collection("classes").get().await()
         android.util.Log.d("FirestoreDebug", "Class documents found: ${snapshot.documents.size}")
-
         return snapshot.documents.mapNotNull { doc ->
-            // If any required field is missing, that document is skipped entirely.
             val name = doc.getString("name") ?: return@mapNotNull null
             val meetingDays = doc.get("meetingDays") as? List<String> ?: emptyList()
             val startTime = doc.getString("startTime") ?: return@mapNotNull null
             val endTime = doc.getString("endTime") ?: return@mapNotNull null
-
-            android.util.Log.d(
-                "FirestoreDebug",
-                "Loaded class -> id=${doc.id}, name=$name, meetingDays=$meetingDays, start=$startTime, end=$endTime"
-            )
-
-            ClassItem(
-                id = doc.id, // Firestore document ID becomes the app's class ID
-                name = name,
-                meetingDays = meetingDays,
-                startTime = startTime,
-                endTime = endTime
-            )
+            ClassItem(id = doc.id, name = name, meetingDays = meetingDays, startTime = startTime, endTime = endTime)
         }
     }
 
     suspend fun loadAssignments(): List<ScheduleItem> {
         val uid = getUid()
-
-        val snapshot = db.collection("users")
-            .document(uid)
-            .collection("assignments")
-            .get()
-            .await()
-
+        val snapshot = db.collection("users").document(uid).collection("assignments").get().await()
         return snapshot.documents.mapNotNull { doc ->
-            // Same pattern: skip any malformed or incomplete documents.
             val date = doc.getString("date") ?: return@mapNotNull null
             val classId = doc.getString("classId") ?: return@mapNotNull null
             val className = doc.getString("className") ?: return@mapNotNull null
             val assignmentName = doc.getString("assignmentName") ?: return@mapNotNull null
             val dueTime = doc.getString("dueTime") ?: return@mapNotNull null
-
-            ScheduleItem(
-                id = doc.id,
-                date = date, // Must match the format used elsewhere (e.g., CalendarGrid)
-                classId = classId,
-                className = className,
-                assignmentName = assignmentName,
-                dueTime = dueTime
-            )
+            ScheduleItem(id = doc.id, date = date, classId = classId, className = className, assignmentName = assignmentName, dueTime = dueTime)
         }
     }
 
-    suspend fun addAssignment(
-        date: String,
-        classId: String,
-        className: String,
-        assignmentName: String,
-        dueTime: String
-    ) {
+    suspend fun loadStudySessions(): List<StudySession> {
         val uid = getUid()
+        val snapshot = db.collection("users").document(uid).collection("studySessions").get().await()
+        return snapshot.documents.mapNotNull { doc ->
+            val date = doc.getString("date") ?: return@mapNotNull null
+            val className = doc.getString("className") ?: return@mapNotNull null
+            val topic = doc.getString("topic") ?: return@mapNotNull null
+            val startTime = doc.getString("startTime") ?: return@mapNotNull null
+            val location = doc.getString("location") ?: ""
+            StudySession(id = doc.id, date = date, className = className, topic = topic, startTime = startTime, location = location)
+        }
+    }
 
-        val assignmentData = mapOf(
-            // Field names must match what loadAssignments() expects.
-            "date" to date,
-            "classId" to classId,
-            "className" to className,
-            "assignmentName" to assignmentName,
-            "dueTime" to dueTime
-        )
+    suspend fun loadEvents(): List<EventItem> {
+        val uid = getUid()
+        val snapshot = db.collection("users").document(uid).collection("events").get().await()
+        return snapshot.documents.mapNotNull { doc ->
+            val date = doc.getString("date") ?: return@mapNotNull null
+            val name = doc.getString("name") ?: return@mapNotNull null
+            val time = doc.getString("time") ?: return@mapNotNull null
+            val location = doc.getString("location") ?: ""
+            EventItem(id = doc.id, date = date, name = name, time = time, location = location)
+        }
+    }
 
-        db.collection("users")
-            .document(uid)
-            .collection("assignments")
-            // .add() generates a new document ID automatically.
-            .add(assignmentData)
+    suspend fun addAssignment(date: String, classId: String, className: String, assignmentName: String, dueTime: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("assignments")
+            .add(mapOf("date" to date, "classId" to classId, "className" to className, "assignmentName" to assignmentName, "dueTime" to dueTime))
             .await()
     }
 
-    suspend fun updateAssignment(
-        assignmentId: String,
-        date: String,
-        classId: String,
-        className: String,
-        assignmentName: String,
-        dueTime: String
-    ) {
+    suspend fun updateAssignment(assignmentId: String, date: String, classId: String, className: String, assignmentName: String, dueTime: String) {
         val uid = getUid()
-
-        val assignmentData = mapOf(
-            "date" to date,
-            "classId" to classId,
-            "className" to className,
-            "assignmentName" to assignmentName,
-            "dueTime" to dueTime
-        )
-
-        db.collection("users")
-            .document(uid)
-            .collection("assignments")
-            .document(assignmentId)
-            // .set() overwrites the entire document (not partial update).
-            .set(assignmentData)
+        db.collection("users").document(uid).collection("assignments").document(assignmentId)
+            .set(mapOf("date" to date, "classId" to classId, "className" to className, "assignmentName" to assignmentName, "dueTime" to dueTime))
             .await()
     }
 
     suspend fun deleteAssignment(assignmentId: String) {
         val uid = getUid()
+        db.collection("users").document(uid).collection("assignments").document(assignmentId).delete().await()
+    }
 
-        db.collection("users")
-            .document(uid)
-            .collection("assignments")
-            .document(assignmentId)
-            .delete()
+    suspend fun addStudySession(date: String, className: String, topic: String, startTime: String, location: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("studySessions")
+            .add(mapOf("date" to date, "className" to className, "topic" to topic, "startTime" to startTime, "location" to location))
             .await()
     }
 
-    suspend fun addClass(
-        name: String,
-        meetingDays: List<String>,
-        startTime: String,
-        endTime: String
-    ) {
+    suspend fun updateStudySession(sessionId: String, date: String, className: String, topic: String, startTime: String, location: String) {
         val uid = getUid()
-
-        val classData = mapOf(
-            // Must match loadClasses() field expectations.
-            "name" to name,
-            "meetingDays" to meetingDays,
-            "startTime" to startTime,
-            "endTime" to endTime
-        )
-
-        db.collection("users")
-            .document(uid)
-            .collection("classes")
-            .add(classData)
+        db.collection("users").document(uid).collection("studySessions").document(sessionId)
+            .set(mapOf("date" to date, "className" to className, "topic" to topic, "startTime" to startTime, "location" to location))
             .await()
+    }
 
+    suspend fun deleteStudySession(sessionId: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("studySessions").document(sessionId).delete().await()
+    }
+
+    suspend fun addEvent(date: String, name: String, time: String, location: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("events")
+            .add(mapOf("date" to date, "name" to name, "time" to time, "location" to location))
+            .await()
+    }
+
+    suspend fun updateEvent(eventId: String, date: String, name: String, time: String, location: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("events").document(eventId)
+            .set(mapOf("date" to date, "name" to name, "time" to time, "location" to location))
+            .await()
+    }
+
+    suspend fun deleteEvent(eventId: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("events").document(eventId).delete().await()
+    }
+
+    suspend fun addClass(name: String, meetingDays: List<String>, startTime: String, endTime: String) {
+        val uid = getUid()
+        db.collection("users").document(uid).collection("classes")
+            .add(mapOf("name" to name, "meetingDays" to meetingDays, "startTime" to startTime, "endTime" to endTime))
+            .await()
         android.util.Log.d("FirestoreDebug", "Added class successfully: $name")
         Log.d("FirestoreDebug", "Added class: $name")
     }
 
-    suspend fun updateClass(
-        classId: String,
-        name: String,
-        meetingDays: List<String>,
-        startTime: String,
-        endTime: String
-    ) {
+    suspend fun updateClass(classId: String, name: String, meetingDays: List<String>, startTime: String, endTime: String) {
         val uid = getUid()
-
-        val classData = mapOf(
-            "name" to name,
-            "meetingDays" to meetingDays,
-            "startTime" to startTime,
-            "endTime" to endTime
-        )
-
-        db.collection("users")
-            .document(uid)
-            .collection("classes")
-            .document(classId)
-            // Overwrites entire class document.
-            .set(classData)
+        db.collection("users").document(uid).collection("classes").document(classId)
+            .set(mapOf("name" to name, "meetingDays" to meetingDays, "startTime" to startTime, "endTime" to endTime))
             .await()
     }
 
     suspend fun deleteClass(classId: String) {
         val uid = getUid()
-
-        db.collection("users")
-            .document(uid)
-            .collection("classes")
-            .document(classId)
-            .delete()
-            .await()
+        db.collection("users").document(uid).collection("classes").document(classId).delete().await()
     }
 }

--- a/app/src/main/java/CalendarFirestoreRepository.kt
+++ b/app/src/main/java/CalendarFirestoreRepository.kt
@@ -11,8 +11,6 @@ class CalendarFirestoreRepository(
 ) {
 
     private fun getUid(): String {
-        // All data is stored under users/{uid}/..., so every operation depends
-        // on having a currently authenticated Firebase user.
         val uid = auth.currentUser?.uid
             ?: throw IllegalStateException("No signed-in user found.")
 
@@ -23,30 +21,29 @@ class CalendarFirestoreRepository(
     suspend fun loadClasses(): List<ClassItem> {
         val uid = getUid()
 
-        android.util.Log.d("FirestoreDebug", "Loading classes from users/$uid/classes")
+        Log.d("FirestoreDebug", "Loading classes from users/$uid/classes")
 
         val snapshot = db.collection("users")
             .document(uid)
             .collection("classes")
             .get()
-            .await() // Converts Firebase Task → coroutine suspend call
+            .await()
 
-        android.util.Log.d("FirestoreDebug", "Class documents found: ${snapshot.documents.size}")
+        Log.d("FirestoreDebug", "Class documents found: ${snapshot.documents.size}")
 
         return snapshot.documents.mapNotNull { doc ->
-            // If any required field is missing, that document is skipped entirely.
             val name = doc.getString("name") ?: return@mapNotNull null
             val meetingDays = doc.get("meetingDays") as? List<String> ?: emptyList()
             val startTime = doc.getString("startTime") ?: return@mapNotNull null
             val endTime = doc.getString("endTime") ?: return@mapNotNull null
 
-            android.util.Log.d(
+            Log.d(
                 "FirestoreDebug",
                 "Loaded class -> id=${doc.id}, name=$name, meetingDays=$meetingDays, start=$startTime, end=$endTime"
             )
 
             ClassItem(
-                id = doc.id, // Firestore document ID becomes the app's class ID
+                id = doc.id,
                 name = name,
                 meetingDays = meetingDays,
                 startTime = startTime,
@@ -65,7 +62,6 @@ class CalendarFirestoreRepository(
             .await()
 
         return snapshot.documents.mapNotNull { doc ->
-            // Same pattern: skip any malformed or incomplete documents.
             val date = doc.getString("date") ?: return@mapNotNull null
             val classId = doc.getString("classId") ?: return@mapNotNull null
             val className = doc.getString("className") ?: return@mapNotNull null
@@ -74,7 +70,7 @@ class CalendarFirestoreRepository(
 
             ScheduleItem(
                 id = doc.id,
-                date = date, // Must match the format used elsewhere (e.g., CalendarGrid)
+                date = date,
                 classId = classId,
                 className = className,
                 assignmentName = assignmentName,
@@ -93,7 +89,6 @@ class CalendarFirestoreRepository(
         val uid = getUid()
 
         val assignmentData = mapOf(
-            // Field names must match what loadAssignments() expects.
             "date" to date,
             "classId" to classId,
             "className" to className,
@@ -104,7 +99,6 @@ class CalendarFirestoreRepository(
         db.collection("users")
             .document(uid)
             .collection("assignments")
-            // .add() generates a new document ID automatically.
             .add(assignmentData)
             .await()
     }
@@ -131,7 +125,6 @@ class CalendarFirestoreRepository(
             .document(uid)
             .collection("assignments")
             .document(assignmentId)
-            // .set() overwrites the entire document (not partial update).
             .set(assignmentData)
             .await()
     }
@@ -152,25 +145,33 @@ class CalendarFirestoreRepository(
         meetingDays: List<String>,
         startTime: String,
         endTime: String
-    ) {
+    ): ClassItem {
         val uid = getUid()
 
         val classData = mapOf(
-            // Must match loadClasses() field expectations.
             "name" to name,
             "meetingDays" to meetingDays,
             "startTime" to startTime,
             "endTime" to endTime
         )
 
-        db.collection("users")
+        val docRef = db.collection("users")
             .document(uid)
             .collection("classes")
             .add(classData)
             .await()
 
-        android.util.Log.d("FirestoreDebug", "Added class successfully: $name")
-        Log.d("FirestoreDebug", "Added class: $name")
+        val newClass = ClassItem(
+            id = docRef.id,
+            name = name,
+            meetingDays = meetingDays,
+            startTime = startTime,
+            endTime = endTime
+        )
+
+        Log.d("FirestoreDebug", "Added class successfully: ${newClass.name}, id=${newClass.id}")
+
+        return newClass
     }
 
     suspend fun updateClass(
@@ -193,9 +194,10 @@ class CalendarFirestoreRepository(
             .document(uid)
             .collection("classes")
             .document(classId)
-            // Overwrites entire class document.
             .set(classData)
             .await()
+
+        Log.d("FirestoreDebug", "Updated class successfully: $name, id=$classId")
     }
 
     suspend fun deleteClass(classId: String) {
@@ -207,5 +209,7 @@ class CalendarFirestoreRepository(
             .document(classId)
             .delete()
             .await()
+
+        Log.d("FirestoreDebug", "Deleted class successfully: id=$classId")
     }
 }

--- a/app/src/main/java/CalendarViewModel.kt
+++ b/app/src/main/java/CalendarViewModel.kt
@@ -4,57 +4,79 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import java.time.LocalDate
 import java.time.YearMonth
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
 class CalendarViewModel : ViewModel() {
 
-    // mutableStateOf makes Compose automatically recompose UI when these values change.
     var currentMonth by mutableStateOf(YearMonth.now())
         private set
-
     var selectedDate by mutableStateOf<LocalDate?>(null)
         private set
-
     var classItems by mutableStateOf<List<ClassItem>>(emptyList())
         private set
-
     var scheduleItems by mutableStateOf<List<ScheduleItem>>(emptyList())
         private set
+    var studySessions by mutableStateOf<List<StudySession>>(emptyList())
+        private set
+    var eventItems by mutableStateOf<List<EventItem>>(emptyList())
+        private set
 
-    fun nextMonth() {
-        currentMonth = currentMonth.plusMonths(1)
+    private val repository = CalendarFirestoreRepository()
+
+    init {
+        refreshClasses()
+        refreshAssignments()
+        refreshStudySessions()
+        refreshEvents()
     }
 
-    fun previousMonth() {
-        currentMonth = currentMonth.minusMonths(1)
+    fun nextMonth() { currentMonth = currentMonth.plusMonths(1) }
+    fun previousMonth() { currentMonth = currentMonth.minusMonths(1) }
+    fun selectDate(day: Int) { selectedDate = currentMonth.atDay(day) }
+
+    fun getItemsForSelectedDate(): List<ScheduleItem> {
+        val date = selectedDate ?: return emptyList()
+        val formattedDate = formatDate(date)
+        return scheduleItems.filter { it.date == formattedDate }.sortedBy { parseTimeToSortableValue(it.dueTime) }
     }
 
-    fun selectDate(day: Int) {
-        selectedDate = currentMonth.atDay(day)
+    fun getClassesForSelectedDate(): List<ClassItem> {
+        val date = selectedDate ?: return emptyList()
+        val dayName = when (date.dayOfWeek.value) {
+            1 -> "Mon"; 2 -> "Tue"; 3 -> "Wed"; 4 -> "Thu"
+            5 -> "Fri"; 6 -> "Sat"; 7 -> "Sun"; else -> ""
+        }
+        return classItems.filter { it.meetingDays.contains(dayName) }.sortedBy { parseTimeToSortableValue(it.startTime) }
     }
 
-    fun addClass(
-        name: String,
-        meetingDays: List<String>,
-        startTime: String,
-        endTime: String
-    ) {
+    fun getStudySessionsForSelectedDate(): List<StudySession> {
+        val date = selectedDate ?: return emptyList()
+        val formattedDate = formatDate(date)
+        return studySessions.filter { it.date == formattedDate }.sortedBy { parseTimeToSortableValue(it.startTime) }
+    }
+
+    fun getEventsForSelectedDate(): List<EventItem> {
+        val date = selectedDate ?: return emptyList()
+        val formattedDate = formatDate(date)
+        return eventItems.filter { it.date == formattedDate }.sortedBy { parseTimeToSortableValue(it.time) }
+    }
+
+    fun getClassesGroupedByDay(): Map<String, List<ClassItem>> {
         val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+        return orderedDays.associateWith { day ->
+            classItems.filter { it.meetingDays.contains(day) }.sortedBy { parseTimeToSortableValue(it.startTime) }
+        }.filterValues { it.isNotEmpty() }
+    }
 
-        // Ensures consistent ordering regardless of user selection order.
-        val sortedMeetingDays = meetingDays.sortedBy { orderedDays.indexOf(it) }
-
+    fun addClass(name: String, meetingDays: List<String>, startTime: String, endTime: String) {
+        val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+        val sortedDays = meetingDays.sortedBy { orderedDays.indexOf(it) }
         viewModelScope.launch {
             try {
-                repository.addClass(
-                    name = name,
-                    meetingDays = sortedMeetingDays,
-                    startTime = startTime,
-                    endTime = endTime
-                )
+                repository.addClass(name, sortedDays, startTime, endTime)
                 refreshClasses()
             } catch (e: Exception) {
                 android.util.Log.e("FirestoreDebug", "addClass failed", e)
@@ -62,34 +84,13 @@ class CalendarViewModel : ViewModel() {
         }
     }
 
-    fun updateClass(
-        classId: String,
-        name: String,
-        meetingDays: List<String>,
-        startTime: String,
-        endTime: String
-    ) {
+    fun updateClass(classId: String, name: String, meetingDays: List<String>, startTime: String, endTime: String) {
         val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-        val sortedMeetingDays = meetingDays.sortedBy { orderedDays.indexOf(it) }
-
+        val sortedDays = meetingDays.sortedBy { orderedDays.indexOf(it) }
         viewModelScope.launch {
             try {
-                repository.updateClass(
-                    classId = classId,
-                    name = name,
-                    meetingDays = sortedMeetingDays,
-                    startTime = startTime,
-                    endTime = endTime
-                )
-
-                // Keeps local scheduleItems consistent after class rename
-                // (Firestore stores className redundantly in assignments).
-                scheduleItems = scheduleItems.map { item ->
-                    if (item.classId == classId) {
-                        item.copy(className = name)
-                    } else item
-                }
-
+                repository.updateClass(classId, name, sortedDays, startTime, endTime)
+                scheduleItems = scheduleItems.map { if (it.classId == classId) it.copy(className = name) else it }
                 refreshClasses()
             } catch (e: Exception) {
                 android.util.Log.e("FirestoreDebug", "updateClass failed", e)
@@ -101,66 +102,31 @@ class CalendarViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 repository.deleteClass(classId)
-
-                // Removes assignments tied to the deleted class locally.
                 scheduleItems = scheduleItems.filterNot { it.classId == classId }
-
                 refreshClasses()
             } catch (e: Exception) {
-                android.util.Log.e("FirestoreDebug", "updateClass failed", e)
+                android.util.Log.e("FirestoreDebug", "deleteClass failed", e)
             }
         }
     }
 
-    fun addScheduleItem(
-        classItem: ClassItem,
-        assignmentName: String,
-        dueTime: String
-    ) {
+    fun addScheduleItem(classItem: ClassItem, assignmentName: String, dueTime: String) {
         val date = selectedDate ?: return
-
-        // Must match the same format used in Firestore + CalendarGrid comparisons.
-        val formattedDate = formatDate(date)
-
         viewModelScope.launch {
             try {
-                repository.addAssignment(
-                    date = formattedDate,
-                    classId = classItem.id,
-                    className = classItem.name,
-                    assignmentName = assignmentName,
-                    dueTime = dueTime
-                )
+                repository.addAssignment(formatDate(date), classItem.id, classItem.name, assignmentName, dueTime)
                 refreshAssignments()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+            } catch (e: Exception) { e.printStackTrace() }
         }
     }
 
-    fun updateScheduleItem(
-        itemId: String,
-        classItem: ClassItem,
-        assignmentName: String,
-        dueTime: String
-    ) {
+    fun updateScheduleItem(itemId: String, classItem: ClassItem, assignmentName: String, dueTime: String) {
         val date = selectedDate ?: return
-        val formattedDate = formatDate(date)
-
         viewModelScope.launch {
             try {
-                repository.updateAssignment(
-                    assignmentId = itemId,
-                    date = formattedDate,
-                    classId = classItem.id,
-                    className = classItem.name,
-                    assignmentName = assignmentName,
-                    dueTime = dueTime
-                )
+                repository.updateAssignment(itemId, formatDate(date), classItem.id, classItem.name, assignmentName, dueTime)
                 refreshAssignments()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+            } catch (e: Exception) { e.printStackTrace() }
         }
     }
 
@@ -169,103 +135,68 @@ class CalendarViewModel : ViewModel() {
             try {
                 repository.deleteAssignment(itemId)
                 refreshAssignments()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+            } catch (e: Exception) { e.printStackTrace() }
         }
     }
 
-    fun getItemsForSelectedDate(): List<ScheduleItem> {
-        val date = selectedDate ?: return emptyList()
-        val formattedDate = formatDate(date)
-
-        return scheduleItems
-            // Relies on ScheduleItem.date using same string format.
-            .filter { it.date == formattedDate }
-            // Converts time string → sortable number (minutes since midnight).
-            .sortedBy { parseTimeToSortableValue(it.dueTime) }
-    }
-
-    fun getClassesGroupedByDay(): Map<String, List<ClassItem>> {
-        val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-
-        return orderedDays.associateWith { day ->
-            classItems
-                .filter { it.meetingDays.contains(day) }
-                .sortedBy { parseTimeToSortableValue(it.startTime) }
-        }.filterValues { it.isNotEmpty() }
-    }
-
-    fun getClassesForSelectedDate(): List<ClassItem> {
-        val date = selectedDate ?: return emptyList()
-
-        // Converts LocalDate → matching string used in ClassItem.meetingDays.
-        val dayName = when (date.dayOfWeek.value) {
-            1 -> "Mon"
-            2 -> "Tue"
-            3 -> "Wed"
-            4 -> "Thu"
-            5 -> "Fri"
-            6 -> "Sat"
-            7 -> "Sun"
-            else -> ""
+    fun addStudySession(date: String, className: String, topic: String, startTime: String, location: String) {
+        viewModelScope.launch {
+            try {
+                repository.addStudySession(date, className, topic, startTime, location)
+                refreshStudySessions()
+            } catch (e: Exception) { e.printStackTrace() }
         }
-
-        return classItems
-            .filter { it.meetingDays.contains(dayName) }
-            .sortedBy { parseTimeToSortableValue(it.startTime) }
     }
 
-    private fun formatDate(date: LocalDate): String {
-        // Must stay consistent with Firestore storage + CalendarGrid comparison.
-        return "%04d-%02d-%02d".format(
-            date.year,
-            date.monthValue,
-            date.dayOfMonth
-        )
+    fun updateStudySession(sessionId: String, date: String, className: String, topic: String, startTime: String, location: String) {
+        viewModelScope.launch {
+            try {
+                repository.updateStudySession(sessionId, date, className, topic, startTime, location)
+                refreshStudySessions()
+            } catch (e: Exception) { e.printStackTrace() }
+        }
     }
 
-    private fun parseTimeToSortableValue(time: String): Int {
-        // Expects format like "hh:mm AM/PM"
-        val parts = time.split(" ", ":")
-        if (parts.size < 3) return Int.MAX_VALUE
-
-        var hour = parts[0].toIntOrNull() ?: return Int.MAX_VALUE
-        val minute = parts[1].toIntOrNull() ?: return Int.MAX_VALUE
-        val amPm = parts[2]
-
-        // Converts 12-hour → 24-hour for sorting.
-        if (amPm == "PM" && hour != 12) hour += 12
-        if (amPm == "AM" && hour == 12) hour = 0
-
-        return hour * 60 + minute
+    fun deleteStudySession(sessionId: String) {
+        viewModelScope.launch {
+            try {
+                repository.deleteStudySession(sessionId)
+                refreshStudySessions()
+            } catch (e: Exception) { e.printStackTrace() }
+        }
     }
 
-    private fun sortClassesByTime(classes: List<ClassItem>): List<ClassItem> {
-        return classes.sortedBy { parseTimeToSortableValue(it.startTime) }
+    fun addEvent(date: String, name: String, time: String, location: String) {
+        viewModelScope.launch {
+            try {
+                repository.addEvent(date, name, time, location)
+                refreshEvents()
+            } catch (e: Exception) { e.printStackTrace() }
+        }
     }
 
-    private val repository = CalendarFirestoreRepository()
+    fun updateEvent(eventId: String, date: String, name: String, time: String, location: String) {
+        viewModelScope.launch {
+            try {
+                repository.updateEvent(eventId, date, name, time, location)
+                refreshEvents()
+            } catch (e: Exception) { e.printStackTrace() }
+        }
+    }
 
-    init {
-        // Automatically loads data when ViewModel is created.
-        refreshClasses()
-        refreshAssignments()
+    fun deleteEvent(eventId: String) {
+        viewModelScope.launch {
+            try {
+                repository.deleteEvent(eventId)
+                refreshEvents()
+            } catch (e: Exception) { e.printStackTrace() }
+        }
     }
 
     fun refreshClasses() {
         viewModelScope.launch {
             try {
                 classItems = sortClassesByTime(repository.loadClasses())
-
-                android.util.Log.d("FirestoreDebug", "Loaded classItems count: ${classItems.size}")
-
-                classItems.forEach {
-                    android.util.Log.d(
-                        "FirestoreDebug",
-                        "Class in ViewModel: ${it.name}, days=${it.meetingDays}, start=${it.startTime}, end=${it.endTime}"
-                    )
-                }
             } catch (e: Exception) {
                 android.util.Log.e("FirestoreDebug", "refreshClasses failed", e)
             }
@@ -274,11 +205,36 @@ class CalendarViewModel : ViewModel() {
 
     fun refreshAssignments() {
         viewModelScope.launch {
-            try {
-                scheduleItems = repository.loadAssignments()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+            try { scheduleItems = repository.loadAssignments() } catch (e: Exception) { e.printStackTrace() }
         }
     }
+
+    fun refreshStudySessions() {
+        viewModelScope.launch {
+            try { studySessions = repository.loadStudySessions() } catch (e: Exception) { e.printStackTrace() }
+        }
+    }
+
+    fun refreshEvents() {
+        viewModelScope.launch {
+            try { eventItems = repository.loadEvents() } catch (e: Exception) { e.printStackTrace() }
+        }
+    }
+
+    private fun formatDate(date: LocalDate): String =
+        "%04d-%02d-%02d".format(date.year, date.monthValue, date.dayOfMonth)
+
+    private fun parseTimeToSortableValue(time: String): Int {
+        val parts = time.split(" ", ":")
+        if (parts.size < 3) return Int.MAX_VALUE
+        var hour = parts[0].toIntOrNull() ?: return Int.MAX_VALUE
+        val minute = parts[1].toIntOrNull() ?: return Int.MAX_VALUE
+        val amPm = parts[2]
+        if (amPm == "PM" && hour != 12) hour += 12
+        if (amPm == "AM" && hour == 12) hour = 0
+        return hour * 60 + minute
+    }
+
+    private fun sortClassesByTime(classes: List<ClassItem>): List<ClassItem> =
+        classes.sortedBy { parseTimeToSortableValue(it.startTime) }
 }

--- a/app/src/main/java/CalendarViewModel.kt
+++ b/app/src/main/java/CalendarViewModel.kt
@@ -43,25 +43,28 @@ class CalendarViewModel : ViewModel() {
         endTime: String
     ) {
         val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-
-        // Ensures consistent ordering regardless of user selection order.
         val sortedMeetingDays = meetingDays.sortedBy { orderedDays.indexOf(it) }
 
         viewModelScope.launch {
             try {
-                repository.addClass(
+                val newClass = repository.addClass(
                     name = name,
                     meetingDays = sortedMeetingDays,
                     startTime = startTime,
                     endTime = endTime
                 )
+
                 refreshClasses()
+
+                android.util.Log.d(
+                    "FirestoreDebug",
+                    "New class created: ${newClass.name}, id=${newClass.id}"
+                )
             } catch (e: Exception) {
                 android.util.Log.e("FirestoreDebug", "addClass failed", e)
             }
         }
     }
-
     fun updateClass(
         classId: String,
         name: String,

--- a/app/src/main/java/com/example/cinet/AssignmentReminderReceiver.kt
+++ b/app/src/main/java/com/example/cinet/AssignmentReminderReceiver.kt
@@ -1,0 +1,24 @@
+package com.example.cinet
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class AssignmentReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        NotificationHelper.createChannel(context)
+
+        val title = intent.getStringExtra("title") ?: "Assignment Due Soon"
+        val message = intent.getStringExtra("message") ?: "You have an assignment due soon."
+
+        NotificationHelper.showNotification(
+            context = context,
+            notification = AppNotification(
+                title = title,
+                message = message,
+                type = NotificationType.REMINDER,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/cinet/AssignmentReminderScheduler.kt
+++ b/app/src/main/java/com/example/cinet/AssignmentReminderScheduler.kt
@@ -1,0 +1,133 @@
+package com.example.cinet
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object AssignmentReminderScheduler {
+
+    private val timeFormatter = DateTimeFormatter.ofPattern("hh:mm a", Locale.US)
+
+    fun scheduleReminder(
+        context: Context,
+        date: String,
+        classId: String,
+        className: String,
+        assignmentName: String,
+        dueTime: String,
+        minutesBefore: Long = AppSettings.assignmentReminderMinutesBefore
+    ) {
+        val dueDate = try {
+            LocalDate.parse(date)
+        } catch (e: Exception) {
+            return
+        }
+
+        val parsedDueTime = try {
+            LocalTime.parse(dueTime, timeFormatter)
+        } catch (e: Exception) {
+            return
+        }
+
+        val dueDateTime = LocalDateTime.of(dueDate, parsedDueTime)
+        val triggerTime = dueDateTime.minusMinutes(minutesBefore)
+        val now = LocalDateTime.now()
+
+        if (dueDateTime.isBefore(now)) return
+
+        if (triggerTime.isBefore(now)) {
+            val minutesUntilDue = Duration.between(now, dueDateTime).toMinutes().coerceAtLeast(0)
+
+            NotificationHelper.createChannel(context)
+            NotificationHelper.showNotification(
+                context = context,
+                notification = AppNotification(
+                    title = assignmentName,
+                    message = "Due in $minutesUntilDue minutes at $dueTime for $className",
+                    type = NotificationType.REMINDER,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
+            return
+        }
+
+        val triggerMillis = triggerTime
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+
+        val intent = Intent(context, AssignmentReminderReceiver::class.java).apply {
+            putExtra("title", assignmentName)
+            putExtra("message", "Due at $dueTime for $className")
+        }
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            requestCodeFor(date, classId, assignmentName, dueTime),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            }
+        } else {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerMillis,
+                pendingIntent
+            )
+        }
+    }
+
+    fun cancelReminder(
+        context: Context,
+        date: String,
+        classId: String,
+        assignmentName: String,
+        dueTime: String
+    ) {
+        val intent = Intent(context, AssignmentReminderReceiver::class.java)
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            requestCodeFor(date, classId, assignmentName, dueTime),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+    }
+
+    private fun requestCodeFor(
+        date: String,
+        classId: String,
+        assignmentName: String,
+        dueTime: String
+    ): Int {
+        return "${date}_${classId}_${assignmentName}_${dueTime}".hashCode()
+    }
+}

--- a/app/src/main/java/com/example/cinet/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/CalendarScreen.kt
@@ -26,7 +26,9 @@ import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CalendarScreen(onBack: () -> Unit) {
+fun CalendarScreen(onBack: () -> Unit,
+                   initialShowClassDialog: Boolean = false
+) {
     val viewModel: CalendarViewModel = viewModel()
     val context = LocalContext.current
     val today = remember { LocalDate.now() }

--- a/app/src/main/java/com/example/cinet/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/CalendarScreen.kt
@@ -30,37 +30,26 @@ fun CalendarScreen(
     onBack: () -> Unit,
     initialShowClassDialog: Boolean = false
 ) {
-    // Provided by Compose; automatically scopes this ViewModel to the current UI lifecycle.
     val viewModel: CalendarViewModel = viewModel()
-
-    // Required because openTimePicker(...) depends on Android context (not visible here).
     val context = LocalContext.current
-
-    // remember prevents recomputing today's date on every recomposition.
     val today = remember { LocalDate.now() }
 
-    // These are backed by ViewModel state (likely StateFlow or mutableState),
-    // so UI updates automatically when they change.
     val classItems = viewModel.classItems
     val currentMonth = viewModel.currentMonth
     val selectedDate = viewModel.selectedDate
 
-    // These methods encapsulate filtering logic inside the ViewModel.
-    // The UI does not know how items/classes are filtered.
     val itemsForSelectedDate = viewModel.getItemsForSelectedDate()
     val classesForSelectedDate = viewModel.getClassesForSelectedDate()
 
     var showAssignmentDialog by remember { mutableStateOf(false) }
     var showClassDialog by remember { mutableStateOf(initialShowClassDialog) }
 
-    // Null = create mode, non-null = edit mode (used throughout dialogs).
     var editingAssignment by remember { mutableStateOf<ScheduleItem?>(null) }
     var editingClass by remember { mutableStateOf<ClassItem?>(null) }
 
     var assignmentName by remember { mutableStateOf("") }
     var dueTime by remember { mutableStateOf("") }
 
-    // Stores only the ID; actual ClassItem is resolved later from classItems.
     var selectedClassId by remember { mutableStateOf<String?>(null) }
 
     var classDropdownExpanded by remember { mutableStateOf(false) }
@@ -69,7 +58,6 @@ fun CalendarScreen(
     var classStartTime by remember { mutableStateOf("") }
     var classEndTime by remember { mutableStateOf("") }
 
-    // Must match whatever format the ViewModel uses for meeting-day matching.
     var selectedMeetingDays by remember { mutableStateOf(setOf<String>()) }
 
     val weekdayOptions = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
@@ -90,17 +78,23 @@ fun CalendarScreen(
         selectedMeetingDays = emptySet()
     }
 
+    fun formatDate(date: LocalDate): String {
+        return "%04d-%02d-%02d".format(
+            date.year,
+            date.monthValue,
+            date.dayOfMonth
+        )
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
-            // Enables scrolling for entire screen (important for smaller devices).
             .verticalScroll(rememberScrollState())
     ) {
         CalendarHeader(
             currentMonth = currentMonth,
             onBack = onBack,
-            // Month navigation logic is handled inside ViewModel.
             onPreviousMonth = { viewModel.previousMonth() },
             onNextMonth = { viewModel.nextMonth() }
         )
@@ -113,7 +107,6 @@ fun CalendarScreen(
         ) {
             OutlinedButton(
                 onClick = {
-                    // Always reset before opening to avoid leftover state from edits.
                     resetClassForm()
                     showClassDialog = true
                 }
@@ -133,7 +126,6 @@ fun CalendarScreen(
                 viewModel.selectDate(day)
             },
             onSameDateClicked = {
-                // Behavior depends on CalendarGrid detecting "same date" clicks.
                 resetAssignmentForm()
                 showAssignmentDialog = true
             }
@@ -143,7 +135,6 @@ fun CalendarScreen(
             selectedDate = selectedDate,
             itemsForSelectedDate = itemsForSelectedDate,
             onItemClick = { item ->
-                // Pre-fills dialog fields so it behaves as an edit form.
                 editingAssignment = item
                 assignmentName = item.assignmentName
                 dueTime = item.dueTime
@@ -157,7 +148,6 @@ fun CalendarScreen(
             selectedDate = selectedDate,
             classesForSelectedDate = classesForSelectedDate,
             onClassClick = { classItem ->
-                // Converts stored list into Set for UI selection handling.
                 editingClass = classItem
                 className = classItem.name
                 classStartTime = classItem.startTime
@@ -185,13 +175,11 @@ fun CalendarScreen(
                 resetAssignmentForm()
             },
             onPickTime = {
-                // External helper; likely launches Android TimePickerDialog.
                 openTimePicker(context) { picked ->
                     dueTime = picked
                 }
             },
             onConfirm = {
-                // Resolves class reference from ID → object (required by ViewModel).
                 val selectedClass = classItems.firstOrNull { it.id == selectedClassId }
 
                 if (
@@ -200,18 +188,48 @@ fun CalendarScreen(
                     dueTime.isNotBlank()
                 ) {
                     val item = editingAssignment
+                    val selectedDateString = formatDate(selectedDate)
+
                     if (item == null) {
                         viewModel.addScheduleItem(
                             classItem = selectedClass,
                             assignmentName = assignmentName,
                             dueTime = dueTime
                         )
+
+                        AssignmentReminderScheduler.scheduleReminder(
+                            context = context,
+                            date = selectedDateString,
+                            classId = selectedClass.id,
+                            className = selectedClass.name,
+                            assignmentName = assignmentName,
+                            dueTime = dueTime,
+                            minutesBefore = AppSettings.assignmentReminderMinutesBefore
+                        )
                     } else {
+                        AssignmentReminderScheduler.cancelReminder(
+                            context = context,
+                            date = item.date,
+                            classId = item.classId,
+                            assignmentName = item.assignmentName,
+                            dueTime = item.dueTime
+                        )
+
                         viewModel.updateScheduleItem(
                             itemId = item.id,
                             classItem = selectedClass,
                             assignmentName = assignmentName,
                             dueTime = dueTime
+                        )
+
+                        AssignmentReminderScheduler.scheduleReminder(
+                            context = context,
+                            date = selectedDateString,
+                            classId = selectedClass.id,
+                            className = selectedClass.name,
+                            assignmentName = assignmentName,
+                            dueTime = dueTime,
+                            minutesBefore = AppSettings.assignmentReminderMinutesBefore
                         )
                     }
 
@@ -221,8 +239,17 @@ fun CalendarScreen(
             },
             onDelete = if (editingAssignment != null) {
                 {
-                    // Delete only available in edit mode.
-                    viewModel.deleteScheduleItem(editingAssignment!!.id)
+                    val item = editingAssignment!!
+
+                    AssignmentReminderScheduler.cancelReminder(
+                        context = context,
+                        date = item.date,
+                        classId = item.classId,
+                        assignmentName = item.assignmentName,
+                        dueTime = item.dueTime
+                    )
+
+                    viewModel.deleteScheduleItem(item.id)
                     showAssignmentDialog = false
                     resetAssignmentForm()
                 }
@@ -264,20 +291,52 @@ fun CalendarScreen(
                     classEndTime.isNotBlank()
                 ) {
                     val classToEdit = editingClass
+                    val meetingDaysList = selectedMeetingDays.toList()
+
                     if (classToEdit == null) {
                         viewModel.addClass(
                             name = className,
-                            meetingDays = selectedMeetingDays.toList(),
+                            meetingDays = meetingDaysList,
                             startTime = classStartTime,
                             endTime = classEndTime
                         )
+
+                        val newClass = ClassItem(
+                            id = "${className}_${classStartTime}_${meetingDaysList.joinToString("_")}",
+                            name = className,
+                            meetingDays = meetingDaysList,
+                            startTime = classStartTime,
+                            endTime = classEndTime
+                        )
+
+                        ClassReminderScheduler.scheduleNextReminder(
+                            context = context,
+                            classItem = newClass,
+                            minutesBefore = AppSettings.classReminderMinutesBefore
+                        )
                     } else {
+                        ClassReminderScheduler.cancelReminder(context, classToEdit)
+
                         viewModel.updateClass(
                             classId = classToEdit.id,
                             name = className,
-                            meetingDays = selectedMeetingDays.toList(),
+                            meetingDays = meetingDaysList,
                             startTime = classStartTime,
                             endTime = classEndTime
+                        )
+
+                        val updatedClass = ClassItem(
+                            id = classToEdit.id,
+                            name = className,
+                            meetingDays = meetingDaysList,
+                            startTime = classStartTime,
+                            endTime = classEndTime
+                        )
+
+                        ClassReminderScheduler.scheduleNextReminder(
+                            context = context,
+                            classItem = updatedClass,
+                            minutesBefore = AppSettings.classReminderMinutesBefore
                         )
                     }
 
@@ -287,11 +346,15 @@ fun CalendarScreen(
             },
             onDelete = if (editingClass != null) {
                 {
-                    viewModel.deleteClass(editingClass!!.id)
+                    val classToDelete = editingClass!!
+                    ClassReminderScheduler.cancelReminder(context, classToDelete)
+                    viewModel.deleteClass(classToDelete.id)
                     showClassDialog = false
                     resetClassForm()
                 }
-            } else null
+            } else {
+                null
+            }
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/CalendarScreen.kt
@@ -26,14 +26,10 @@ import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CalendarScreen(onBack: () -> Unit,
-                   initialShowClassDialog: Boolean = false
-) {
 fun CalendarScreen(
     onBack: () -> Unit,
     initialShowClassDialog: Boolean = false
 ) {
-    // Provided by Compose; automatically scopes this ViewModel to the current UI lifecycle.
     val viewModel: CalendarViewModel = viewModel()
     val context = LocalContext.current
     val today = remember { LocalDate.now() }
@@ -47,19 +43,14 @@ fun CalendarScreen(
     val studySessionsForSelectedDate = viewModel.getStudySessionsForSelectedDate()
     val eventsForSelectedDate = viewModel.getEventsForSelectedDate()
 
-    // Assignment dialog state
     var showAssignmentDialog by remember { mutableStateOf(false) }
     var showClassDialog by remember { mutableStateOf(initialShowClassDialog) }
-
-    // Null = create mode, non-null = edit mode (used throughout dialogs).
     var editingAssignment by remember { mutableStateOf<ScheduleItem?>(null) }
     var assignmentName by remember { mutableStateOf("") }
     var dueTime by remember { mutableStateOf("") }
     var selectedClassId by remember { mutableStateOf<String?>(null) }
     var classDropdownExpanded by remember { mutableStateOf(false) }
 
-    // Class dialog state
-    var showClassDialog by remember { mutableStateOf(false) }
     var editingClass by remember { mutableStateOf<ClassItem?>(null) }
     var className by remember { mutableStateOf("") }
     var classStartTime by remember { mutableStateOf("") }
@@ -67,7 +58,6 @@ fun CalendarScreen(
     var selectedMeetingDays by remember { mutableStateOf(setOf<String>()) }
     val weekdayOptions = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
-    // Study session dialog state
     var showStudySessionDialog by remember { mutableStateOf(false) }
     var editingSession by remember { mutableStateOf<StudySession?>(null) }
     var sessionClassName by remember { mutableStateOf("") }
@@ -75,7 +65,6 @@ fun CalendarScreen(
     var sessionStartTime by remember { mutableStateOf("") }
     var sessionLocation by remember { mutableStateOf("") }
 
-    // Event dialog state
     var showEventDialog by remember { mutableStateOf(false) }
     var editingEvent by remember { mutableStateOf<EventItem?>(null) }
     var eventName by remember { mutableStateOf("") }
@@ -109,7 +98,6 @@ fun CalendarScreen(
         )
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Management buttons row
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -177,7 +165,6 @@ fun CalendarScreen(
         )
     }
 
-    // Assignment dialog
     if (showAssignmentDialog && selectedDate != null) {
         AssignmentDialog(
             selectedDate = selectedDate,
@@ -207,7 +194,6 @@ fun CalendarScreen(
         )
     }
 
-    // Class dialog
     if (showClassDialog) {
         ClassDialog(
             editingClass = editingClass,
@@ -235,7 +221,6 @@ fun CalendarScreen(
         )
     }
 
-    // Study session dialog
     if (showStudySessionDialog && selectedDate != null) {
         val dateStr = "%04d-%02d-%02d".format(selectedDate.year, selectedDate.monthValue, selectedDate.dayOfMonth)
         StudySessionDialog(
@@ -264,7 +249,6 @@ fun CalendarScreen(
         )
     }
 
-    // Event dialog
     if (showEventDialog && selectedDate != null) {
         val dateStr = "%04d-%02d-%02d".format(selectedDate.year, selectedDate.monthValue, selectedDate.dayOfMonth)
         EventItemDialog(

--- a/app/src/main/java/com/example/cinet/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/CalendarScreen.kt
@@ -23,98 +23,95 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CalendarScreen(onBack: () -> Unit) {
-    // Provided by Compose; automatically scopes this ViewModel to the current UI lifecycle.
     val viewModel: CalendarViewModel = viewModel()
-
-    // Required because openTimePicker(...) depends on Android context (not visible here).
     val context = LocalContext.current
-
-    // remember prevents recomputing today's date on every recomposition.
     val today = remember { LocalDate.now() }
 
-    // These are backed by ViewModel state (likely StateFlow or mutableState),
-    // so UI updates automatically when they change.
     val classItems = viewModel.classItems
     val currentMonth = viewModel.currentMonth
     val selectedDate = viewModel.selectedDate
 
-    // These methods encapsulate filtering logic inside the ViewModel.
-    // The UI does not know how items/classes are filtered.
     val itemsForSelectedDate = viewModel.getItemsForSelectedDate()
     val classesForSelectedDate = viewModel.getClassesForSelectedDate()
+    val studySessionsForSelectedDate = viewModel.getStudySessionsForSelectedDate()
+    val eventsForSelectedDate = viewModel.getEventsForSelectedDate()
 
+    // Assignment dialog state
     var showAssignmentDialog by remember { mutableStateOf(false) }
-    var showClassDialog by remember { mutableStateOf(false) }
-
-    // Null = create mode, non-null = edit mode (used throughout dialogs).
     var editingAssignment by remember { mutableStateOf<ScheduleItem?>(null) }
-    var editingClass by remember { mutableStateOf<ClassItem?>(null) }
-
     var assignmentName by remember { mutableStateOf("") }
     var dueTime by remember { mutableStateOf("") }
-
-    // Stores only the ID; actual ClassItem is resolved later from classItems.
     var selectedClassId by remember { mutableStateOf<String?>(null) }
-
     var classDropdownExpanded by remember { mutableStateOf(false) }
 
+    // Class dialog state
+    var showClassDialog by remember { mutableStateOf(false) }
+    var editingClass by remember { mutableStateOf<ClassItem?>(null) }
     var className by remember { mutableStateOf("") }
     var classStartTime by remember { mutableStateOf("") }
     var classEndTime by remember { mutableStateOf("") }
-
-    // Must match whatever format the ViewModel uses for meeting-day matching.
     var selectedMeetingDays by remember { mutableStateOf(setOf<String>()) }
-
     val weekdayOptions = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
-    fun resetAssignmentForm() {
-        editingAssignment = null
-        assignmentName = ""
-        dueTime = ""
-        selectedClassId = null
-        classDropdownExpanded = false
-    }
+    // Study session dialog state
+    var showStudySessionDialog by remember { mutableStateOf(false) }
+    var editingSession by remember { mutableStateOf<StudySession?>(null) }
+    var sessionClassName by remember { mutableStateOf("") }
+    var sessionTopic by remember { mutableStateOf("") }
+    var sessionStartTime by remember { mutableStateOf("") }
+    var sessionLocation by remember { mutableStateOf("") }
 
+    // Event dialog state
+    var showEventDialog by remember { mutableStateOf(false) }
+    var editingEvent by remember { mutableStateOf<EventItem?>(null) }
+    var eventName by remember { mutableStateOf("") }
+    var eventTime by remember { mutableStateOf("") }
+    var eventLocation by remember { mutableStateOf("") }
+
+    fun resetAssignmentForm() {
+        editingAssignment = null; assignmentName = ""; dueTime = ""; selectedClassId = null; classDropdownExpanded = false
+    }
     fun resetClassForm() {
-        editingClass = null
-        className = ""
-        classStartTime = ""
-        classEndTime = ""
-        selectedMeetingDays = emptySet()
+        editingClass = null; className = ""; classStartTime = ""; classEndTime = ""; selectedMeetingDays = emptySet()
+    }
+    fun resetStudySessionForm() {
+        editingSession = null; sessionClassName = ""; sessionTopic = ""; sessionStartTime = ""; sessionLocation = ""
+    }
+    fun resetEventForm() {
+        editingEvent = null; eventName = ""; eventTime = ""; eventLocation = ""
     }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
-            // Enables scrolling for entire screen (important for smaller devices).
             .verticalScroll(rememberScrollState())
     ) {
         CalendarHeader(
             currentMonth = currentMonth,
             onBack = onBack,
-            // Month navigation logic is handled inside ViewModel.
             onPreviousMonth = { viewModel.previousMonth() },
             onNextMonth = { viewModel.nextMonth() }
         )
-
         Spacer(modifier = Modifier.height(12.dp))
 
+        // Management buttons row
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            OutlinedButton(
-                onClick = {
-                    // Always reset before opening to avoid leftover state from edits.
-                    resetClassForm()
-                    showClassDialog = true
-                }
-            ) {
-                Text("Manage Classes")
+            OutlinedButton(onClick = { resetClassForm(); showClassDialog = true }) {
+                Text("Classes")
+            }
+            OutlinedButton(onClick = { resetStudySessionForm(); showStudySessionDialog = true }) {
+                Text("Study")
+            }
+            OutlinedButton(onClick = { resetEventForm(); showEventDialog = true }) {
+                Text("Events")
             }
         }
 
@@ -125,27 +122,17 @@ fun CalendarScreen(onBack: () -> Unit) {
             selectedDate = selectedDate,
             today = today,
             scheduleItems = viewModel.scheduleItems,
-            onDateSelected = { day ->
-                viewModel.selectDate(day)
-            },
-            onSameDateClicked = {
-                // Behavior depends on CalendarGrid detecting "same date" clicks.
-                resetAssignmentForm()
-                showAssignmentDialog = true
-            }
+            onDateSelected = { day -> viewModel.selectDate(day) },
+            onSameDateClicked = { resetAssignmentForm(); showAssignmentDialog = true }
         )
 
         ScheduleSection(
             selectedDate = selectedDate,
             itemsForSelectedDate = itemsForSelectedDate,
             onItemClick = { item ->
-                // Pre-fills dialog fields so it behaves as an edit form.
-                editingAssignment = item
-                assignmentName = item.assignmentName
-                dueTime = item.dueTime
-                selectedClassId = item.classId
-                classDropdownExpanded = false
-                showAssignmentDialog = true
+                editingAssignment = item; assignmentName = item.assignmentName
+                dueTime = item.dueTime; selectedClassId = item.classId
+                classDropdownExpanded = false; showAssignmentDialog = true
             }
         )
 
@@ -153,17 +140,34 @@ fun CalendarScreen(onBack: () -> Unit) {
             selectedDate = selectedDate,
             classesForSelectedDate = classesForSelectedDate,
             onClassClick = { classItem ->
-                // Converts stored list into Set for UI selection handling.
-                editingClass = classItem
-                className = classItem.name
-                classStartTime = classItem.startTime
-                classEndTime = classItem.endTime
-                selectedMeetingDays = classItem.meetingDays.toSet()
-                showClassDialog = true
+                editingClass = classItem; className = classItem.name
+                classStartTime = classItem.startTime; classEndTime = classItem.endTime
+                selectedMeetingDays = classItem.meetingDays.toSet(); showClassDialog = true
+            }
+        )
+
+        StudySessionsSection(
+            selectedDate = selectedDate,
+            studySessionsForSelectedDate = studySessionsForSelectedDate,
+            onSessionClick = { session ->
+                editingSession = session; sessionClassName = session.className
+                sessionTopic = session.topic; sessionStartTime = session.startTime
+                sessionLocation = session.location; showStudySessionDialog = true
+            }
+        )
+
+        EventsSection(
+            selectedDate = selectedDate,
+            eventsForSelectedDate = eventsForSelectedDate,
+            onEventClick = { event ->
+                editingEvent = event; eventName = event.name
+                eventTime = event.time; eventLocation = event.location
+                showEventDialog = true
             }
         )
     }
 
+    // Assignment dialog
     if (showAssignmentDialog && selectedDate != null) {
         AssignmentDialog(
             selectedDate = selectedDate,
@@ -176,58 +180,24 @@ fun CalendarScreen(onBack: () -> Unit) {
             onSelectedClassIdChange = { selectedClassId = it },
             classDropdownExpanded = classDropdownExpanded,
             onClassDropdownExpandedChange = { classDropdownExpanded = it },
-            onDismiss = {
-                showAssignmentDialog = false
-                resetAssignmentForm()
-            },
-            onPickTime = {
-                // External helper; likely launches Android TimePickerDialog.
-                openTimePicker(context) { picked ->
-                    dueTime = picked
-                }
-            },
+            onDismiss = { showAssignmentDialog = false; resetAssignmentForm() },
+            onPickTime = { openTimePicker(context) { picked -> dueTime = picked } },
             onConfirm = {
-                // Resolves class reference from ID → object (required by ViewModel).
                 val selectedClass = classItems.firstOrNull { it.id == selectedClassId }
-
-                if (
-                    selectedClass != null &&
-                    assignmentName.isNotBlank() &&
-                    dueTime.isNotBlank()
-                ) {
+                if (selectedClass != null && assignmentName.isNotBlank() && dueTime.isNotBlank()) {
                     val item = editingAssignment
-                    if (item == null) {
-                        viewModel.addScheduleItem(
-                            classItem = selectedClass,
-                            assignmentName = assignmentName,
-                            dueTime = dueTime
-                        )
-                    } else {
-                        viewModel.updateScheduleItem(
-                            itemId = item.id,
-                            classItem = selectedClass,
-                            assignmentName = assignmentName,
-                            dueTime = dueTime
-                        )
-                    }
-
-                    showAssignmentDialog = false
-                    resetAssignmentForm()
+                    if (item == null) viewModel.addScheduleItem(selectedClass, assignmentName, dueTime)
+                    else viewModel.updateScheduleItem(item.id, selectedClass, assignmentName, dueTime)
+                    showAssignmentDialog = false; resetAssignmentForm()
                 }
             },
             onDelete = if (editingAssignment != null) {
-                {
-                    // Delete only available in edit mode.
-                    viewModel.deleteScheduleItem(editingAssignment!!.id)
-                    showAssignmentDialog = false
-                    resetAssignmentForm()
-                }
-            } else {
-                null
-            }
+                { viewModel.deleteScheduleItem(editingAssignment!!.id); showAssignmentDialog = false; resetAssignmentForm() }
+            } else null
         )
     }
 
+    // Class dialog
     if (showClassDialog) {
         ClassDialog(
             editingClass = editingClass,
@@ -238,55 +208,75 @@ fun CalendarScreen(onBack: () -> Unit) {
             selectedMeetingDays = selectedMeetingDays,
             onMeetingDaysChange = { selectedMeetingDays = it },
             weekdayOptions = weekdayOptions,
-            onPickStartTime = {
-                openTimePicker(context) { picked ->
-                    classStartTime = picked
-                }
-            },
-            onPickEndTime = {
-                openTimePicker(context) { picked ->
-                    classEndTime = picked
-                }
-            },
-            onDismiss = {
-                showClassDialog = false
-                resetClassForm()
-            },
+            onPickStartTime = { openTimePicker(context) { picked -> classStartTime = picked } },
+            onPickEndTime = { openTimePicker(context) { picked -> classEndTime = picked } },
+            onDismiss = { showClassDialog = false; resetClassForm() },
             onConfirm = {
-                if (
-                    className.isNotBlank() &&
-                    selectedMeetingDays.isNotEmpty() &&
-                    classStartTime.isNotBlank() &&
-                    classEndTime.isNotBlank()
-                ) {
-                    val classToEdit = editingClass
-                    if (classToEdit == null) {
-                        viewModel.addClass(
-                            name = className,
-                            meetingDays = selectedMeetingDays.toList(),
-                            startTime = classStartTime,
-                            endTime = classEndTime
-                        )
-                    } else {
-                        viewModel.updateClass(
-                            classId = classToEdit.id,
-                            name = className,
-                            meetingDays = selectedMeetingDays.toList(),
-                            startTime = classStartTime,
-                            endTime = classEndTime
-                        )
-                    }
-
-                    showClassDialog = false
-                    resetClassForm()
+                if (className.isNotBlank() && selectedMeetingDays.isNotEmpty() && classStartTime.isNotBlank() && classEndTime.isNotBlank()) {
+                    val c = editingClass
+                    if (c == null) viewModel.addClass(className, selectedMeetingDays.toList(), classStartTime, classEndTime)
+                    else viewModel.updateClass(c.id, className, selectedMeetingDays.toList(), classStartTime, classEndTime)
+                    showClassDialog = false; resetClassForm()
                 }
             },
             onDelete = if (editingClass != null) {
-                {
-                    viewModel.deleteClass(editingClass!!.id)
-                    showClassDialog = false
-                    resetClassForm()
+                { viewModel.deleteClass(editingClass!!.id); showClassDialog = false; resetClassForm() }
+            } else null
+        )
+    }
+
+    // Study session dialog
+    if (showStudySessionDialog && selectedDate != null) {
+        val dateStr = "%04d-%02d-%02d".format(selectedDate.year, selectedDate.monthValue, selectedDate.dayOfMonth)
+        StudySessionDialog(
+            editingSession = editingSession,
+            date = dateStr,
+            className = sessionClassName,
+            onClassNameChange = { sessionClassName = it },
+            topic = sessionTopic,
+            onTopicChange = { sessionTopic = it },
+            startTime = sessionStartTime,
+            location = sessionLocation,
+            onLocationChange = { sessionLocation = it },
+            onPickStartTime = { openTimePicker(context) { picked -> sessionStartTime = picked } },
+            onDismiss = { showStudySessionDialog = false; resetStudySessionForm() },
+            onConfirm = {
+                if (sessionClassName.isNotBlank() && sessionTopic.isNotBlank() && sessionStartTime.isNotBlank()) {
+                    val s = editingSession
+                    if (s == null) viewModel.addStudySession(dateStr, sessionClassName, sessionTopic, sessionStartTime, sessionLocation)
+                    else viewModel.updateStudySession(s.id, dateStr, sessionClassName, sessionTopic, sessionStartTime, sessionLocation)
+                    showStudySessionDialog = false; resetStudySessionForm()
                 }
+            },
+            onDelete = if (editingSession != null) {
+                { viewModel.deleteStudySession(editingSession!!.id); showStudySessionDialog = false; resetStudySessionForm() }
+            } else null
+        )
+    }
+
+    // Event dialog
+    if (showEventDialog && selectedDate != null) {
+        val dateStr = "%04d-%02d-%02d".format(selectedDate.year, selectedDate.monthValue, selectedDate.dayOfMonth)
+        EventItemDialog(
+            editingEvent = editingEvent,
+            date = dateStr,
+            eventName = eventName,
+            onEventNameChange = { eventName = it },
+            eventTime = eventTime,
+            location = eventLocation,
+            onLocationChange = { eventLocation = it },
+            onPickTime = { openTimePicker(context) { picked -> eventTime = picked } },
+            onDismiss = { showEventDialog = false; resetEventForm() },
+            onConfirm = {
+                if (eventName.isNotBlank() && eventTime.isNotBlank()) {
+                    val e = editingEvent
+                    if (e == null) viewModel.addEvent(dateStr, eventName, eventTime, eventLocation)
+                    else viewModel.updateEvent(e.id, dateStr, eventName, eventTime, eventLocation)
+                    showEventDialog = false; resetEventForm()
+                }
+            },
+            onDelete = if (editingEvent != null) {
+                { viewModel.deleteEvent(editingEvent!!.id); showEventDialog = false; resetEventForm() }
             } else null
         )
     }

--- a/app/src/main/java/com/example/cinet/ClassReminderReceiver.kt
+++ b/app/src/main/java/com/example/cinet/ClassReminderReceiver.kt
@@ -1,0 +1,24 @@
+package com.example.cinet
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class ClassReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        NotificationHelper.createChannel(context)
+
+        val title = intent.getStringExtra("title") ?: "Upcoming Class"
+        val message = intent.getStringExtra("message") ?: "Your class starts soon."
+
+        NotificationHelper.showNotification(
+            context = context,
+            notification = AppNotification(
+                title = title,
+                message = message,
+                type = NotificationType.REMINDER,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/cinet/ClassReminderScheduler.kt
+++ b/app/src/main/java/com/example/cinet/ClassReminderScheduler.kt
@@ -1,0 +1,143 @@
+package com.example.cinet
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object ClassReminderScheduler {
+
+    private val timeFormatter = DateTimeFormatter.ofPattern("hh:mm a", Locale.US)
+
+    fun scheduleNextReminder(
+        context: Context,
+        classItem: ClassItem,
+        minutesBefore: Long = 10L
+    ) {
+        val nextClassDateTime = getNextClassDateTime(classItem) ?: return
+        val triggerTime = nextClassDateTime.minusMinutes(minutesBefore)
+
+        val minutesUntilClass = java.time.Duration.between(
+            LocalDateTime.now(),
+            nextClassDateTime
+        ).toMinutes()
+
+        if (triggerTime.isBefore(LocalDateTime.now())) {
+            NotificationHelper.createChannel(context)
+            NotificationHelper.showNotification(
+                context = context,
+                notification = AppNotification(
+                    title = classItem.name,
+                    message = "Starts in $minutesUntilClass minutes at ${classItem.startTime}",
+                    type = NotificationType.REMINDER,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
+            return
+        }
+
+        val triggerMillis = triggerTime
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+
+        val intent = Intent(context, ClassReminderReceiver::class.java).apply {
+            putExtra("title", classItem.name)
+            putExtra("message", "Starts in $minutesBefore minutes at ${classItem.startTime}")
+        }
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            classItem.id.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            }
+        } else {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerMillis,
+                pendingIntent
+            )
+        }
+    }
+
+    fun cancelReminder(
+        context: Context,
+        classItem: ClassItem
+    ) {
+        val intent = Intent(context, ClassReminderReceiver::class.java)
+
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            classItem.id.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+    }
+
+    private fun getNextClassDateTime(classItem: ClassItem): LocalDateTime? {
+        val startTime = try {
+            LocalTime.parse(classItem.startTime, timeFormatter)
+        } catch (e: Exception) {
+            return null
+        }
+
+        val validDays = classItem.meetingDays.mapNotNull { toDayOfWeek(it) }.toSet()
+        if (validDays.isEmpty()) return null
+
+        val now = LocalDateTime.now()
+
+        for (offset in 0..7) {
+            val date = LocalDate.now().plusDays(offset.toLong())
+            if (date.dayOfWeek in validDays) {
+                val candidate = LocalDateTime.of(date, startTime)
+                if (candidate.isAfter(now)) {
+                    return candidate
+                }
+            }
+        }
+
+        return null
+    }
+
+    private fun toDayOfWeek(day: String): DayOfWeek? {
+        return when (day) {
+            "Mon" -> DayOfWeek.MONDAY
+            "Tue" -> DayOfWeek.TUESDAY
+            "Wed" -> DayOfWeek.WEDNESDAY
+            "Thu" -> DayOfWeek.THURSDAY
+            "Fri" -> DayOfWeek.FRIDAY
+            "Sat" -> DayOfWeek.SATURDAY
+            "Sun" -> DayOfWeek.SUNDAY
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/ConversationScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -19,6 +20,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -29,20 +31,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.model.Message
 import com.example.cinet.data.remote.SocialRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
 import kotlinx.coroutines.launch
-
-// Preset message content — easy to add more types here
-private val presetMessages = listOf(
-    "study_invite" to "Want to study together?",
-    "event_invite" to "You should come to this event!",
-)
 
 @Composable
 fun ConversationScreen(
@@ -50,33 +46,51 @@ fun ConversationScreen(
     onBack: () -> Unit,
 ) {
     val repository = remember { SocialRepository() }
+    val calendarRepository = remember { CalendarFirestoreRepository() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val listState = rememberLazyListState()
 
     var messages by remember { mutableStateOf<List<Message>>(emptyList()) }
     var messageInput by remember { mutableStateOf("") }
+    var showStudyInviteDialog by remember { mutableStateOf(false) }
+    var showEventInviteDialog by remember { mutableStateOf(false) }
+    var myScheduleItems by remember { mutableStateOf<List<ScheduleItem>>(emptyList()) }
 
-    // Real-time listener — updates messages instantly when Firestore changes
+    // State for accept dialogs — pre-filled from invite metadata
+    var acceptingStudyInvite by remember { mutableStateOf<Message?>(null) }
+    var acceptingEventInvite by remember { mutableStateOf<Message?>(null) }
+
+    // Pre-filled fields for study invite acceptance
+    var acceptSessionClassName by remember { mutableStateOf("") }
+    var acceptSessionTopic by remember { mutableStateOf("") }
+    var acceptSessionDate by remember { mutableStateOf("") }
+    var acceptSessionTime by remember { mutableStateOf("") }
+    var acceptSessionLocation by remember { mutableStateOf("") }
+
+    // Pre-filled fields for event invite acceptance
+    var acceptEventName by remember { mutableStateOf("") }
+    var acceptEventDate by remember { mutableStateOf("") }
+    var acceptEventTime by remember { mutableStateOf("") }
+    var acceptEventLocation by remember { mutableStateOf("") }
+
     DisposableEffect(conversation.id) {
         val listener = FirebaseFirestore.getInstance()
             .collection("conversations")
             .document(conversation.id)
             .collection("messages")
-            .orderBy("createdAt", Query.Direction.ASCENDING)
             .addSnapshotListener { snapshot, _ ->
                 if (snapshot != null) {
                     messages = snapshot.toObjects(Message::class.java)
+                        .sortedBy { it.createdAt }
                 }
             }
         onDispose { listener.remove() }
     }
 
-    // Scroll to bottom whenever new messages arrive
     LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.size - 1)
-        }
+        if (messages.isNotEmpty()) listState.animateScrollToItem(messages.size - 1)
     }
 
     val conversationTitle = if (conversation.isGroup) {
@@ -91,11 +105,8 @@ fun ConversationScreen(
         color = MaterialTheme.colorScheme.background
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // Header — frontend team can restyle this
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Button(onClick = onBack) { Text("Back") }
@@ -105,49 +116,83 @@ fun ConversationScreen(
 
             HorizontalDivider()
 
-            // Preset message buttons
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                presetMessages.forEach { (type, label) ->
-                    OutlinedButton(
-                        onClick = {
-                            scope.launch {
-                                repository.sendMessage(conversation.id, label, type)
-                            }
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            repository.getMyScheduleItems().onSuccess { myScheduleItems = it }
+                            showStudyInviteDialog = true
                         }
-                    ) {
-                        Text(label, style = MaterialTheme.typography.labelSmall)
                     }
+                ) {
+                    Text("Study Invite", style = MaterialTheme.typography.labelSmall)
+                }
+                OutlinedButton(onClick = { showEventInviteDialog = true }) {
+                    Text("Event Invite", style = MaterialTheme.typography.labelSmall)
                 }
             }
 
             HorizontalDivider()
 
-            // Messages list
             LazyColumn(
                 state = listState,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(16.dp),
+                modifier = Modifier.weight(1f).padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(messages) { message ->
+                    val alreadyResponded = message.metadata["response"] != null
                     MessageBubble(
                         message = message,
-                        isCurrentUser = message.senderId == currentUid
+                        isCurrentUser = message.senderId == currentUid,
+                        onAccept = if (!alreadyResponded && message.senderId != currentUid &&
+                            (message.type == "study_invite" || message.type == "event_invite")) {
+                            {
+                                scope.launch {
+                                    if (message.type == "study_invite") {
+                                        val className = message.metadata["className"] ?: ""
+                                        val topic = message.metadata["topic"] ?: ""
+                                        val date = message.metadata["date"] ?: ""
+                                        val time = message.metadata["time"] ?: ""
+                                        val location = message.metadata["location"] ?: ""
+                                        android.util.Log.d("CalendarSave", "Saving study session: $className $topic $date $time")
+                                        if (date.isNotBlank()) {
+                                            calendarRepository.addStudySession(date, className, topic, time, location)
+                                            android.util.Log.d("CalendarSave", "Study session saved successfully")
+                                        } else {
+                                            android.util.Log.e("CalendarSave", "Date is blank — metadata: ${message.metadata}")
+                                        }
+                                    } else {
+                                        val name = message.metadata["name"] ?: ""
+                                        val date = message.metadata["date"] ?: ""
+                                        val time = message.metadata["time"] ?: ""
+                                        val location = message.metadata["location"] ?: ""
+                                        if (date.isNotBlank()) {
+                                            calendarRepository.addEvent(date, name, time, location)
+                                        }
+                                    }
+                                    repository.respondToInvite(conversation.id, message.id, "accepted")
+                                    repository.sendMessage(conversation.id, "Accepted your invite!", "text")
+                                }
+                            }
+                        } else null,
+                        onDecline = if (!alreadyResponded && message.senderId != currentUid &&
+                            (message.type == "study_invite" || message.type == "event_invite")) {
+                            {
+                                scope.launch {
+                                    repository.respondToInvite(conversation.id, message.id, "declined")
+                                    repository.sendMessage(conversation.id, "Declined your invite.", "text")
+                                }
+                            }
+                        } else null
                     )
                 }
             }
 
-            // Text input
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 OutlinedTextField(
@@ -168,19 +213,127 @@ fun ConversationScreen(
                             }
                         }
                     }
-                ) {
-                    Text("Send")
-                }
+                ) { Text("Send") }
             }
         }
     }
+
+    // Study invite sender dialog
+    if (showStudyInviteDialog) {
+        StudyInviteDialog(
+            existingItems = myScheduleItems,
+            onDismiss = { showStudyInviteDialog = false },
+            onSendExisting = { item ->
+                scope.launch {
+                    val content = "Study invite: ${item.className} — ${item.assignmentName} on ${item.date} at ${item.dueTime}"
+                    repository.sendMessage(
+                        conversationId = conversation.id,
+                        content = content,
+                        type = "study_invite",
+                        metadata = mapOf(
+                            "className" to item.className,
+                            "topic" to item.assignmentName,
+                            "date" to item.date,
+                            "time" to item.dueTime,
+                            "location" to ""
+                        )
+                    )
+                    showStudyInviteDialog = false
+                }
+            },
+            onSendNew = { cls, topic, date, time ->
+                scope.launch {
+                    val content = "Study invite: $cls — $topic on $date at $time"
+                    repository.sendMessage(
+                        conversationId = conversation.id,
+                        content = content,
+                        type = "study_invite",
+                        metadata = mapOf("className" to cls, "topic" to topic, "date" to date, "time" to time, "location" to "")
+                    )
+                    showStudyInviteDialog = false
+                }
+            }
+        )
+    }
+
+    // Event invite sender dialog
+    if (showEventInviteDialog) {
+        EventInviteSenderDialog(
+            onDismiss = { showEventInviteDialog = false },
+            onSend = { name, date, time, location ->
+                scope.launch {
+                    val content = "Event invite: $name on $date at $time"
+                    repository.sendMessage(
+                        conversationId = conversation.id,
+                        content = content,
+                        type = "event_invite",
+                        metadata = mapOf("name" to name, "date" to date, "time" to time, "location" to location)
+                    )
+                    showEventInviteDialog = false
+                }
+            }
+        )
+    }
+
+    // Study invite accept dialog — pre-filled, user can edit before saving
+    if (acceptingStudyInvite != null) {
+        StudySessionDialog(
+            editingSession = null,
+            date = acceptSessionDate,
+            className = acceptSessionClassName,
+            onClassNameChange = { acceptSessionClassName = it },
+            topic = acceptSessionTopic,
+            onTopicChange = { acceptSessionTopic = it },
+            startTime = acceptSessionTime,
+            location = acceptSessionLocation,
+            onLocationChange = { acceptSessionLocation = it },
+            onPickStartTime = { openTimePicker(context) { picked -> acceptSessionTime = picked } },
+            onDismiss = { acceptingStudyInvite = null },
+            onConfirm = {
+                if (acceptSessionClassName.isNotBlank() && acceptSessionTopic.isNotBlank() && acceptSessionDate.isNotBlank()) {
+                    scope.launch {
+                        calendarRepository.addStudySession(acceptSessionDate, acceptSessionClassName, acceptSessionTopic, acceptSessionTime, acceptSessionLocation)
+                        repository.sendMessage(conversation.id, "Accepted your study invite!", "text")
+                        acceptingStudyInvite = null
+                    }
+                }
+            },
+            onDelete = null
+        )
+    }
+
+    // Event invite accept dialog — pre-filled, user can edit before saving
+    if (acceptingEventInvite != null) {
+        EventItemDialog(
+            editingEvent = null,
+            date = acceptEventDate,
+            eventName = acceptEventName,
+            onEventNameChange = { acceptEventName = it },
+            eventTime = acceptEventTime,
+            location = acceptEventLocation,
+            onLocationChange = { acceptEventLocation = it },
+            onPickTime = { openTimePicker(context) { picked -> acceptEventTime = picked } },
+            onDismiss = { acceptingEventInvite = null },
+            onConfirm = {
+                if (acceptEventName.isNotBlank() && acceptEventDate.isNotBlank()) {
+                    scope.launch {
+                        calendarRepository.addEvent(acceptEventDate, acceptEventName, acceptEventTime, acceptEventLocation)
+                        repository.sendMessage(conversation.id, "Accepted your event invite!", "text")
+                        acceptingEventInvite = null
+                    }
+                }
+            },
+            onDelete = null
+        )
+    }
 }
 
-// Frontend team: restyle this bubble however you want
 @Composable
 fun MessageBubble(
     message: Message,
     isCurrentUser: Boolean,
+    onAccept: (() -> Unit)? = null,
+    onDecline: (() -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -199,5 +352,29 @@ fun MessageBubble(
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(4.dp)
         )
+
+        val response = message.metadata["response"]
+        when {
+            // Already responded — show status label instead of buttons
+            response == "accepted" -> Text(
+                text = "✓ Accepted",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+            response == "declined" -> Text(
+                text = "✗ Declined",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+            // Not yet responded — show buttons
+            onAccept != null && onDecline != null -> {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onAccept) { Text("Accept") }
+                    OutlinedButton(onClick = onDecline) { Text("Decline") }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/cinet/EventInviteSenderDialog.kt
+++ b/app/src/main/java/com/example/cinet/EventInviteSenderDialog.kt
@@ -1,0 +1,132 @@
+package com.example.cinet
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventInviteSenderDialog(
+    onDismiss: () -> Unit,
+    onSend: (name: String, date: String, time: String, location: String) -> Unit,
+) {
+    val context = LocalContext.current
+    var eventName by remember { mutableStateOf("") }
+    var eventDate by remember { mutableStateOf("") }
+    var eventTime by remember { mutableStateOf("") }
+    var eventLocation by remember { mutableStateOf("") }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                        sdf.timeZone = TimeZone.getTimeZone("UTC")
+                        eventDate = sdf.format(Date(millis))
+                    }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Send Event Invite") },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                OutlinedTextField(
+                    value = eventName,
+                    onValueChange = { eventName = it },
+                    label = { Text("Event Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = eventDate,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Date") },
+                    placeholder = { Text("Tap to pick a date") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { showDatePicker = true }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { showDatePicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Pick Date")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = eventTime,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Time") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { openTimePicker(context) { eventTime = it } },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Pick Time")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = eventLocation,
+                    onValueChange = { eventLocation = it },
+                    label = { Text("Location (optional)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = {
+                if (eventName.isNotBlank() && eventDate.isNotBlank() && eventTime.isNotBlank()) {
+                    onSend(eventName, eventDate, eventTime, eventLocation)
+                }
+            }) { Text("Send") }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/app/src/main/java/com/example/cinet/EventItem.kt
+++ b/app/src/main/java/com/example/cinet/EventItem.kt
@@ -1,0 +1,9 @@
+package com.example.cinet
+
+data class EventItem(
+    val id: String = "",
+    val date: String = "",
+    val name: String = "",
+    val time: String = "",
+    val location: String = ""
+)

--- a/app/src/main/java/com/example/cinet/EventItemDialog.kt
+++ b/app/src/main/java/com/example/cinet/EventItemDialog.kt
@@ -1,0 +1,85 @@
+package com.example.cinet
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EventItemDialog(
+    editingEvent: EventItem?,
+    date: String,
+    eventName: String,
+    onEventNameChange: (String) -> Unit,
+    eventTime: String,
+    location: String,
+    onLocationChange: (String) -> Unit,
+    onPickTime: () -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    onDelete: (() -> Unit)?
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (editingEvent == null) "Add Event" else "Edit Event") },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Text("Date: $date")
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = eventName,
+                    onValueChange = onEventNameChange,
+                    label = { Text("Event Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = eventTime,
+                    onValueChange = {},
+                    label = { Text("Time") },
+                    modifier = Modifier.fillMaxWidth(),
+                    readOnly = true
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onPickTime) { Text("Pick Time") }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = onLocationChange,
+                    label = { Text("Location (optional)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(if (editingEvent == null) "Save" else "Update")
+            }
+        },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (onDelete != null) {
+                    Button(
+                        onClick = onDelete,
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                    ) { Text("Delete") }
+                }
+                OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/cinet/EventSection.kt
+++ b/app/src/main/java/com/example/cinet/EventSection.kt
@@ -1,0 +1,54 @@
+package com.example.cinet
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+
+@Composable
+fun EventsSection(
+    selectedDate: LocalDate?,
+    eventsForSelectedDate: List<EventItem>,
+    onEventClick: (EventItem) -> Unit
+) {
+    Spacer(modifier = Modifier.height(24.dp))
+    Text("Events", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (selectedDate == null) {
+        Text("Select a date to view events.")
+    } else if (eventsForSelectedDate.isEmpty()) {
+        Text("No events for $selectedDate")
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            eventsForSelectedDate.forEach { event ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onEventClick(event) }
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(text = event.name, style = MaterialTheme.typography.titleSmall)
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(text = event.time)
+                        if (event.location.isNotBlank()) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(text = event.location, style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/NavigationHandler.kt
@@ -69,17 +69,8 @@ private fun MainScaffold(
     userProfile: UserProfile,
     onSignOut: () -> Unit
 ) {
-    var currentScreen by remember { mutableStateOf<Screen>(Screen.Home) }
-    var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
-    var activeConversation by remember { mutableStateOf<Conversation?>(null) }
-
-    BackHandler(enabled = currentScreen == Screen.Social &&
-            (selectedProfile != null || activeConversation != null)) {
-        when {
-            activeConversation != null -> activeConversation = null
-            selectedProfile != null -> selectedProfile = null
     val calendarViewModel: CalendarViewModel = viewModel()
-    
+
     val calendarScheduleItems = remember(calendarViewModel.classItems, calendarViewModel.scheduleItems) {
         val cal = Calendar.getInstance()
         val dayName = cal.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.SHORT, Locale.US) ?: ""
@@ -88,13 +79,10 @@ private fun MainScaffold(
             cal.get(Calendar.MONTH) + 1,
             cal.get(Calendar.DAY_OF_MONTH)
         )
-
         val list = mutableListOf<Pair<String, String>>()
-        // Add classes for today
         calendarViewModel.classItems
             .filter { it.meetingDays.contains(dayName) }
             .forEach { list.add(it.name to "${it.startTime} - ${it.endTime}") }
-        // Add assignments/tasks for today
         calendarViewModel.scheduleItems
             .filter { it.date == dateStr }
             .forEach { list.add(it.assignmentName to "Due: ${it.dueTime} (${it.className})") }
@@ -103,11 +91,12 @@ private fun MainScaffold(
 
     var currentScreen by remember { mutableStateOf(Screen.Home) }
     var showAddClassOnCalendar by remember { mutableStateOf(false) }
+    var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
+    var activeConversation by remember { mutableStateOf<Conversation?>(null) }
 
     val context = LocalContext.current
     val sharedPrefs = remember { context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE) }
 
-    // Helper to load from SharedPreferences (Used only for Events now)
     fun loadItems(key: String): List<Pair<String, String>> {
         val saved = sharedPrefs.getString(key, null) ?: return emptyList()
         return saved.split("||").filter { it.contains("|") }.map {
@@ -116,27 +105,18 @@ private fun MainScaffold(
         }
     }
 
-    // Helper to save to SharedPreferences
     fun saveItems(key: String, items: List<Pair<String, String>>) {
         val stringified = items.joinToString("||") { "${it.first}|${it.second}" }
         sharedPrefs.edit().putString(key, stringified).apply()
     }
 
-    // State for the upcoming events items
     var upcomingEventsItems by remember { mutableStateOf(loadItems("event_items")) }
 
-    // Sub-navigation state for Social tab
-    var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
-    var activeConversation by remember { mutableStateOf<Conversation?>(null) }
-
-    // Handle system back button
     BackHandler(enabled = currentScreen != Screen.Home || selectedProfile != null || activeConversation != null) {
-        if (activeConversation != null) {
-            activeConversation = null
-        } else if (selectedProfile != null) {
-            selectedProfile = null
-        } else {
-            currentScreen = Screen.Home
+        when {
+            activeConversation != null -> activeConversation = null
+            selectedProfile != null -> selectedProfile = null
+            else -> currentScreen = Screen.Home
         }
     }
 
@@ -153,7 +133,6 @@ private fun MainScaffold(
                                 selectedProfile = null
                                 activeConversation = null
                             }
-                            // Reset calendar sub-state when navigating normally
                             if (screen != Screen.Calendar) {
                                 showAddClassOnCalendar = false
                             }
@@ -191,7 +170,7 @@ private fun MainScaffold(
                     nickname = userProfile.nickname,
                     scheduleItems = calendarScheduleItems,
                     upcomingEventsItems = upcomingEventsItems,
-                    onUpdateSchedule = { /* Read-only from calendar */ },
+                    onUpdateSchedule = { },
                     onUpdateEvents = {
                         upcomingEventsItems = it
                         saveItems("event_items", it)
@@ -223,7 +202,7 @@ private fun MainScaffold(
                     onBack = { currentScreen = Screen.Home }
                 )
                 Screen.Calendar -> CalendarScreen(
-                    onBack = { 
+                    onBack = {
                         currentScreen = Screen.Home
                         showAddClassOnCalendar = false
                     },

--- a/app/src/main/java/com/example/cinet/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/NavigationHandler.kt
@@ -1,5 +1,6 @@
 package com.example.cinet
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -64,10 +65,16 @@ private fun MainScaffold(
     onSignOut: () -> Unit
 ) {
     var currentScreen by remember { mutableStateOf<Screen>(Screen.Home) }
-
-    // Sub-navigation state for Social tab
     var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
     var activeConversation by remember { mutableStateOf<Conversation?>(null) }
+
+    BackHandler(enabled = currentScreen == Screen.Social &&
+            (selectedProfile != null || activeConversation != null)) {
+        when {
+            activeConversation != null -> activeConversation = null
+            selectedProfile != null -> selectedProfile = null
+        }
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -78,7 +85,6 @@ private fun MainScaffold(
                         selected = currentScreen == screen,
                         onClick = {
                             currentScreen = screen
-                            // Reset social sub-navigation when leaving the tab
                             if (screen != Screen.Social) {
                                 selectedProfile = null
                                 activeConversation = null

--- a/app/src/main/java/com/example/cinet/SocialScreen.kt
+++ b/app/src/main/java/com/example/cinet/SocialScreen.kt
@@ -46,6 +46,7 @@ fun SocialScreen(
     var friends by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
     var pendingRequests by remember { mutableStateOf<List<FriendRequest>>(emptyList()) }
     var sentRequests by remember { mutableStateOf<List<FriendRequest>>(emptyList()) }
+    var sentRequestNicknames by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var searchQuery by remember { mutableStateOf("") }
     var searchResults by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
     var isSearching by remember { mutableStateOf(false) }
@@ -56,7 +57,14 @@ fun SocialScreen(
         isLoading = true
         repository.getFriends().onSuccess { friends = it }
         repository.getPendingRequests().onSuccess { pendingRequests = it }
-        repository.getSentRequests().onSuccess { sentRequests = it }
+        repository.getSentRequests().onSuccess { requests ->
+            sentRequests = requests
+            val nicknames = mutableMapOf<String, String>()
+            requests.forEach { request ->
+                nicknames[request.receiverId] = repository.getUserNickname(request.receiverId)
+            }
+            sentRequestNicknames = nicknames
+        }
         isLoading = false
     }
 
@@ -127,8 +135,15 @@ fun SocialScreen(
                                     scope.launch {
                                         repository.sendFriendRequest(user)
                                         searchResults = searchResults - user
-                                        repository.getSentRequests()
-                                            .onSuccess { sentRequests = it }
+                                        repository.getSentRequests().onSuccess { requests ->
+                                            sentRequests = requests
+                                            val nicknames = mutableMapOf<String, String>()
+                                            requests.forEach { request ->
+                                                nicknames[request.receiverId] =
+                                                    repository.getUserNickname(request.receiverId)
+                                            }
+                                            sentRequestNicknames = nicknames
+                                        }
                                     }
                                 }) {
                                     Text("Add")
@@ -218,7 +233,8 @@ fun SocialScreen(
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = request.receiverId,
+                                    text = sentRequestNicknames[request.receiverId]
+                                        ?: request.receiverId,
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                                 Text(
@@ -236,7 +252,7 @@ fun SocialScreen(
     }
 }
 
-// Frontend team: restyle this row however you want
+// Frontend: restyle this row however you want
 @Composable
 fun UserRow(
     user: UserProfile,

--- a/app/src/main/java/com/example/cinet/StudyInviteDialog.kt
+++ b/app/src/main/java/com/example/cinet/StudyInviteDialog.kt
@@ -1,0 +1,186 @@
+package com.example.cinet
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StudyInviteDialog(
+    existingItems: List<ScheduleItem>,
+    onDismiss: () -> Unit,
+    onSendExisting: (ScheduleItem) -> Unit,
+    onSendNew: (className: String, assignmentName: String, date: String, time: String) -> Unit,
+) {
+    val context = LocalContext.current
+    var isCreatingNew by remember { mutableStateOf(false) }
+    var newClassName by remember { mutableStateOf("") }
+    var newAssignmentName by remember { mutableStateOf("") }
+    var newDate by remember { mutableStateOf("") }
+    var newTime by remember { mutableStateOf("") }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                        sdf.timeZone = TimeZone.getTimeZone("UTC")
+                        newDate = sdf.format(Date(millis))
+                    }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (isCreatingNew) "New Study Invite" else "Send Study Invite") },
+        text = {
+            Column {
+                if (isCreatingNew) {
+                    OutlinedTextField(
+                        value = newClassName,
+                        onValueChange = { newClassName = it },
+                        label = { Text("Class name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = newAssignmentName,
+                        onValueChange = { newAssignmentName = it },
+                        label = { Text("What to study") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = newDate,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Date") },
+                        placeholder = { Text("Tap to pick a date") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showDatePicker = true }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = { showDatePicker = true }, modifier = Modifier.fillMaxWidth()) {
+                        Text("Pick Date")
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = newTime,
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Time") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(
+                        onClick = { openTimePicker(context) { newTime = it } },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Pick Time")
+                    }
+                } else {
+                    if (existingItems.isEmpty()) {
+                        Text(
+                            "No assignments found — create a new invite below.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        Text("Pick from your assignments:", style = MaterialTheme.typography.bodyMedium)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        LazyColumn {
+                            items(existingItems) { item ->
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp)
+                                        .clickable { onSendExisting(item) }
+                                ) {
+                                    Column(modifier = Modifier.padding(12.dp)) {
+                                        Text(text = item.className, style = MaterialTheme.typography.titleSmall)
+                                        Text(text = item.assignmentName)
+                                        Text(
+                                            text = "Due: ${item.dueTime} on ${item.date}",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextButton(onClick = { isCreatingNew = true }) {
+                        Text("Create new instead")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (isCreatingNew) {
+                TextButton(
+                    onClick = {
+                        if (newClassName.isNotBlank() && newAssignmentName.isNotBlank()
+                            && newDate.isNotBlank() && newTime.isNotBlank()
+                        ) {
+                            onSendNew(newClassName, newAssignmentName, newDate, newTime)
+                        }
+                    }
+                ) { Text("Send") }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = {
+                if (isCreatingNew) isCreatingNew = false else onDismiss()
+            }) {
+                Text(if (isCreatingNew) "Back" else "Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/cinet/StudySession.kt
+++ b/app/src/main/java/com/example/cinet/StudySession.kt
@@ -1,0 +1,10 @@
+package com.example.cinet
+
+data class StudySession(
+    val id: String = "",
+    val date: String = "",
+    val className: String = "",
+    val topic: String = "",
+    val startTime: String = "",
+    val location: String = ""
+)

--- a/app/src/main/java/com/example/cinet/StudySessionDialog.kt
+++ b/app/src/main/java/com/example/cinet/StudySessionDialog.kt
@@ -1,0 +1,94 @@
+package com.example.cinet
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+
+@Composable
+fun StudySessionDialog(
+    editingSession: StudySession?,
+    date: String,
+    className: String,
+    onClassNameChange: (String) -> Unit,
+    topic: String,
+    onTopicChange: (String) -> Unit,
+    startTime: String,
+    location: String,
+    onLocationChange: (String) -> Unit,
+    onPickStartTime: () -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    onDelete: (() -> Unit)?
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (editingSession == null) "Add Study Session" else "Edit Study Session") },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                Text("Date: $date")
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = className,
+                    onValueChange = onClassNameChange,
+                    label = { Text("Class Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = topic,
+                    onValueChange = onTopicChange,
+                    label = { Text("Topic / What to study") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = startTime,
+                    onValueChange = {},
+                    label = { Text("Start Time") },
+                    modifier = Modifier.fillMaxWidth(),
+                    readOnly = true
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = onPickStartTime) { Text("Pick Start Time") }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = onLocationChange,
+                    label = { Text("Location (optional)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(if (editingSession == null) "Save" else "Update")
+            }
+        },
+        dismissButton = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (onDelete != null) {
+                    Button(
+                        onClick = onDelete,
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                    ) { Text("Delete") }
+                }
+                OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/cinet/StudySessionsSection.kt
+++ b/app/src/main/java/com/example/cinet/StudySessionsSection.kt
@@ -1,0 +1,56 @@
+package com.example.cinet
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+
+@Composable
+fun StudySessionsSection(
+    selectedDate: LocalDate?,
+    studySessionsForSelectedDate: List<StudySession>,
+    onSessionClick: (StudySession) -> Unit
+) {
+    Spacer(modifier = Modifier.height(24.dp))
+    Text("Study Sessions", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (selectedDate == null) {
+        Text("Select a date to view study sessions.")
+    } else if (studySessionsForSelectedDate.isEmpty()) {
+        Text("No study sessions for $selectedDate")
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            studySessionsForSelectedDate.forEach { session ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSessionClick(session) }
+                ) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(text = session.className, style = MaterialTheme.typography.titleSmall)
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(text = session.topic)
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(text = session.startTime)
+                        if (session.location.isNotBlank()) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(text = session.location, style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/UserSetting.kt
+++ b/app/src/main/java/com/example/cinet/UserSetting.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.setValue
 object AppSettings {
     var isDarkMode by mutableStateOf(false)
     var notificationsEnabled by mutableStateOf(true)
+    var classReminderMinutesBefore: Long = 10L
+    var assignmentReminderMinutesBefore: Long = 60L
 }
 // settings stuff - Zack
 /**

--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -12,4 +12,5 @@ data class Conversation(
     val isGroup: Boolean = false,
     val groupName: String = "",
     @ServerTimestamp val lastUpdated: Date? = null,
+
 )

--- a/app/src/main/java/com/example/cinet/data/model/Message.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Message.kt
@@ -10,5 +10,7 @@ data class Message(
     val content: String = "",
     // type: "text", "study_invite", "event_invite"
     val type: String = "text",
+    // stores structured invite data so receiver can auto-populate their calendar
+    val metadata: Map<String, String> = emptyMap(),
     @ServerTimestamp val createdAt: Date? = null,
 )

--- a/app/src/main/java/com/example/cinet/data/remote/SocielRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocielRepository.kt
@@ -4,10 +4,11 @@ import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.model.FriendRequest
 import com.example.cinet.data.model.Message
 import com.example.cinet.data.model.UserProfile
+import com.example.cinet.ScheduleItem
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.SetOptions
 import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
 
 class SocialRepository(
@@ -15,8 +16,6 @@ class SocialRepository(
     private val auth: FirebaseAuth = FirebaseAuth.getInstance(),
 ) {
     private val currentUid get() = auth.currentUser?.uid ?: error("No signed-in user.")
-
-    // --- Friend search ---
 
     suspend fun searchUsersByNickname(query: String): Result<List<UserProfile>> {
         return try {
@@ -32,8 +31,6 @@ class SocialRepository(
             Result.failure(e)
         }
     }
-
-    // --- Friend requests ---
 
     suspend fun sendFriendRequest(receiver: UserProfile): Result<Unit> {
         return try {
@@ -71,13 +68,25 @@ class SocialRepository(
         }
     }
 
+    suspend fun getSentRequests(): Result<List<FriendRequest>> {
+        return try {
+            val snapshot = db.collection("friendRequests")
+                .whereEqualTo("senderId", currentUid)
+                .whereEqualTo("status", "pending")
+                .get()
+                .await()
+            Result.success(snapshot.toObjects(FriendRequest::class.java))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     suspend fun acceptFriendRequest(request: FriendRequest): Result<Unit> {
         return try {
             db.collection("friendRequests").document(request.id)
                 .update("status", "accepted")
                 .await()
 
-            // Add each user to the other's friends subcollection
             db.collection("users").document(currentUid)
                 .collection("friends").document(request.senderId)
                 .set(mapOf("uid" to request.senderId)).await()
@@ -119,8 +128,6 @@ class SocialRepository(
         }
     }
 
-    // --- Conversations ---
-
     suspend fun getOrCreateConversation(
         participantIds: List<String>,
         participantNicknames: Map<String, String>,
@@ -128,7 +135,8 @@ class SocialRepository(
         groupName: String = "",
     ): Result<Conversation> {
         return try {
-            // For 1-on-1, check if conversation already exists
+            android.util.Log.d("SocialRepository", "getOrCreateConversation called with participantIds: $participantIds")
+
             if (!isGroup) {
                 val existing = db.collection("conversations")
                     .whereArrayContains("participantIds", currentUid)
@@ -136,7 +144,10 @@ class SocialRepository(
                     .toObjects(Conversation::class.java)
                     .firstOrNull { it.participantIds.containsAll(participantIds) }
 
-                if (existing != null) return Result.success(existing)
+                if (existing != null) {
+                    android.util.Log.d("SocialRepository", "Found existing conversation: ${existing.id}")
+                    return Result.success(existing)
+                }
             }
 
             val docRef = db.collection("conversations").document()
@@ -169,7 +180,12 @@ class SocialRepository(
         }
     }
 
-    suspend fun sendMessage(conversationId: String, content: String, type: String = "text"): Result<Unit> {
+    suspend fun sendMessage(
+        conversationId: String,
+        content: String,
+        type: String = "text",
+        metadata: Map<String, String> = emptyMap(),
+    ): Result<Unit> {
         return try {
             val currentUser = db.collection("users").document(currentUid).get().await()
                 .toObject(UserProfile::class.java) ?: error("Current user not found.")
@@ -185,16 +201,17 @@ class SocialRepository(
                 senderNickname = currentUser.nickname,
                 content = content,
                 type = type,
+                metadata = metadata,
             )
             docRef.set(message).await()
 
-            // Update lastMessage on the conversation
             db.collection("conversations").document(conversationId)
                 .set(mapOf("lastMessage" to content), SetOptions.merge())
                 .await()
 
             Result.success(Unit)
         } catch (e: Exception) {
+            android.util.Log.e("SocialRepository", "sendMessage failed: ${e.message}")
             Result.failure(e)
         }
     }
@@ -208,18 +225,56 @@ class SocialRepository(
                 .get().await()
             Result.success(snapshot.toObjects(Message::class.java))
         } catch (e: Exception) {
-            android.util.Log.e("SocialRepository", "sendMessage failed: ${e.message}")
             Result.failure(e)
         }
     }
-    suspend fun getSentRequests(): Result<List<FriendRequest>> {
+
+    suspend fun getUserNickname(uid: String): String {
         return try {
-            val snapshot = db.collection("friendRequests")
-                .whereEqualTo("senderId", currentUid)
-                .whereEqualTo("status", "pending")
+            val snapshot = db.collection("users").document(uid).get().await()
+            snapshot.getString("nickname") ?: uid
+        } catch (e: Exception) {
+            uid
+        }
+    }
+
+    // Loads the current user's schedule items to pick from for study invites
+    suspend fun getMyScheduleItems(): Result<List<ScheduleItem>> {
+        return try {
+            val snapshot = db.collection("users")
+                .document(currentUid)
+                .collection("assignments")
                 .get()
                 .await()
-            Result.success(snapshot.toObjects(FriendRequest::class.java))
+            val items = snapshot.documents.mapNotNull { doc ->
+                val date = doc.getString("date") ?: return@mapNotNull null
+                val classId = doc.getString("classId") ?: return@mapNotNull null
+                val className = doc.getString("className") ?: return@mapNotNull null
+                val assignmentName = doc.getString("assignmentName") ?: return@mapNotNull null
+                val dueTime = doc.getString("dueTime") ?: return@mapNotNull null
+                ScheduleItem(
+                    id = doc.id,
+                    date = date,
+                    classId = classId,
+                    className = className,
+                    assignmentName = assignmentName,
+                    dueTime = dueTime
+                )
+            }
+            Result.success(items)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+    suspend fun respondToInvite(conversationId: String, messageId: String, response: String): Result<Unit> {
+        return try {
+            db.collection("conversations")
+                .document(conversationId)
+                .collection("messages")
+                .document(messageId)
+                .update("metadata.response", response)
+                .await()
+            Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }


### PR DESCRIPTION
### What this PR does
Improves the Social tab with better UX, fixes data issues, and integrates calendar with messaging through study session and event invites.

### Changes

**Social fixes**
- Add back button support using BackHandler for Social tab sub-navigation
- Fix pending sent requests showing UID — now resolves and displays receiver nickname
- Add getUserNickname to SocialRepository for nickname lookups

**Calendar integration**
- Add StudySession and EventItem models
- Add StudySessionDialog, EventItemDialog, EventInviteSenderDialog composables
- Add StudySessionsSection and EventsSection calendar composables
- Add Study and Events management buttons to CalendarScreen
- Update StudyInviteDialog with date picker replacing manual text input
- Update CalendarFirestoreRepository with study session and event CRUD
- Update CalendarViewModel with study session and event state and refresh methods
- Update Firestore rules for studySessions and events subcollections
- Add initialShowClassDialog parameter to CalendarScreen for dev compatibility

**Messaging invite system**
- Update Message model to include metadata map for storing invite details
- Fix sendMessage in SocialRepository to persist metadata to Firestore
- Add respondToInvite to SocialRepository to record accept/decline on message
- Update ConversationScreen with Accept/Decline buttons for study and event invites
- Update MessageBubble to show accepted/declined status after responding
- Accepting a study invite automatically saves to receiver's studySessions on Firestore
- Accepting an event invite automatically saves to receiver's events on Firestore

### Notes
- Old invite messages sent before the metadata fix will not have calendar data — only new invites will save to calendar on accept
- Requires `initialShowClassDialog` parameter added to CalendarScreen — default is false so existing callers are unaffected