### PR TITLE
Social tab tweaks

### DIFF
--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.data.model
 
+import com.google.firebase.firestore.PropertyName
 import com.google.firebase.firestore.ServerTimestamp
 import java.util.Date
 
@@ -9,8 +10,9 @@ data class Conversation(
     // maps uid → nickname for display purposes
     val participantNicknames: Map<String, String> = emptyMap(),
     val lastMessage: String = "",
-    val isGroup: Boolean = false,
+    @get:PropertyName("isGroup")
+    @set:PropertyName("isGroup")
+    var isGroup: Boolean = false,
     val groupName: String = "",
     @ServerTimestamp val lastUpdated: Date? = null,
-
 )

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -526,7 +526,11 @@ class SocialRepository(
             .get()
             .await()
             .toObjects(Conversation::class.java)
-            .firstOrNull { it.participantIds.containsAll(participantIds) }
+            .firstOrNull {
+                !it.isGroup &&
+                        it.participantIds.size == participantIds.size &&
+                        it.participantIds.containsAll(participantIds)
+            }
     }
 
     /** Creates and saves a new conversation document. */

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -9,6 +9,7 @@ import com.example.cinet.data.model.FriendRequest
 import com.example.cinet.data.model.Message
 import com.example.cinet.data.model.UserProfile
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
@@ -150,6 +151,20 @@ class SocialRepository(
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e("SocialRepository", "removeFriend failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    /** Renames a group conversation. */
+    suspend fun renameConversation(conversationId: String, newName: String): Result<Unit> {
+        return try {
+            db.collection("conversations")
+                .document(conversationId)
+                .update("groupName", newName)
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "renameConversation failed: ${e.message}")
             Result.failure(e)
         }
     }
@@ -569,14 +584,23 @@ class SocialRepository(
             .await()
     }
 
-    /** Updates the last message preview for a conversation. */
+    /**
+     * Updates the last message preview and lastUpdated timestamp for a conversation.
+     * lastUpdated is written as a server timestamp so sort order in the list is correct.
+     */
     private suspend fun updateConversationLastMessage(
         conversationId: String,
         content: String,
     ) {
         db.collection("conversations")
             .document(conversationId)
-            .set(mapOf("lastMessage" to content), SetOptions.merge())
+            .set(
+                mapOf(
+                    "lastMessage" to content,
+                    "lastUpdated" to FieldValue.serverTimestamp()
+                ),
+                SetOptions.merge()
+            )
             .await()
     }
 

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -130,6 +130,30 @@ class SocialRepository(
         }
     }
 
+    /** Removes a friend by deleting the friend doc from both users' subcollections. */
+    suspend fun removeFriend(friendUid: String): Result<Unit> {
+        return try {
+            db.collection("users")
+                .document(currentUid)
+                .collection("friends")
+                .document(friendUid)
+                .delete()
+                .await()
+
+            db.collection("users")
+                .document(friendUid)
+                .collection("friends")
+                .document(currentUid)
+                .delete()
+                .await()
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "removeFriend failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
     /** Finds an existing conversation or creates a new one. */
     suspend fun getOrCreateConversation(
         participantIds: List<String>,

--- a/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -20,6 +21,16 @@ fun ProfileScreen(
     onBack: () -> Unit,
 ) {
     val repository = remember { SocialRepository() }
+    val scope = rememberCoroutineScope()
+
+    var isFriend by remember { mutableStateOf(false) }
+
+    // Check friendship status on load
+    LaunchedEffect(user.uid) {
+        repository.getFriends().onSuccess { friends ->
+            isFriend = friends.any { it.uid == user.uid }
+        }
+    }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -47,23 +58,33 @@ fun ProfileScreen(
             )
             Spacer(modifier = Modifier.height(32.dp))
 
-            Button(
-                onClick = {
-                    // Use GlobalScope so the coroutine survives navigation away from this screen
-                    kotlinx.coroutines.GlobalScope.launch {
-                        repository.getOrCreateConversation(
-                            participantIds = listOf(currentUserProfile.uid, user.uid),
-                            participantNicknames = mapOf(
-                                currentUserProfile.uid to currentUserProfile.nickname,
-                                user.uid to user.nickname
-                            )
-                        ).onSuccess { onOpenConversation(it) }
-                    }
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Message")
+            if (isFriend) {
+                Button(
+                    onClick = {
+                        // Use GlobalScope so the coroutine survives navigation away from this screen
+                        kotlinx.coroutines.GlobalScope.launch {
+                            repository.getOrCreateConversation(
+                                participantIds = listOf(currentUserProfile.uid, user.uid),
+                                participantNicknames = mapOf(
+                                    currentUserProfile.uid to currentUserProfile.nickname,
+                                    user.uid to user.nickname
+                                )
+                            ).onSuccess { onOpenConversation(it) }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Message")
+                }
+            } else {
+                Text(
+                    text = "Add ${user.nickname} as a friend to send a message",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
             }
+
             Spacer(modifier = Modifier.height(8.dp))
             Button(
                 onClick = onBack,

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -44,21 +44,23 @@ fun ConversationScreen(
     var messageInput by remember { mutableStateOf("") }
     var showStudyInviteDialog by remember { mutableStateOf(false) }
     var showEventInviteDialog by remember { mutableStateOf(false) }
+    var showRemoveFriendDialog by remember { mutableStateOf(false) }
     var myScheduleItems by remember { mutableStateOf<List<ScheduleItem>>(emptyList()) }
     var myStudySessions by remember { mutableStateOf<List<StudySession>>(emptyList()) }
     var myEvents by remember { mutableStateOf<List<EventItem>>(emptyList()) }
-    var otherUserPhotoUrl by remember { mutableStateOf("") } // header avatar photo
-    var currentUserPhotoUrl by remember { mutableStateOf("") } // current user's avatar
+    var otherUserPhotoUrl by remember { mutableStateOf("") }
+    var currentUserPhotoUrl by remember { mutableStateOf("") }
+
+    val otherUid = conversation.participantIds.firstOrNull { it != currentUid } ?: ""
 
     // Load both participants' photos on open
     LaunchedEffect(conversation.id) {
-        val otherUid = conversation.participantIds.firstOrNull { it != currentUid } ?: return@LaunchedEffect
+        if (otherUid.isBlank()) return@LaunchedEffect
 
         val otherSnapshot = FirebaseFirestore.getInstance()
             .collection("users").document(otherUid).get().await()
         otherUserPhotoUrl = otherSnapshot.getString("photoUrl") ?: ""
 
-        // Also load current user's photo for sent message avatars
         val currentSnapshot = FirebaseFirestore.getInstance()
             .collection("users").document(currentUid).get().await()
         currentUserPhotoUrl = currentSnapshot.getString("photoUrl") ?: ""
@@ -89,13 +91,40 @@ fun ConversationScreen(
             .firstOrNull { it.key != currentUid }?.value ?: "Conversation"
     }
 
+    // Remove Friend confirmation dialog
+    if (showRemoveFriendDialog) {
+        AlertDialog(
+            onDismissRequest = { showRemoveFriendDialog = false },
+            title = { Text("Remove Friend") },
+            text = { Text("Are you sure you want to remove $conversationTitle as a friend?") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showRemoveFriendDialog = false
+                        scope.launch {
+                            repository.removeFriend(otherUid)
+                            onBack()
+                        }
+                    }
+                ) {
+                    Text("Remove")
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { showRemoveFriendDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
-            // Header — shows avatar and conversation title
+            // Header — shows avatar, conversation title, and Remove Friend button
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -145,7 +174,23 @@ fun ConversationScreen(
                 }
 
                 Spacer(modifier = Modifier.width(10.dp))
-                Text(text = conversationTitle, style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = conversationTitle,
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.weight(1f)
+                )
+
+                // Remove Friend button — only shown for direct (non-group) conversations
+                if (!conversation.isGroup && otherUid.isNotBlank()) {
+                    OutlinedButton(
+                        onClick = { showRemoveFriendDialog = true },
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        )
+                    ) {
+                        Text("Remove Friend", style = MaterialTheme.typography.labelSmall)
+                    }
+                }
             }
 
             HorizontalDivider()
@@ -354,7 +399,7 @@ fun ConversationScreen(
 fun MessageBubble(
     message: Message,
     isCurrentUser: Boolean,
-    currentUserPhotoUrl: String = "", // current user's photo for sent messages
+    currentUserPhotoUrl: String = "",
     onAccept: (() -> Unit)? = null,
     onDecline: (() -> Unit)? = null,
 ) {
@@ -380,7 +425,6 @@ fun MessageBubble(
                         .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
                 )
             } else {
-                // Fallback initials if no photo available
                 Box(
                     modifier = Modifier
                         .size(36.dp)
@@ -417,7 +461,6 @@ fun MessageBubble(
 
             val response = message.metadata["response"]
             when {
-                // Already responded — show status label instead of buttons
                 response == "accepted" -> Text(
                     text = "✓ Accepted",
                     style = MaterialTheme.typography.labelSmall,
@@ -430,7 +473,6 @@ fun MessageBubble(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(start = 4.dp)
                 )
-                // Not yet responded — show buttons
                 onAccept != null && onDecline != null -> {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         Button(onClick = onAccept) { Text("Accept") }
@@ -458,7 +500,6 @@ fun MessageBubble(
                         .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
                 )
             } else {
-                // Fallback initials if no photo available
                 Box(
                     modifier = Modifier
                         .size(36.dp)

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -497,34 +497,56 @@ fun MessageBubble(
                 Text(
                     text = message.senderNickname,
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-            }
-            Text(
-                text = message.content,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(4.dp)
-            )
-
-            val response = message.metadata["response"]
-            when {
-                response == "accepted" -> Text(
-                    text = "✓ Accepted",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(start = 4.dp)
-                )
-                response == "declined" -> Text(
-                    text = "✗ Declined",
-                    style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(start = 4.dp)
                 )
-                onAccept != null && onDecline != null -> {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Button(onClick = onAccept) { Text("Accept") }
-                        OutlinedButton(onClick = onDecline) { Text("Decline") }
+                Spacer(modifier = Modifier.height(2.dp))
+            }
+
+            val bubbleColor = if (isCurrentUser)
+                MaterialTheme.colorScheme.primary
+            else
+                MaterialTheme.colorScheme.secondaryContainer
+            val textColor = if (isCurrentUser)
+                MaterialTheme.colorScheme.onPrimary
+            else
+                MaterialTheme.colorScheme.onSecondaryContainer
+
+            Surface(
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(
+                    topStart = if (isCurrentUser) 16.dp else 4.dp,
+                    topEnd = if (isCurrentUser) 4.dp else 16.dp,
+                    bottomStart = 16.dp,
+                    bottomEnd = 16.dp
+                ),
+                color = bubbleColor,
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    Text(
+                        text = message.content,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = textColor
+                    )
+
+                    val response = message.metadata["response"]
+                    when {
+                        response == "accepted" -> Text(
+                            text = "✓ Accepted",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = textColor.copy(alpha = 0.8f)
+                        )
+                        response == "declined" -> Text(
+                            text = "✗ Declined",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = textColor.copy(alpha = 0.6f)
+                        )
+                        onAccept != null && onDecline != null -> {
+                            Spacer(modifier = Modifier.height(6.dp))
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(onClick = onAccept) { Text("Accept") }
+                                OutlinedButton(onClick = onDecline) { Text("Decline") }
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -2,6 +2,7 @@ package com.example.cinet.feature.social
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.shape.CircleShape
@@ -12,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -45,6 +47,10 @@ fun ConversationScreen(
     var showStudyInviteDialog by remember { mutableStateOf(false) }
     var showEventInviteDialog by remember { mutableStateOf(false) }
     var showRemoveFriendDialog by remember { mutableStateOf(false) }
+    var showRenameDialog by remember { mutableStateOf(false) }
+    var renameInput by remember { mutableStateOf("") }
+    // Local override so rename is reflected immediately without re-navigation
+    var displayGroupName by remember { mutableStateOf(conversation.groupName) }
     var myScheduleItems by remember { mutableStateOf<List<ScheduleItem>>(emptyList()) }
     var myStudySessions by remember { mutableStateOf<List<StudySession>>(emptyList()) }
     var myEvents by remember { mutableStateOf<List<EventItem>>(emptyList()) }
@@ -53,14 +59,20 @@ fun ConversationScreen(
 
     val otherUid = conversation.participantIds.firstOrNull { it != currentUid } ?: ""
 
+    val conversationTitle = if (conversation.isGroup) {
+        displayGroupName.ifBlank { "Group Chat" }
+    } else {
+        conversation.participantNicknames.entries
+            .firstOrNull { it.key != currentUid }?.value ?: "Conversation"
+    }
+
     // Load both participants' photos on open
     LaunchedEffect(conversation.id) {
-        if (otherUid.isBlank()) return@LaunchedEffect
-
-        val otherSnapshot = FirebaseFirestore.getInstance()
-            .collection("users").document(otherUid).get().await()
-        otherUserPhotoUrl = otherSnapshot.getString("photoUrl") ?: ""
-
+        if (otherUid.isNotBlank()) {
+            val otherSnapshot = FirebaseFirestore.getInstance()
+                .collection("users").document(otherUid).get().await()
+            otherUserPhotoUrl = otherSnapshot.getString("photoUrl") ?: ""
+        }
         val currentSnapshot = FirebaseFirestore.getInstance()
             .collection("users").document(currentUid).get().await()
         currentUserPhotoUrl = currentSnapshot.getString("photoUrl") ?: ""
@@ -84,13 +96,6 @@ fun ConversationScreen(
         if (messages.isNotEmpty()) listState.animateScrollToItem(messages.size - 1)
     }
 
-    val conversationTitle = if (conversation.isGroup) {
-        conversation.groupName
-    } else {
-        conversation.participantNicknames.entries
-            .firstOrNull { it.key != currentUid }?.value ?: "Conversation"
-    }
-
     // Remove Friend confirmation dialog
     if (showRemoveFriendDialog) {
         AlertDialog(
@@ -106,12 +111,47 @@ fun ConversationScreen(
                             onBack()
                         }
                     }
-                ) {
-                    Text("Remove")
-                }
+                ) { Text("Remove") }
             },
             dismissButton = {
                 OutlinedButton(onClick = { showRemoveFriendDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    // Rename group dialog
+    if (showRenameDialog) {
+        AlertDialog(
+            onDismissRequest = { showRenameDialog = false },
+            title = { Text("Rename Group") },
+            text = {
+                OutlinedTextField(
+                    value = renameInput,
+                    onValueChange = { renameInput = it },
+                    label = { Text("Group name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        val newName = renameInput.trim()
+                        if (newName.isNotBlank()) {
+                            showRenameDialog = false
+                            scope.launch {
+                                repository.renameConversation(conversation.id, newName)
+                                displayGroupName = newName
+                            }
+                        }
+                    },
+                    enabled = renameInput.isNotBlank()
+                ) { Text("Save") }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { showRenameDialog = false }) {
                     Text("Cancel")
                 }
             }
@@ -124,7 +164,7 @@ fun ConversationScreen(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
-            // Header — shows avatar, conversation title, and Remove Friend button
+            // Header
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -134,8 +174,8 @@ fun ConversationScreen(
                 Button(onClick = onBack) { Text("Back") }
                 Spacer(modifier = Modifier.width(12.dp))
 
-                // Avatar — shows Google photo if available, otherwise initials
-                val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() }
+                // Avatar — group uses tertiaryContainer tint to distinguish visually
+                val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() && !conversation.isGroup }
                 if (headerPhoto != null) {
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
@@ -147,23 +187,20 @@ fun ConversationScreen(
                         modifier = Modifier
                             .size(40.dp)
                             .clip(CircleShape)
-                            .border(
-                                width = 1.5.dp,
-                                color = MaterialTheme.colorScheme.primary,
-                                shape = CircleShape
-                            )
+                            .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
                     )
                 } else {
                     Box(
                         modifier = Modifier
                             .size(40.dp)
                             .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.secondaryContainer)
-                            .border(
-                                width = 1.5.dp,
-                                color = MaterialTheme.colorScheme.primary,
-                                shape = CircleShape
-                            ),
+                            .background(
+                                if (conversation.isGroup)
+                                    MaterialTheme.colorScheme.tertiaryContainer
+                                else
+                                    MaterialTheme.colorScheme.secondaryContainer
+                            )
+                            .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
@@ -174,13 +211,29 @@ fun ConversationScreen(
                 }
 
                 Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = conversationTitle,
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.weight(1f)
-                )
 
-                // Remove Friend button — only shown for direct (non-group) conversations
+                // Group name is tappable to rename; DM name is static
+                if (conversation.isGroup) {
+                    Text(
+                        text = conversationTitle,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable {
+                                renameInput = displayGroupName
+                                showRenameDialog = true
+                            }
+                    )
+                } else {
+                    Text(
+                        text = conversationTitle,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                // Remove Friend button — only for direct (non-group) conversations
                 if (!conversation.isGroup && otherUid.isNotBlank()) {
                     OutlinedButton(
                         onClick = { showRemoveFriendDialog = true },
@@ -201,7 +254,6 @@ fun ConversationScreen(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                // Study invite — loads assignments and study sessions only
                 OutlinedButton(
                     onClick = {
                         scope.launch {
@@ -213,7 +265,6 @@ fun ConversationScreen(
                 ) {
                     Text("Study Invite", style = MaterialTheme.typography.labelSmall)
                 }
-                // Event invite — loads existing events for picker
                 OutlinedButton(
                     onClick = {
                         scope.launch {
@@ -316,7 +367,6 @@ fun ConversationScreen(
         }
     }
 
-    // Study invite sender dialog — shows assignments and study sessions
     if (showStudyInviteDialog) {
         StudyInviteDialog(
             existingItems = myScheduleItems,
@@ -373,7 +423,6 @@ fun ConversationScreen(
         )
     }
 
-    // Event invite sender dialog — shows existing events with manual form option
     if (showEventInviteDialog) {
         EventInviteSenderDialog(
             existingEvents = myEvents,
@@ -408,7 +457,6 @@ fun MessageBubble(
         horizontalArrangement = if (isCurrentUser) Arrangement.End else Arrangement.Start,
         verticalAlignment = Alignment.Top
     ) {
-        // Avatar on the left for incoming messages
         if (!isCurrentUser) {
             val photoUrl = message.senderPhotoUrl.takeIf { it.isNotBlank() }
             if (photoUrl != null) {
@@ -482,7 +530,6 @@ fun MessageBubble(
             }
         }
 
-        // Avatar on the right for sent messages
         if (isCurrentUser) {
             Spacer(modifier = Modifier.width(8.dp))
             val photoUrl = currentUserPhotoUrl.takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -29,6 +29,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.tasks.await
 
 @Composable
 fun ConversationsListScreen(
@@ -296,7 +297,3 @@ private fun formatConversationTime(date: Date?): String {
         else -> SimpleDateFormat("MMM d", Locale.US).format(date)
     }
 }
-
-// Workaround for using await() inside LaunchedEffect without importing coroutines directly
-private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
-    kotlinx.coroutines.tasks.await(this)

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -1,0 +1,302 @@
+package com.example.cinet.feature.social
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.cinet.data.model.Conversation
+import com.example.cinet.data.remote.SocialRepository
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun ConversationsListScreen(
+    onOpenConversation: (Conversation) -> Unit,
+    onNewConversation: () -> Unit,
+    onOpenFriends: () -> Unit,
+) {
+    val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    val repository = remember { SocialRepository() }
+
+    var conversations by remember { mutableStateOf<List<Conversation>>(emptyList()) }
+    var pendingRequestCount by remember { mutableIntStateOf(0) }
+    var isLoading by remember { mutableStateOf(true) }
+
+    // Real-time listener — updates automatically when messages arrive
+    DisposableEffect(currentUid) {
+        val listener = FirebaseFirestore.getInstance()
+            .collection("conversations")
+            .whereArrayContains("participantIds", currentUid)
+            .addSnapshotListener { snapshot, _ ->
+                if (snapshot != null) {
+                    conversations = snapshot.toObjects(Conversation::class.java)
+                        .sortedByDescending { it.lastUpdated?.time ?: 0L }
+                    isLoading = false
+                }
+            }
+        onDispose { listener.remove() }
+    }
+
+    // One-shot load for pending request badge
+    LaunchedEffect(Unit) {
+        repository.getPendingRequests().onSuccess { pendingRequestCount = it.size }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Messages",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
+                )
+
+                // Friends button with pending request badge
+                BadgedBox(
+                    badge = {
+                        if (pendingRequestCount > 0) {
+                            Badge { Text(pendingRequestCount.toString()) }
+                        }
+                    },
+                    modifier = Modifier.padding(end = 8.dp)
+                ) {
+                    IconButton(onClick = onOpenFriends) {
+                        Icon(
+                            imageVector = Icons.Default.People,
+                            contentDescription = "Friends",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+
+                // Compose new conversation
+                IconButton(onClick = onNewConversation) {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = "New conversation",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else if (conversations.isEmpty()) {
+                // Empty state
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text(
+                            text = "No messages yet",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Tap the pencil icon to start a conversation",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Button(onClick = onNewConversation) {
+                            Text("New Message")
+                        }
+                    }
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(conversations, key = { it.id }) { conversation ->
+                        ConversationListItem(
+                            conversation = conversation,
+                            currentUid = currentUid,
+                            onClick = { onOpenConversation(conversation) }
+                        )
+                        HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConversationListItem(
+    conversation: Conversation,
+    currentUid: String,
+    onClick: () -> Unit,
+) {
+    val displayName = if (conversation.isGroup) {
+        conversation.groupName.ifBlank { "Group Chat" }
+    } else {
+        conversation.participantNicknames.entries
+            .firstOrNull { it.key != currentUid }?.value ?: "Unknown"
+    }
+
+    val otherUid = if (!conversation.isGroup) {
+        conversation.participantIds.firstOrNull { it != currentUid } ?: ""
+    } else ""
+
+    // For DMs, try to load the other user's photo
+    var otherPhotoUrl by remember(otherUid) { mutableStateOf("") }
+    LaunchedEffect(otherUid) {
+        if (otherUid.isNotBlank()) {
+            try {
+                val snap = FirebaseFirestore.getInstance()
+                    .collection("users").document(otherUid).get().await()
+                otherPhotoUrl = snap.getString("photoUrl") ?: ""
+            } catch (_: Exception) {}
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Avatar
+        ConversationAvatar(
+            isGroup = conversation.isGroup,
+            displayName = displayName,
+            photoUrl = otherPhotoUrl,
+            participantCount = conversation.participantIds.size
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (conversation.lastMessage.isNotBlank()) {
+                Text(
+                    text = conversation.lastMessage,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        // Timestamp
+        val timeStr = formatConversationTime(conversation.lastUpdated)
+        if (timeStr.isNotBlank()) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = timeStr,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationAvatar(
+    isGroup: Boolean,
+    displayName: String,
+    photoUrl: String,
+    participantCount: Int,
+) {
+    val initial = displayName.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+    val avatarColor = if (isGroup)
+        MaterialTheme.colorScheme.tertiaryContainer
+    else
+        MaterialTheme.colorScheme.secondaryContainer
+
+    if (!isGroup && photoUrl.isNotBlank()) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(photoUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = "Profile photo",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(52.dp)
+                .clip(CircleShape)
+                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(52.dp)
+                .clip(CircleShape)
+                .background(avatarColor)
+                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = initial,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
+    }
+}
+
+private fun formatConversationTime(date: Date?): String {
+    date ?: return ""
+    val now = System.currentTimeMillis()
+    val diff = now - date.time
+    return when {
+        diff < 60_000L -> "Just now"
+        diff < 3_600_000L -> "${diff / 60_000}m"
+        diff < 86_400_000L -> "${diff / 3_600_000}h"
+        diff < 172_800_000L -> "Yesterday"
+        else -> SimpleDateFormat("MMM d", Locale.US).format(date)
+    }
+}
+
+// Workaround for using await() inside LaunchedEffect without importing coroutines directly
+private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
+    kotlinx.coroutines.tasks.await(this)

--- a/app/src/main/java/com/example/cinet/feature/social/NewConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/NewConversationScreen.kt
@@ -1,0 +1,397 @@
+package com.example.cinet.feature.social
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.cinet.data.model.Conversation
+import com.example.cinet.data.model.UserProfile
+import com.example.cinet.data.remote.SocialRepository
+import kotlinx.coroutines.launch
+
+private enum class NewConvStep { Selecting, Naming }
+
+@Composable
+fun NewConversationScreen(
+    currentUserProfile: UserProfile,
+    onBack: () -> Unit,
+    onOpenConversation: (Conversation) -> Unit,
+) {
+    val repository = remember { SocialRepository() }
+    val scope = rememberCoroutineScope()
+
+    var step by remember { mutableStateOf(NewConvStep.Selecting) }
+    var friends by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isCreating by remember { mutableStateOf(false) }
+
+    var searchQuery by remember { mutableStateOf("") }
+    var selectedFriends by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
+    var groupName by remember { mutableStateOf("") }
+
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        repository.getFriends().onSuccess { friends = it }
+        isLoading = false
+    }
+
+    val filteredFriends = remember(friends, searchQuery) {
+        if (searchQuery.isBlank()) friends
+        else friends.filter { it.nickname.contains(searchQuery, ignoreCase = true) }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            // ── Header ──────────────────────────────────────────────
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = {
+                    when (step) {
+                        NewConvStep.Selecting -> onBack()
+                        NewConvStep.Naming -> step = NewConvStep.Selecting
+                    }
+                }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                }
+
+                Text(
+                    text = when (step) {
+                        NewConvStep.Selecting -> "New Message"
+                        NewConvStep.Naming -> "New Group"
+                    },
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+
+                // Action button — changes label based on step and selection
+                when (step) {
+                    NewConvStep.Selecting -> {
+                        val canProceed = selectedFriends.isNotEmpty() && !isCreating
+                        TextButton(
+                            onClick = {
+                                when {
+                                    selectedFriends.size == 1 -> {
+                                        // Single friend → open DM directly
+                                        val friend = selectedFriends.first()
+                                        isCreating = true
+                                        scope.launch {
+                                            repository.getOrCreateConversation(
+                                                participantIds = listOf(currentUserProfile.uid, friend.uid),
+                                                participantNicknames = mapOf(
+                                                    currentUserProfile.uid to currentUserProfile.nickname,
+                                                    friend.uid to friend.nickname
+                                                )
+                                            ).onSuccess { onOpenConversation(it) }
+                                            isCreating = false
+                                        }
+                                    }
+                                    selectedFriends.size >= 2 -> {
+                                        // Multiple → go to naming step
+                                        step = NewConvStep.Naming
+                                    }
+                                }
+                            },
+                            enabled = canProceed
+                        ) {
+                            if (isCreating) {
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                            } else {
+                                Text(
+                                    text = when {
+                                        selectedFriends.size >= 2 -> "Next"
+                                        else -> "Chat"
+                                    },
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                    }
+                    NewConvStep.Naming -> {
+                        TextButton(
+                            onClick = {
+                                if (groupName.isNotBlank() && !isCreating) {
+                                    isCreating = true
+                                    scope.launch {
+                                        val allIds = listOf(currentUserProfile.uid) + selectedFriends.map { it.uid }
+                                        val nicknames = (listOf(currentUserProfile) + selectedFriends)
+                                            .associate { it.uid to it.nickname }
+                                        repository.getOrCreateConversation(
+                                            participantIds = allIds,
+                                            participantNicknames = nicknames,
+                                            isGroup = true,
+                                            groupName = groupName.trim()
+                                        ).onSuccess { onOpenConversation(it) }
+                                        isCreating = false
+                                    }
+                                }
+                            },
+                            enabled = groupName.isNotBlank() && !isCreating
+                        ) {
+                            if (isCreating) {
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                            } else {
+                                Text("Create", fontWeight = FontWeight.Bold)
+                            }
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider()
+
+            // ── Step: Friend Selection ───────────────────────────────
+            if (step == NewConvStep.Selecting) {
+
+                // Selected friends chips
+                if (selectedFriends.isNotEmpty()) {
+                    LazyRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(selectedFriends, key = { it.uid }) { friend ->
+                            SelectedFriendChip(
+                                friend = friend,
+                                onRemove = {
+                                    selectedFriends = selectedFriends - friend
+                                }
+                            )
+                        }
+                    }
+                    HorizontalDivider()
+                }
+
+                // Search field
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text("Search friends…") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .focusRequester(focusRequester),
+                    shape = RoundedCornerShape(24.dp)
+                )
+
+                if (isLoading) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                } else if (friends.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "Add some friends first to start a conversation",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(filteredFriends, key = { it.uid }) { friend ->
+                            val isSelected = selectedFriends.any { it.uid == friend.uid }
+                            FriendSelectRow(
+                                friend = friend,
+                                isSelected = isSelected,
+                                onToggle = {
+                                    selectedFriends = if (isSelected) {
+                                        selectedFriends - friend
+                                    } else {
+                                        selectedFriends + friend
+                                    }
+                                }
+                            )
+                            HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+                        }
+                    }
+                }
+            }
+
+            // ── Step: Group Name ─────────────────────────────────────
+            if (step == NewConvStep.Naming) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    // Member preview
+                    Text(
+                        text = "${selectedFriends.size + 1} members",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        items(selectedFriends) { friend ->
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                FriendAvatar(friend = friend, size = 44)
+                                Text(
+                                    text = friend.nickname,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    maxLines = 1
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    OutlinedTextField(
+                        value = groupName,
+                        onValueChange = { groupName = it },
+                        label = { Text("Group name") },
+                        placeholder = { Text("e.g. Study crew, COMP 101…") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Text(
+                        text = "You can rename it later from the conversation.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FriendSelectRow(
+    friend: UserProfile,
+    isSelected: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        FriendAvatar(friend = friend, size = 48)
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = friend.nickname,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = "${friend.major} · ${friend.pronouns}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Checkbox(
+            checked = isSelected,
+            onCheckedChange = { onToggle() }
+        )
+    }
+}
+
+@Composable
+private fun SelectedFriendChip(
+    friend: UserProfile,
+    onRemove: () -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        modifier = Modifier.height(36.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(
+                text = friend.nickname,
+                style = MaterialTheme.typography.labelMedium
+            )
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Remove ${friend.nickname}",
+                modifier = Modifier
+                    .size(16.dp)
+                    .clickable(onClick = onRemove)
+            )
+        }
+    }
+}
+
+@Composable
+fun FriendAvatar(friend: UserProfile, size: Int) {
+    val photoUrl = friend.photoUrl.takeIf { it.isNotBlank() }
+    if (photoUrl != null) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(photoUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = "Profile photo",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(size.dp)
+                .clip(CircleShape)
+                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(size.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.secondaryContainer)
+                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = friend.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
@@ -24,10 +24,12 @@ import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import androidx.compose.foundation.layout.size
+import com.example.cinet.core.designsystem.PullToRefreshContainer
 
 @Composable
 fun SocialScreen(
     onOpenProfile: (UserProfile) -> Unit,
+    onOpenConversation: (UserProfile) -> Unit,
 ) {
     val repository = remember { SocialRepository() }
     val scope = rememberCoroutineScope()
@@ -38,12 +40,13 @@ fun SocialScreen(
     var sentRequestNicknames by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var searchQuery by remember { mutableStateOf("") }
     var searchResults by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
-    var isSearching by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(true) }
+    var isRefreshing by remember { mutableStateOf(false) }
     var refreshKey by remember { mutableIntStateOf(0) }
 
+    // Load friends/requests whenever refreshKey changes
     LaunchedEffect(refreshKey) {
-        isLoading = true
+        if (refreshKey > 0) isRefreshing = true
         repository.getFriends().onSuccess { friends = it }
         repository.getPendingRequests().onSuccess { pendingRequests = it }
         repository.getSentRequests().onSuccess { requests ->
@@ -55,6 +58,20 @@ fun SocialScreen(
             sentRequestNicknames = nicknames
         }
         isLoading = false
+        isRefreshing = false
+    }
+
+    // Auto-search when query changes; clear results when field is emptied
+    LaunchedEffect(searchQuery) {
+        if (searchQuery.isBlank()) {
+            searchResults = emptyList()
+        } else {
+            val friendUids = friends.map { it.uid }.toSet()
+            val sentUids = sentRequests.map { it.receiverId }.toSet()
+            repository.searchUsersByNickname(searchQuery).onSuccess { results ->
+                searchResults = results.filter { it.uid !in friendUids && it.uid !in sentUids }
+            }
+        }
     }
 
     Surface(
@@ -70,191 +87,178 @@ fun SocialScreen(
                 CircularProgressIndicator()
             }
         } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
+            PullToRefreshContainer(
+                isRefreshing = isRefreshing,
+                onRefresh = { refreshKey++ },
+                modifier = Modifier.fillMaxSize()
             ) {
-                item {
-                    Text("Social", style = MaterialTheme.typography.headlineMedium)
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    OutlinedTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        label = { Text("Search by nickname") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = {
-                            scope.launch {
-                                isSearching = true
-                                repository.searchUsersByNickname(searchQuery)
-                                    .onSuccess { searchResults = it }
-                                isSearching = false
-                            }
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Search")
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedButton(
-                        onClick = { refreshKey++ },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Refresh")
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-
-                if (searchResults.isNotEmpty()) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp)
+                ) {
                     item {
-                        Text("Search Results", style = MaterialTheme.typography.titleMedium)
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Text("Social", style = MaterialTheme.typography.headlineMedium)
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            label = { Text("Search by nickname") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
                     }
-                    items(searchResults) { user ->
-                        UserRow(
-                            user = user,
-                            onClick = { onOpenProfile(user) },
-                            trailingContent = {
-                                OutlinedButton(onClick = {
-                                    scope.launch {
-                                        repository.sendFriendRequest(user)
-                                        searchResults = searchResults - user
-                                        repository.getSentRequests().onSuccess { requests ->
-                                            sentRequests = requests
-                                            val nicknames = mutableMapOf<String, String>()
-                                            requests.forEach { request ->
-                                                nicknames[request.receiverId] =
-                                                    repository.getUserNickname(request.receiverId)
+
+                    if (searchResults.isNotEmpty()) {
+                        item {
+                            Text("Search Results", style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(searchResults) { user ->
+                            // Search results are not tappable — Add button only
+                            UserRow(
+                                user = user,
+                                onClick = {},
+                                trailingContent = {
+                                    OutlinedButton(onClick = {
+                                        scope.launch {
+                                            repository.sendFriendRequest(user)
+                                            searchResults = searchResults - user
+                                            repository.getSentRequests().onSuccess { requests ->
+                                                sentRequests = requests
+                                                val nicknames = mutableMapOf<String, String>()
+                                                requests.forEach { request ->
+                                                    nicknames[request.receiverId] =
+                                                        repository.getUserNickname(request.receiverId)
+                                                }
+                                                sentRequestNicknames = nicknames
                                             }
-                                            sentRequestNicknames = nicknames
                                         }
+                                    }) {
+                                        Text("Add")
+                                    }
+                                }
+                            )
+                            HorizontalDivider()
+                        }
+                        item { Spacer(modifier = Modifier.height(16.dp)) }
+                    }
+
+                    if (pendingRequests.isNotEmpty()) {
+                        item {
+                            Text("Friend Requests", style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(pendingRequests) { request ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = request.senderNickname,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                Button(onClick = {
+                                    scope.launch {
+                                        repository.acceptFriendRequest(request)
+                                        pendingRequests = pendingRequests - request
+                                        repository.getFriends().onSuccess { friends = it }
                                     }
                                 }) {
-                                    Text("Add")
+                                    Text("Accept")
+                                }
+                                Spacer(modifier = Modifier.width(8.dp))
+                                OutlinedButton(onClick = {
+                                    scope.launch {
+                                        repository.declineFriendRequest(request)
+                                        pendingRequests = pendingRequests - request
+                                    }
+                                }) {
+                                    Text("Decline")
                                 }
                             }
-                        )
-                        HorizontalDivider()
+                            HorizontalDivider()
+                        }
+                        item { Spacer(modifier = Modifier.height(16.dp)) }
                     }
-                    item { Spacer(modifier = Modifier.height(16.dp)) }
-                }
 
-                if (pendingRequests.isNotEmpty()) {
                     item {
-                        Text("Friend Requests", style = MaterialTheme.typography.titleMedium)
+                        Text("Friends", style = MaterialTheme.typography.titleMedium)
                         Spacer(modifier = Modifier.height(8.dp))
                     }
-                    items(pendingRequests) { request ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
+                    if (friends.isEmpty()) {
+                        item {
                             Text(
-                                text = request.senderNickname,
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.weight(1f)
+                                "No friends yet — search for someone above",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                            Button(onClick = {
-                                scope.launch {
-                                    repository.acceptFriendRequest(request)
-                                    pendingRequests = pendingRequests - request
-                                    repository.getFriends().onSuccess { friends = it }
-                                }
-                            }) {
-                                Text("Accept")
-                            }
-                            Spacer(modifier = Modifier.width(8.dp))
-                            OutlinedButton(onClick = {
-                                scope.launch {
-                                    repository.declineFriendRequest(request)
-                                    pendingRequests = pendingRequests - request
-                                }
-                            }) {
-                                Text("Decline")
-                            }
                         }
-                        HorizontalDivider()
+                    } else {
+                        items(friends) { friend ->
+                            // Friends tap straight to conversation
+                            UserRow(
+                                user = friend,
+                                onClick = { onOpenConversation(friend) }
+                            )
+                            HorizontalDivider()
+                        }
                     }
-                    item { Spacer(modifier = Modifier.height(16.dp)) }
-                }
 
-                item {
-                    Text("Friends", style = MaterialTheme.typography.titleMedium)
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-                if (friends.isEmpty()) {
-                    item {
-                        Text(
-                            "No friends yet — search for someone above",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                } else {
-                    items(friends) { friend ->
-                        UserRow(
-                            user = friend,
-                            onClick = { onOpenProfile(friend) }
-                        )
-                        HorizontalDivider()
-                    }
-                }
-
-                if (sentRequests.isNotEmpty()) {
-                    item {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text("Pending Sent Requests", style = MaterialTheme.typography.titleMedium)
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
-                    items(sentRequests) { request ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            // Initials fallback only — sent requests don't carry photoUrl
-                            Box(
+                    if (sentRequests.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text("Pending Sent Requests", style = MaterialTheme.typography.titleMedium)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(sentRequests) { request ->
+                            Row(
                                 modifier = Modifier
-                                    .size(44.dp)
-                                    .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.secondaryContainer)
-                                    .border(
-                                        width = 1.5.dp,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        shape = CircleShape
-                                    ),
-                                contentAlignment = Alignment.Center
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                val nickname = sentRequestNicknames[request.receiverId] ?: "?"
-                                Text(
-                                    text = nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                            }
+                                // Initials fallback only — sent requests don't carry photoUrl
+                                Box(
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                                        .border(
+                                            width = 1.5.dp,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            shape = CircleShape
+                                        ),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    val nickname = sentRequestNicknames[request.receiverId] ?: "?"
+                                    Text(
+                                        text = nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                        style = MaterialTheme.typography.titleMedium
+                                    )
+                                }
 
-                            Spacer(modifier = Modifier.width(12.dp))
+                                Spacer(modifier = Modifier.width(12.dp))
 
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = sentRequestNicknames[request.receiverId] ?: request.receiverId,
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                                Text(
-                                    text = "Request pending",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = sentRequestNicknames[request.receiverId] ?: request.receiverId,
+                                        style = MaterialTheme.typography.bodyLarge
+                                    )
+                                    Text(
+                                        text = "Request pending",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
+                            HorizontalDivider()
                         }
-                        HorizontalDivider()
                     }
                 }
             }
@@ -262,7 +266,6 @@ fun SocialScreen(
     }
 }
 
-// Frontend: restyle this row however you want
 // Frontend: restyle this row however you want
 @Composable
 fun UserRow(

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.*
 import com.example.cinet.data.remote.SocialRepository
 import java.util.Calendar
@@ -65,7 +64,7 @@ private fun MainScaffold(
     onSignOut: () -> Unit,
     viewModel: CampusRegistry = androidx.lifecycle.viewmodel.compose.viewModel()
 ) {
-    val calendarViewModel: CalendarViewModel = viewModel()
+    val calendarViewModel: CalendarViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
     val campusRegistry by viewModel.campusRegistry.collectAsState()
     var preSelectedMapLocation by remember { mutableStateOf<CampusLocation?>(null) }
 
@@ -82,10 +81,8 @@ private fun MainScaffold(
         )
         val list = mutableListOf<Pair<String, String>>()
         calendarViewModel.classItems
-        calendarViewModel.classItems
             .filter { it.meetingDays.contains(dayName) }
             .forEach { list.add(it.name to "${it.startTime} - ${it.endTime} | ${it.location}") }
-        // Add assignments/tasks for today
         calendarViewModel.scheduleItems
             .filter { it.date == dateStr }
             .forEach { list.add(it.assignmentName to "Due: ${it.dueTime} (${it.className})") }
@@ -94,9 +91,13 @@ private fun MainScaffold(
 
     var currentScreen by remember { mutableStateOf(Screen.Home) }
     var showAddClassOnCalendar by remember { mutableStateOf(false) }
-    var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
-    var activeConversation by remember { mutableStateOf<Conversation?>(null) }
     var showProfileEdit by remember { mutableStateOf(false) }
+
+    // Social sub-navigation stack
+    var activeConversation by remember { mutableStateOf<Conversation?>(null) }
+    var selectedProfile by remember { mutableStateOf<UserProfile?>(null) }
+    var showNewConversation by remember { mutableStateOf(false) }
+    var showSocialScreen by remember { mutableStateOf(false) } // friends / search / requests
 
     val context = LocalContext.current
     val sharedPrefs = remember { context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE) }
@@ -116,10 +117,16 @@ private fun MainScaffold(
 
     var upcomingEventsItems by remember { mutableStateOf(loadItems("event_items")) }
 
-    BackHandler(enabled = currentScreen != Screen.Home || selectedProfile != null || activeConversation != null || showProfileEdit) {
+    val socialBackStackActive = currentScreen == Screen.Social &&
+            (activeConversation != null || selectedProfile != null ||
+                    showNewConversation || showSocialScreen)
+
+    BackHandler(enabled = currentScreen != Screen.Home || socialBackStackActive || showProfileEdit) {
         when {
             activeConversation != null -> activeConversation = null
+            showNewConversation -> showNewConversation = false
             selectedProfile != null -> selectedProfile = null
+            showSocialScreen -> showSocialScreen = false
             else -> currentScreen = Screen.Home
         }
     }
@@ -134,15 +141,17 @@ private fun MainScaffold(
                         onClick = {
                             currentScreen = screen
                             if (screen != Screen.Social) {
-                                selectedProfile = null
+                                // Clear social sub-navigation when leaving the tab
                                 activeConversation = null
+                                selectedProfile = null
+                                showNewConversation = false
+                                showSocialScreen = false
                             }
                             if (screen != Screen.Calendar) {
                                 showAddClassOnCalendar = false
                                 if (screen != Screen.Settings)
                                     showProfileEdit = false
                             }
-
                         },
                         label = {
                             Text(
@@ -195,7 +204,9 @@ private fun MainScaffold(
                         currentScreen = Screen.Map
                     }
                 )
+
                 Screen.Social -> when {
+                    // Deepest layer first
                     activeConversation != null -> ConversationScreen(
                         conversation = activeConversation!!,
                         onBack = { activeConversation = null }
@@ -206,7 +217,15 @@ private fun MainScaffold(
                         onOpenConversation = { activeConversation = it },
                         onBack = { selectedProfile = null }
                     )
-                    else -> SocialScreen(
+                    showNewConversation -> NewConversationScreen(
+                        currentUserProfile = userProfile,
+                        onBack = { showNewConversation = false },
+                        onOpenConversation = {
+                            showNewConversation = false
+                            activeConversation = it
+                        }
+                    )
+                    showSocialScreen -> SocialScreen(
                         onOpenProfile = { selectedProfile = it },
                         onOpenConversation = { friend ->
                             socialScope.launch {
@@ -216,18 +235,26 @@ private fun MainScaffold(
                                         userProfile.uid to userProfile.nickname,
                                         friend.uid to friend.nickname
                                     )
-                                ).onSuccess { activeConversation = it }
+                                ).onSuccess {
+                                    showSocialScreen = false
+                                    activeConversation = it
+                                }
                             }
                         }
                     )
+                    else -> ConversationsListScreen(
+                        onOpenConversation = { activeConversation = it },
+                        onNewConversation = { showNewConversation = true },
+                        onOpenFriends = { showSocialScreen = true }
+                    )
                 }
+
                 Screen.Map -> CampusMapScreen(
                     onBack = { currentScreen = Screen.Home },
                     preSelectedLocation = preSelectedMapLocation,
-                    onFinishedLoading = {
-                        preSelectedMapLocation = null
-                    }
+                    onFinishedLoading = { preSelectedMapLocation = null }
                 )
+
                 Screen.Calendar -> CalendarScreen(
                     onBack = {
                         currentScreen = Screen.Home
@@ -235,16 +262,17 @@ private fun MainScaffold(
                     },
                     initialShowClassDialog = showAddClassOnCalendar
                 )
+
                 Screen.Settings -> if (showProfileEdit) {
                     ProfileEditScreen(
                         onBack = { showProfileEdit = false }
                     )
                 } else {
                     SettingScreen(
-                        onBack        = { currentScreen = Screen.Home },
-                        onSignOut     = onSignOut,
+                        onBack = { currentScreen = Screen.Home },
+                        onSignOut = onSignOut,
                         onEditProfile = { showProfileEdit = true },
-                        userProfile   = userProfile
+                        userProfile = userProfile
                     )
                 }
             }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.*
+import com.example.cinet.data.remote.SocialRepository
 import java.util.Calendar
 import java.util.Locale
 import com.example.cinet.feature.auth.*
@@ -24,6 +25,8 @@ import com.example.cinet.feature.social.*
 import com.example.cinet.feature.profile.*
 import com.example.cinet.feature.calendar.calendarFiles.*
 import com.example.cinet.feature.settings.*
+import kotlinx.coroutines.launch
+
 enum class Screen(val label: String, val icon: ImageVector) {
     Home("Home", Icons.Default.Home),
     Social("Social", Icons.Default.People),
@@ -65,6 +68,9 @@ private fun MainScaffold(
     val calendarViewModel: CalendarViewModel = viewModel()
     val campusRegistry by viewModel.campusRegistry.collectAsState()
     var preSelectedMapLocation by remember { mutableStateOf<CampusLocation?>(null) }
+
+    val socialScope = rememberCoroutineScope()
+    val socialRepository = remember { SocialRepository() }
 
     val calendarScheduleItems = remember(calendarViewModel.classItems, calendarViewModel.scheduleItems) {
         val cal = Calendar.getInstance()
@@ -201,7 +207,18 @@ private fun MainScaffold(
                         onBack = { selectedProfile = null }
                     )
                     else -> SocialScreen(
-                        onOpenProfile = { selectedProfile = it }
+                        onOpenProfile = { selectedProfile = it },
+                        onOpenConversation = { friend ->
+                            socialScope.launch {
+                                socialRepository.getOrCreateConversation(
+                                    participantIds = listOf(userProfile.uid, friend.uid),
+                                    participantNicknames = mapOf(
+                                        userProfile.uid to userProfile.nickname,
+                                        friend.uid to friend.nickname
+                                    )
+                                ).onSuccess { activeConversation = it }
+                            }
+                        }
                     )
                 }
                 Screen.Map -> CampusMapScreen(
@@ -227,7 +244,7 @@ private fun MainScaffold(
                         onBack        = { currentScreen = Screen.Home },
                         onSignOut     = onSignOut,
                         onEditProfile = { showProfileEdit = true },
-                        userProfile   = userProfile  // ← add this
+                        userProfile   = userProfile
                     )
                 }
             }


### PR DESCRIPTION
### Summary
Adds to the social tab with group messaging, a conversations-first layout, and a set of DM/UI fixes.

### What's new
- **Conversations list** — real-time listener, DMs and groups coexist sorted by last message time, pending friend request badge
- **Group messaging** — Instagram-style creation flow: select friends with checkboxes and chips, skip name step for DMs, group name step for 2+ friends
- **Group rename** — tap the group name in the conversation header to rename inline
- **Message bubbles** — colored backgrounds (primary for sent, secondaryContainer for received)
- **Remove Friend** — confirmation dialog in DM header, hidden on group chats

### Bug fixes
- `isGroup` Firestore deserialization fixed via `@PropertyName` — groups were reading back as `false`
- `findExistingDirectConversation` now requires exact participant count match and excludes groups — tapping a friend no longer opens a group chat they share
- `lastUpdated` now written as server timestamp on every message send — conversation list sort order was broken
- Auto-search in SocialScreen filters out existing friends and pending sent requests

### Notes for reviewers
- `ConversationsListScreen` uses a real-time snapshot listener — no pull-to-refresh needed
- `Conversation.isGroup` is now `var` (required for Firestore deserialization)
