### PR TITLE
Calendar events added

### DIFF
--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarFirestoreRepository.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarFirestoreRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.example.cinet.feature.calendar.schedule.ScheduleItem
 import com.example.cinet.feature.calendar.classEvent.ClassItem
 import com.example.cinet.feature.calendar.event.EventItem
+import com.example.cinet.feature.calendar.event.EventSource
 import com.example.cinet.feature.calendar.study.StudySession
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -257,7 +258,7 @@ class CalendarFirestoreRepository(
             val name = doc.getString("name") ?: return@mapNotNull null
             val time = doc.getString("time") ?: return@mapNotNull null
             val location = doc.getString("location") ?: ""
-            EventItem(id = doc.id, date = date, name = name, time = time, location = location)
+            EventItem(id = doc.id, date = date, name = name, time = time, location = location, source = EventSource.USER)
         }
     }
 

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarGrid.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarGrid.kt
@@ -3,7 +3,15 @@ package com.example.cinet.feature.calendar.calendarFiles
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,22 +30,24 @@ fun CalendarGrid(
     selectedDate: LocalDate?,
     today: LocalDate,
     scheduleItems: List<ScheduleItem>,
+    markedDates: Set<String>,
     onDateSelected: (Int) -> Unit,
     onSameDateClicked: () -> Unit
 ) {
     val firstDayOfMonth = currentMonth.atDay(1)
     val daysInMonth = currentMonth.lengthOfMonth()
-
-    // dayOfWeek.value = 1 (Mon) → 7 (Sun), so % 7 shifts Sunday to 0 for grid alignment.
     val startDayOfWeek = firstDayOfMonth.dayOfWeek.value % 7
 
     val days = mutableListOf<Int?>()
     repeat(startDayOfWeek) { days.add(null) }
 
-    for (day in 1..daysInMonth) days.add(day)
+    for (day in 1..daysInMonth) {
+        days.add(day)
+    }
 
-    // Pads the grid so total cells are divisible by 7 (full weeks).
-    while (days.size % 7 != 0) days.add(null)
+    while (days.size % 7 != 0) {
+        days.add(null)
+    }
 
     Row(modifier = Modifier.fillMaxWidth()) {
         listOf("Su", "Mo", "Tu", "We", "Th", "Fr", "Sa").forEach {
@@ -67,39 +77,32 @@ fun CalendarGrid(
                             val cellDate = currentMonth.atDay(day)
                             val isToday = cellDate == today
                             val isSelected = selectedDate == cellDate
-
-                            // Matches whatever format ScheduleItem.date uses.
                             val dateString = "%04d-%02d-%02d".format(
                                 cellDate.year,
                                 cellDate.monthValue,
                                 cellDate.dayOfMonth
                             )
-
-                            // Relies on ScheduleItem storing date as a formatted string.
-                            val hasItems = scheduleItems.any { it.date == dateString }
+                            val hasItems = scheduleItems.any { it.date == dateString } || markedDates.contains(dateString)
 
                             Box(
                                 modifier = Modifier
                                     .size(42.dp)
                                     .background(
-                                        if (isToday) MaterialTheme.colorScheme.primary
-                                        else Color.Transparent,
+                                        if (isToday) MaterialTheme.colorScheme.primary else Color.Transparent,
                                         CircleShape
                                     )
                                     .then(
                                         if (isSelected) {
-                                            // Selection is indicated separately from "today",
-                                            // so both states can be visible at once.
                                             Modifier.border(
                                                 2.dp,
                                                 MaterialTheme.colorScheme.tertiary,
                                                 CircleShape
                                             )
-                                        } else Modifier
+                                        } else {
+                                            Modifier
+                                        }
                                     )
                                     .clickable {
-                                        // Same-date click triggers a different action
-                                        // (e.g., open dialog instead of just selecting).
                                         if (selectedDate == cellDate) {
                                             onSameDateClicked()
                                         } else {
@@ -108,13 +111,10 @@ fun CalendarGrid(
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                     Text(
                                         text = day.toString(),
-                                        color = if (isToday) Color.White
-                                        else MaterialTheme.colorScheme.onSurface
+                                        color = if (isToday) Color.White else MaterialTheme.colorScheme.onSurface
                                     )
 
                                     if (hasItems) {
@@ -123,9 +123,7 @@ fun CalendarGrid(
                                             modifier = Modifier
                                                 .size(4.dp)
                                                 .background(
-                                                    // Dot color adapts so it's visible on "today" background.
-                                                    if (isToday) Color.White
-                                                    else MaterialTheme.colorScheme.primary,
+                                                    if (isToday) Color.White else MaterialTheme.colorScheme.primary,
                                                     CircleShape
                                                 )
                                         )

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import android.widget.Toast
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
@@ -42,10 +43,17 @@ fun CalendarScreen(
     val classesForSelectedDate = viewModel.getClassesForSelectedDate()
     val studySessionsForSelectedDate = viewModel.getStudySessionsForSelectedDate()
     val eventsForSelectedDate = viewModel.getEventsForSelectedDate()
+    val markedDates = viewModel.getCalendarMarkedDates()
+
+    var reminderRefreshKey by remember { mutableStateOf(0) }
+    val reminderEventsForSelectedDate = remember(eventsForSelectedDate, reminderRefreshKey) {
+        buildReminderEventsForSelectedDate(context, eventsForSelectedDate)
+    }
 
     LaunchedEffect(Unit) {
         viewModel.refreshStudySessions()
         viewModel.refreshEvents()
+        viewModel.refreshCampusEvents()
     }
 
     var showAssignmentDialog by remember { mutableStateOf(false) }
@@ -71,7 +79,9 @@ fun CalendarScreen(
     var sessionLocation by remember { mutableStateOf<CampusLocation?>(null) }
 
     var showEventDialog by remember { mutableStateOf(false) }
+    var showCampusEventDialog by remember { mutableStateOf(false) }
     var editingEvent by remember { mutableStateOf<EventItem?>(null) }
+    var selectedCampusEvent by remember { mutableStateOf<EventItem?>(null) }
     var eventName by remember { mutableStateOf("") }
     var eventTime by remember { mutableStateOf("") }
     var eventLocation by remember { mutableStateOf<CampusLocation?>(null) }
@@ -147,6 +157,7 @@ fun CalendarScreen(
             selectedDate = selectedDate,
             today = today,
             scheduleItems = viewModel.scheduleItems,
+            markedDates = markedDates,
             onDateSelected = { day -> viewModel.selectDate(day) },
             onSameDateClicked = {
                 resetAssignmentForm()
@@ -157,6 +168,7 @@ fun CalendarScreen(
         ScheduleSection(
             selectedDate = selectedDate,
             itemsForSelectedDate = itemsForSelectedDate,
+            reminderEventsForSelectedDate = reminderEventsForSelectedDate,
             onItemClick = { item ->
                 editingAssignment = item
                 assignmentName = item.assignmentName
@@ -164,6 +176,10 @@ fun CalendarScreen(
                 selectedClassId = item.classId
                 classDropdownExpanded = false
                 showAssignmentDialog = true
+            },
+            onReminderClick = { event ->
+                selectedCampusEvent = event
+                showCampusEventDialog = true
             }
         )
 
@@ -188,7 +204,7 @@ fun CalendarScreen(
                 sessionClassName = session.className
                 sessionTopic = session.topic
                 sessionStartTime = session.startTime
-                sessionLocation = null // location is CampusLocation?, restored via search bar
+                sessionLocation = null
                 showStudySessionDialog = true
             }
         )
@@ -197,11 +213,16 @@ fun CalendarScreen(
             selectedDate = selectedDate,
             eventsForSelectedDate = eventsForSelectedDate,
             onEventClick = { event ->
-                editingEvent = event
-                eventName = event.name
-                eventTime = event.time
-                eventLocation = null // location is CampusLocation?, restored via search bar
-                showEventDialog = true
+                if (event.isCampusEvent) {
+                    selectedCampusEvent = event
+                    showCampusEventDialog = true
+                } else {
+                    editingEvent = event
+                    eventName = event.name
+                    eventTime = event.time
+                    eventLocation = null
+                    showEventDialog = true
+                }
             }
         )
     }
@@ -411,6 +432,17 @@ fun CalendarScreen(
         )
     }
 
+    if (showCampusEventDialog && selectedCampusEvent != null) {
+        HandleCampusEventReminderToggle(
+            event = selectedCampusEvent!!,
+            onReminderChanged = { reminderRefreshKey++ },
+            onDismiss = {
+                showCampusEventDialog = false
+                selectedCampusEvent = null
+            }
+        )
+    }
+
     if (showEventDialog && selectedDate != null) {
         val dateStr = formatDate(selectedDate)
         EventItemDialog(
@@ -441,4 +473,65 @@ fun CalendarScreen(
             } else null
         )
     }
+}
+
+/** Returns only the campus events on the selected day that currently have reminders enabled. */
+private fun buildReminderEventsForSelectedDate(
+    context: android.content.Context,
+    eventsForSelectedDate: List<EventItem>
+): List<EventItem> {
+    return eventsForSelectedDate.filter(isCampusEventWithReminderEnabled(context))
+}
+
+/** Builds the predicate used to keep only reminder-enabled campus events. */
+private fun isCampusEventWithReminderEnabled(context: android.content.Context): (EventItem) -> Boolean = { event ->
+    event.isCampusEvent && CampusEventReminderPreferences.isReminderEnabled(context, event.id)
+}
+
+@Composable
+private fun HandleCampusEventReminderToggle(
+    event: EventItem,
+    onReminderChanged: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    var isReminderEnabled by remember(event.id) {
+        mutableStateOf(CampusEventReminderPreferences.isReminderEnabled(context, event.id))
+    }
+
+    CampusEventDetailsDialog(
+        event = event,
+        isReminderEnabled = isReminderEnabled,
+        onReminderToggle = { enabled ->
+            if (enabled) {
+                val wasScheduled = CampusEventReminderScheduler.scheduleReminder(context, event)
+                if (wasScheduled) {
+                    CampusEventReminderPreferences.setReminderEnabled(context, event.id, true)
+                    isReminderEnabled = true
+                    onReminderChanged()
+                    Toast.makeText(
+                        context,
+                        if (event.allDay) "Reminder set for 9:00 AM on the event day" else "Reminder set for 30 minutes before the event",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                } else {
+                    CampusEventReminderPreferences.setReminderEnabled(context, event.id, false)
+                    isReminderEnabled = false
+                    onReminderChanged()
+                    Toast.makeText(
+                        context,
+                        "This event has already started, so a reminder could not be set",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            } else {
+                CampusEventReminderScheduler.cancelReminder(context, event)
+                CampusEventReminderPreferences.setReminderEnabled(context, event.id, false)
+                isReminderEnabled = false
+                onReminderChanged()
+                Toast.makeText(context, "Reminder removed", Toast.LENGTH_SHORT).show()
+            }
+        },
+        onDismiss = onDismiss
+    )
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarViewModel.kt
@@ -1,56 +1,78 @@
 package com.example.cinet.feature.calendar.calendarFiles
 
 import android.util.Log
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.cinet.feature.calendar.calendarFiles.CalendarFirestoreRepository
-import com.example.cinet.feature.calendar.schedule.ScheduleItem
 import com.example.cinet.feature.calendar.classEvent.ClassItem
+import com.example.cinet.feature.calendar.event.CampusEventFeedRepository
 import com.example.cinet.feature.calendar.event.EventItem
+import com.example.cinet.feature.calendar.schedule.ScheduleItem
 import com.example.cinet.feature.calendar.study.StudySession
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.YearMonth
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-
 
 class CalendarViewModel : ViewModel() {
 
-    // mutableStateOf makes Compose automatically recompose UI when these values change.
+    // Holds the month currently shown in the calendar header/grid.
     var currentMonth by mutableStateOf(YearMonth.now())
         private set
 
+    // Holds the day currently selected by the user.
     var selectedDate by mutableStateOf<LocalDate?>(null)
         private set
 
+    // Stores the user's saved classes from Firestore.
     var classItems by mutableStateOf<List<ClassItem>>(emptyList())
         private set
 
+    // Stores the user's saved assignments from Firestore.
     var scheduleItems by mutableStateOf<List<ScheduleItem>>(emptyList())
         private set
 
+    // Stores the user's saved study sessions from Firestore.
     var studySessions by mutableStateOf<List<StudySession>>(emptyList())
         private set
 
-    var eventItems by mutableStateOf<List<EventItem>>(emptyList())
+    // Stores the user's manually created events from Firestore.
+    var userEventItems by mutableStateOf<List<EventItem>>(emptyList())
+        private set
+
+    // Stores the live campus events fetched from the ICS feed.
+    var campusEventItems by mutableStateOf<List<EventItem>>(emptyList())
         private set
 
     private val repository = CalendarFirestoreRepository()
+    private val campusEventRepository = CampusEventFeedRepository()
 
     init {
-        // Automatically loads data when ViewModel is created.
+        // Automatically loads calendar data when the ViewModel is created.
         refreshClasses()
         refreshAssignments()
         refreshStudySessions()
         refreshEvents()
+        refreshCampusEvents()
     }
 
-    fun nextMonth() { currentMonth = currentMonth.plusMonths(1) }
-    fun previousMonth() { currentMonth = currentMonth.minusMonths(1) }
-    fun selectDate(day: Int) { selectedDate = currentMonth.atDay(day) }
+    // Advances the visible month by one.
+    fun nextMonth() {
+        currentMonth = currentMonth.plusMonths(1)
+    }
 
+    // Moves the visible month back by one.
+    fun previousMonth() {
+        currentMonth = currentMonth.minusMonths(1)
+    }
+
+    // Marks one day as selected inside the current month.
+    fun selectDate(day: Int) {
+        selectedDate = currentMonth.atDay(day)
+    }
+
+    // Saves a new class for the current user.
     fun addClass(
         name: String,
         meetingDays: List<String>,
@@ -80,6 +102,7 @@ class CalendarViewModel : ViewModel() {
         }
     }
 
+    // Updates an existing class and keeps related assignments aligned with a class rename.
     fun updateClass(
         classId: String,
         name: String,
@@ -104,8 +127,6 @@ class CalendarViewModel : ViewModel() {
                     remindersEnabled = remindersEnabled
                 )
 
-                // Keeps local scheduleItems consistent after class rename
-                // (Firestore stores className redundantly in assignments).
                 scheduleItems = scheduleItems.map { item ->
                     if (item.classId == classId) item.copy(className = name) else item
                 }
@@ -117,11 +138,11 @@ class CalendarViewModel : ViewModel() {
         }
     }
 
+    // Deletes one class and removes any local assignments tied to it.
     fun deleteClass(classId: String) {
         viewModelScope.launch {
             try {
                 repository.deleteClass(classId)
-                // Removes assignments tied to the deleted class locally.
                 scheduleItems = scheduleItems.filterNot { it.classId == classId }
                 refreshClasses()
             } catch (e: Exception) {
@@ -130,10 +151,11 @@ class CalendarViewModel : ViewModel() {
         }
     }
 
+    // Adds a new assignment to the currently selected date.
     fun addScheduleItem(classItem: ClassItem, assignmentName: String, dueTime: String) {
         val date = selectedDate ?: return
-        // Must match the same format used in Firestore + CalendarGrid comparisons.
         val formattedDate = formatDate(date)
+
         viewModelScope.launch {
             try {
                 repository.addAssignment(
@@ -144,13 +166,17 @@ class CalendarViewModel : ViewModel() {
                     dueTime = dueTime
                 )
                 refreshAssignments()
-            } catch (e: Exception) { e.printStackTrace() }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Updates one assignment on the currently selected date.
     fun updateScheduleItem(itemId: String, classItem: ClassItem, assignmentName: String, dueTime: String) {
         val date = selectedDate ?: return
         val formattedDate = formatDate(date)
+
         viewModelScope.launch {
             try {
                 repository.updateAssignment(
@@ -162,69 +188,106 @@ class CalendarViewModel : ViewModel() {
                     dueTime = dueTime
                 )
                 refreshAssignments()
-            } catch (e: Exception) { e.printStackTrace() }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Deletes one assignment.
     fun deleteScheduleItem(itemId: String) {
         viewModelScope.launch {
-            try { repository.deleteAssignment(itemId); refreshAssignments() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.deleteAssignment(itemId)
+                refreshAssignments()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Adds one study session for the selected day.
     fun addStudySession(date: String, className: String, topic: String, startTime: String, location: String) {
         viewModelScope.launch {
-            try { repository.addStudySession(date, className, topic, startTime, location); refreshStudySessions() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.addStudySession(date, className, topic, startTime, location)
+                refreshStudySessions()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Updates one study session.
     fun updateStudySession(sessionId: String, date: String, className: String, topic: String, startTime: String, location: String) {
         viewModelScope.launch {
-            try { repository.updateStudySession(sessionId, date, className, topic, startTime, location); refreshStudySessions() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.updateStudySession(sessionId, date, className, topic, startTime, location)
+                refreshStudySessions()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Deletes one study session.
     fun deleteStudySession(sessionId: String) {
         viewModelScope.launch {
-            try { repository.deleteStudySession(sessionId); refreshStudySessions() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.deleteStudySession(sessionId)
+                refreshStudySessions()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Adds one user-created event for the selected day.
     fun addEvent(date: String, name: String, time: String, location: String) {
         viewModelScope.launch {
-            try { repository.addEvent(date, name, time, location); refreshEvents() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.addEvent(date, name, time, location)
+                refreshEvents()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Updates one user-created event.
     fun updateEvent(eventId: String, date: String, name: String, time: String, location: String) {
         viewModelScope.launch {
-            try { repository.updateEvent(eventId, date, name, time, location); refreshEvents() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.updateEvent(eventId, date, name, time, location)
+                refreshEvents()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Deletes one user-created event.
     fun deleteEvent(eventId: String) {
         viewModelScope.launch {
-            try { repository.deleteEvent(eventId); refreshEvents() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                repository.deleteEvent(eventId)
+                refreshEvents()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Returns assignments for the selected day, ordered by due time.
     fun getItemsForSelectedDate(): List<ScheduleItem> {
         val date = selectedDate ?: return emptyList()
         val formattedDate = formatDate(date)
         return scheduleItems
-            // Relies on ScheduleItem.date using same string format.
             .filter { it.date == formattedDate }
-            // Converts time string → sortable number (minutes since midnight).
             .sortedBy { parseTimeToSortableValue(it.dueTime) }
     }
 
+    // Groups classes by weekday so other calendar views can reuse the same data.
     fun getClassesGroupedByDay(): Map<String, List<ClassItem>> {
         val orderedDays = listOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
         return orderedDays.associateWith { day ->
@@ -234,18 +297,26 @@ class CalendarViewModel : ViewModel() {
         }.filterValues { it.isNotEmpty() }
     }
 
+    // Returns only the classes that meet on the selected day.
     fun getClassesForSelectedDate(): List<ClassItem> {
         val date = selectedDate ?: return emptyList()
-        // Converts LocalDate → matching string used in ClassItem.meetingDays.
         val dayName = when (date.dayOfWeek.value) {
-            1 -> "Mon"; 2 -> "Tue"; 3 -> "Wed"; 4 -> "Thu"
-            5 -> "Fri"; 6 -> "Sat"; 7 -> "Sun"; else -> ""
+            1 -> "Mon"
+            2 -> "Tue"
+            3 -> "Wed"
+            4 -> "Thu"
+            5 -> "Fri"
+            6 -> "Sat"
+            7 -> "Sun"
+            else -> ""
         }
+
         return classItems
             .filter { it.meetingDays.contains(dayName) }
             .sortedBy { parseTimeToSortableValue(it.startTime) }
     }
 
+    // Returns study sessions for the selected day.
     fun getStudySessionsForSelectedDate(): List<StudySession> {
         val date = selectedDate ?: return emptyList()
         val formattedDate = formatDate(date)
@@ -254,14 +325,24 @@ class CalendarViewModel : ViewModel() {
             .sortedBy { parseTimeToSortableValue(it.startTime) }
     }
 
+    // Returns both user-created and live campus events for the selected day.
     fun getEventsForSelectedDate(): List<EventItem> {
         val date = selectedDate ?: return emptyList()
         val formattedDate = formatDate(date)
-        return eventItems
+        return allEventItems()
             .filter { it.date == formattedDate }
             .sortedBy { parseTimeToSortableValue(it.time) }
     }
 
+    // Returns every date string that should show an activity dot on the calendar grid.
+    fun getCalendarMarkedDates(): Set<String> {
+        return buildSet {
+            addAll(scheduleItems.map { it.date })
+            addAll(allEventItems().map { it.date })
+        }
+    }
+
+    // Reloads the user's class list from Firestore.
     fun refreshClasses() {
         viewModelScope.launch {
             try {
@@ -279,45 +360,79 @@ class CalendarViewModel : ViewModel() {
         }
     }
 
+    // Reloads the user's assignments from Firestore.
     fun refreshAssignments() {
         viewModelScope.launch {
-            try { scheduleItems = repository.loadAssignments() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                scheduleItems = repository.loadAssignments()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Reloads the user's study sessions from Firestore.
     fun refreshStudySessions() {
         viewModelScope.launch {
-            try { studySessions = repository.loadStudySessions() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                studySessions = repository.loadStudySessions()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Reloads the user's custom events from Firestore.
     fun refreshEvents() {
         viewModelScope.launch {
-            try { eventItems = repository.loadEvents() }
-            catch (e: Exception) { e.printStackTrace() }
+            try {
+                userEventItems = repository.loadEvents()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 
+    // Reloads live campus events from the ICS feed.
+    fun refreshCampusEvents() {
+        viewModelScope.launch {
+            try {
+                campusEventItems = campusEventRepository.loadCampusEvents()
+            } catch (e: Exception) {
+                Log.e("CampusEventFeed", "refreshCampusEvents failed", e)
+            }
+        }
+    }
+
+    // Formats a LocalDate into the string format already used across this calendar feature.
     private fun formatDate(date: LocalDate): String {
-        // Must stay consistent with Firestore storage + CalendarGrid comparison.
         return "%04d-%02d-%02d".format(date.year, date.monthValue, date.dayOfMonth)
     }
 
+    // Converts displayed times into sortable minute values.
     private fun parseTimeToSortableValue(time: String): Int {
-        // Expects format like "hh:mm AM/PM"
-        val parts = time.split(" ", ":")
+        if (time.equals("All day", ignoreCase = true)) return Int.MIN_VALUE
+
+        val normalizedTime = time.substringBefore("-").trim()
+        val parts = normalizedTime.split(" ", ":")
         if (parts.size < 3) return Int.MAX_VALUE
+
         var hour = parts[0].toIntOrNull() ?: return Int.MAX_VALUE
         val minute = parts[1].toIntOrNull() ?: return Int.MAX_VALUE
         val amPm = parts[2]
-        // Converts 12-hour → 24-hour for sorting.
+
         if (amPm == "PM" && hour != 12) hour += 12
         if (amPm == "AM" && hour == 12) hour = 0
         return hour * 60 + minute
     }
 
-    private fun sortClassesByTime(classes: List<ClassItem>): List<ClassItem> =
-        classes.sortedBy { parseTimeToSortableValue(it.startTime) }
+    // Combines the two event sources into one list for display/filtering.
+    private fun allEventItems(): List<EventItem> {
+        return (userEventItems + campusEventItems).distinctBy { it.id }
+    }
+
+    // Sorts classes by their starting time for consistent display.
+    private fun sortClassesByTime(classes: List<ClassItem>): List<ClassItem> {
+        return classes.sortedBy { parseTimeToSortableValue(it.startTime) }
+    }
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventDateHelper.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventDateHelper.kt
@@ -1,0 +1,144 @@
+package com.example.cinet.feature.calendar.event
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/** Parses campus event dates and builds the display values used by the calendar UI. */
+class CampusEventDateHelper(
+    private val zoneId: ZoneId = ZoneId.systemDefault()
+) {
+    private val dateFormatter = DateTimeFormatter.BASIC_ISO_DATE
+    private val localDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss")
+    private val localDateTimeMinuteFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm")
+    private val utcDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+    private val utcDateTimeMinuteFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm'Z'")
+    private val outputDateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+    private val outputTimeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.US)
+
+    /** Converts one raw ICS field into epoch milliseconds. */
+    fun parseDateMillis(field: IcsField?): Long? {
+        field ?: return null
+
+        return when {
+            field.isDateOnly -> parseDateOnlyMillis(field.value)
+            field.value.endsWith("Z") -> parseUtcDateTimeMillis(field.value)
+            else -> parseLocalDateTimeMillis(field.value, field.timeZone)
+        }
+    }
+
+    /** Creates the fallback end time when an event does not include DTEND. */
+    fun buildFallbackEndMillis(startField: IcsField, startMillis: Long): Long {
+        if (!startField.isDateOnly) {
+            return startMillis
+        }
+
+        return Instant.ofEpochMilli(startMillis)
+            .atZone(zoneId)
+            .toLocalDate()
+            .plusDays(1)
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+
+    /** Converts epoch milliseconds into a zoned date time using the parser's zone. */
+    fun toZonedDateTime(epochMillis: Long): ZonedDateTime {
+        return Instant.ofEpochMilli(epochMillis).atZone(zoneId)
+    }
+
+    /** Resolves the last day an event should appear on the calendar. */
+    fun resolveLastCoveredDate(
+        startField: IcsField,
+        endField: IcsField?,
+        rawEndDate: LocalDate
+    ): LocalDate {
+        return if (startField.isDateOnly && endField != null) rawEndDate.minusDays(1) else rawEndDate
+    }
+
+    /** Builds the time text shown on a campus event card. */
+    fun buildTimeLabel(startTime: LocalTime, endTime: LocalTime, allDay: Boolean): String {
+        if (allDay) return "All day"
+        if (startTime == endTime) return outputTimeFormatter.format(startTime)
+        return "${outputTimeFormatter.format(startTime)} - ${outputTimeFormatter.format(endTime)}"
+    }
+
+    /** Builds the ISO date string stored by the existing calendar UI. */
+    fun formatDate(date: LocalDate): String {
+        return date.format(outputDateFormatter)
+    }
+
+    /** Creates an inclusive list of dates for multi-day campus events. */
+    fun generateDateSequence(startDate: LocalDate, endDate: LocalDate): List<LocalDate> {
+        val safeEndDate = if (endDate.isBefore(startDate)) startDate else endDate
+        val dates = mutableListOf<LocalDate>()
+        var currentDate = startDate
+
+        while (!currentDate.isAfter(safeEndDate)) {
+            dates.add(currentDate)
+            currentDate = currentDate.plusDays(1)
+        }
+
+        return dates
+    }
+
+    /** Parses a date-only ICS value. */
+    private fun parseDateOnlyMillis(value: String): Long {
+        val date = LocalDate.parse(value, dateFormatter)
+        return date.atStartOfDay(zoneId).toInstant().toEpochMilli()
+    }
+
+    /** Parses a UTC ICS date-time value. */
+    private fun parseUtcDateTimeMillis(value: String): Long? {
+        val localDateTime = parseUtcLocalDateTime(value) ?: return null
+        return localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli()
+    }
+
+    /** Parses a local or TZID-based ICS date-time value. */
+    private fun parseLocalDateTimeMillis(value: String, timeZone: String?): Long? {
+        val localDateTime = parseLocalDateTime(value) ?: return null
+        val parsedZone = resolveZoneId(timeZone)
+        return localDateTime.atZone(parsedZone).toInstant().toEpochMilli()
+    }
+
+    /** Parses a UTC local date time before it is converted to an instant. */
+    private fun parseUtcLocalDateTime(value: String): LocalDateTime? {
+        return try {
+            when (value.length) {
+                16 -> LocalDateTime.parse(value, utcDateTimeFormatter)
+                14 -> LocalDateTime.parse(value, utcDateTimeMinuteFormatter)
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Parses a non-UTC local date time before time zone conversion. */
+    private fun parseLocalDateTime(value: String): LocalDateTime? {
+        return try {
+            when (value.length) {
+                15 -> LocalDateTime.parse(value, localDateTimeFormatter)
+                13 -> LocalDateTime.parse(value, localDateTimeMinuteFormatter)
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Resolves the ICS TZID into a valid Java ZoneId with a safe fallback. */
+    private fun resolveZoneId(timeZone: String?): ZoneId {
+        return try {
+            if (timeZone.isNullOrBlank()) zoneId else ZoneId.of(timeZone)
+        } catch (_: Exception) {
+            zoneId
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventDetailsDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventDetailsDialog.kt
@@ -1,0 +1,145 @@
+package com.example.cinet.feature.calendar.event
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/** Shows details for one live campus event and lets the user toggle reminders. */
+@Composable
+fun CampusEventDetailsDialog(
+    event: EventItem,
+    isReminderEnabled: Boolean,
+    onReminderToggle: (Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(event.name) },
+        text = {
+            CampusEventDetailsContent(
+                event = event,
+                isReminderEnabled = isReminderEnabled,
+                onReminderToggle = onReminderToggle
+            )
+        },
+        confirmButton = {
+            OutlinedButton(onClick = onDismiss) {
+                Text("Close")
+            }
+        }
+    )
+}
+
+/** Displays the scrollable body content inside the campus event dialog. */
+@Composable
+private fun CampusEventDetailsContent(
+    event: EventItem,
+    isReminderEnabled: Boolean,
+    onReminderToggle: (Boolean) -> Unit
+) {
+    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        CampusEventTypeLabel()
+        Spacer(modifier = Modifier.height(12.dp))
+        EventDetailLine(label = "Date", value = event.date)
+        EventDetailLine(label = "Time", value = event.time)
+        EventDetailLine(label = "Location", value = event.location.ifBlank { "TBA" })
+        EventDescription(event.description)
+        Spacer(modifier = Modifier.height(16.dp))
+        CampusEventReminderRow(
+            event = event,
+            isReminderEnabled = isReminderEnabled,
+            onReminderToggle = onReminderToggle
+        )
+    }
+}
+
+/** Shows the small campus-event label at the top of the dialog. */
+@Composable
+private fun CampusEventTypeLabel() {
+    Text(
+        text = "Campus event",
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary
+    )
+}
+
+/** Shows the optional event description block when the feed includes one. */
+@Composable
+private fun EventDescription(description: String) {
+    if (description.isBlank()) {
+        return
+    }
+
+    Spacer(modifier = Modifier.height(12.dp))
+    Text("Description", style = MaterialTheme.typography.labelLarge)
+    Spacer(modifier = Modifier.height(4.dp))
+    CampusEventLinkText(description)
+}
+
+/** Shows the reminder row with the helper text and toggle switch. */
+@Composable
+private fun CampusEventReminderRow(
+    event: EventItem,
+    isReminderEnabled: Boolean,
+    onReminderToggle: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("Event reminder", style = MaterialTheme.typography.bodyLarge)
+            ReminderDescription(event)
+        }
+
+        Switch(
+            checked = isReminderEnabled,
+            onCheckedChange = onReminderToggle
+        )
+    }
+}
+
+/** Shows the reminder timing text for timed and all-day campus events. */
+@Composable
+private fun ReminderDescription(event: EventItem) {
+    Text(
+        text = reminderDescriptionText(event),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+}
+
+/** Builds the reminder timing description shown below the reminder title. */
+private fun reminderDescriptionText(event: EventItem): String {
+    return if (event.allDay) {
+        "Get a reminder at 9:00 AM on the event day"
+    } else {
+        "Get a reminder 30 minutes before the event"
+    }
+}
+
+/** Shows one labeled detail line inside the campus event dialog. */
+@Composable
+private fun EventDetailLine(label: String, value: String) {
+    Column(modifier = Modifier.padding(bottom = 8.dp)) {
+        Text(text = label, style = MaterialTheme.typography.labelLarge)
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(text = value)
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventFeedParser.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventFeedParser.kt
@@ -1,0 +1,194 @@
+package com.example.cinet.feature.calendar.event
+
+import java.time.LocalDate
+import java.time.ZoneId
+
+/** Parses raw ICS text into calendar events that match the app's existing event model. */
+class CampusEventFeedParser(
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    private val dateHelper: CampusEventDateHelper = CampusEventDateHelper(zoneId)
+) {
+
+    /** Converts one ICS document into a sorted list of display events. */
+    fun parse(icsText: String): List<EventItem> {
+        val unfoldedText = unfoldLines(icsText)
+        val eventBlocks = extractEventBlocks(unfoldedText)
+
+        return eventBlocks
+            .flatMap(::parseEventBlock)
+            .sortedWith(compareBy<EventItem> { it.date }
+                .thenBy { it.startEpochMillis ?: Long.MAX_VALUE }
+                .thenBy { it.name })
+    }
+
+    /** Joins folded ICS lines so each property can be read as one line. */
+    private fun unfoldLines(icsText: String): String {
+        return icsText
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+            .replace(Regex("\n[ \t]"), "")
+    }
+
+    /** Extracts each VEVENT block from the ICS document. */
+    private fun extractEventBlocks(icsText: String): List<String> {
+        return icsText
+            .split("BEGIN:VEVENT")
+            .drop(1)
+            .mapNotNull(::extractEventBlockBody)
+    }
+
+    /** Keeps only the inner lines of one VEVENT block. */
+    private fun extractEventBlockBody(block: String): String? {
+        return block
+            .substringBefore("END:VEVENT")
+            .trim()
+            .takeIf { it.isNotBlank() }
+    }
+
+    /** Parses one VEVENT block and expands multi-day events across their covered dates. */
+    private fun parseEventBlock(block: String): List<EventItem> {
+        val lines = block.lines().filter { it.isNotBlank() }
+        val metadata = readEventMetadata(lines) ?: return emptyList()
+        val timing = readEventTiming(lines) ?: return emptyList()
+        val displayDates = buildDisplayDates(timing)
+        val timeLabel = buildTimeLabel(timing)
+
+        return displayDates.map { date ->
+            buildEventItem(
+                metadata = metadata,
+                timing = timing,
+                displayDate = date,
+                timeLabel = timeLabel
+            )
+        }
+    }
+
+    /** Reads the text fields needed to display one campus event. */
+    private fun readEventMetadata(lines: List<String>): CampusEventMetadata? {
+        val uid = readField(lines, "UID")?.value ?: return null
+        val title = sanitizeFieldValue(lines, "SUMMARY", "Campus Event")
+        val description = sanitizeFieldValue(lines, "DESCRIPTION")
+        val location = sanitizeFieldValue(lines, "LOCATION")
+
+        return CampusEventMetadata(
+            uid = uid,
+            title = title,
+            description = description,
+            location = location
+        )
+    }
+
+    /** Reads and converts the start and end timing for one campus event. */
+    private fun readEventTiming(lines: List<String>): CampusEventTiming? {
+        val startField = readField(lines, "DTSTART") ?: return null
+        val endField = readField(lines, "DTEND")
+        val startMillis = dateHelper.parseDateMillis(startField) ?: return null
+        val endMillis = dateHelper.parseDateMillis(endField)
+            ?: dateHelper.buildFallbackEndMillis(startField, startMillis)
+
+        return CampusEventTiming(
+            startField = startField,
+            endField = endField,
+            startMillis = startMillis,
+            endMillis = endMillis,
+            allDay = startField.isDateOnly
+        )
+    }
+
+    /** Builds the list of dates on which the event should appear in the calendar. */
+    private fun buildDisplayDates(timing: CampusEventTiming): List<LocalDate> {
+        val startDate = dateHelper.toZonedDateTime(timing.startMillis).toLocalDate()
+        val rawEndDate = dateHelper.toZonedDateTime(timing.endMillis).toLocalDate()
+        val lastCoveredDate = dateHelper.resolveLastCoveredDate(
+            startField = timing.startField,
+            endField = timing.endField,
+            rawEndDate = rawEndDate
+        )
+
+        return dateHelper.generateDateSequence(startDate, lastCoveredDate)
+    }
+
+    /** Builds the time label shown in the event list and details dialog. */
+    private fun buildTimeLabel(timing: CampusEventTiming): String {
+        val startTime = dateHelper.toZonedDateTime(timing.startMillis).toLocalTime()
+        val endTime = dateHelper.toZonedDateTime(timing.endMillis).toLocalTime()
+        return dateHelper.buildTimeLabel(startTime, endTime, timing.allDay)
+    }
+
+    /** Creates one EventItem instance for a specific display date. */
+    private fun buildEventItem(
+        metadata: CampusEventMetadata,
+        timing: CampusEventTiming,
+        displayDate: LocalDate,
+        timeLabel: String
+    ): EventItem {
+        val formattedDate = dateHelper.formatDate(displayDate)
+
+        return EventItem(
+            id = buildEventId(metadata.uid, formattedDate),
+            date = formattedDate,
+            name = metadata.title,
+            time = timeLabel,
+            location = metadata.location,
+            description = metadata.description,
+            source = EventSource.CAMPUS,
+            startEpochMillis = timing.startMillis,
+            endEpochMillis = timing.endMillis,
+            allDay = timing.allDay
+        )
+    }
+
+    /** Builds the stable ID used for one campus event occurrence. */
+    private fun buildEventId(uid: String, formattedDate: String): String {
+        return "campus_${uid}_${formattedDate}"
+    }
+
+    /** Reads and sanitizes one text field from the ICS lines. */
+    private fun sanitizeFieldValue(
+        lines: List<String>,
+        key: String,
+        defaultValue: String = ""
+    ): String {
+        val rawValue = readField(lines, key)?.value ?: defaultValue
+        return CampusEventTextFormatter.sanitize(rawValue)
+    }
+
+    /** Reads one ICS property and keeps any useful metadata attached to it. */
+    private fun readField(lines: List<String>, key: String): IcsField? {
+        val rawLine = lines.firstOrNull { it.startsWith("$key:") || it.startsWith("$key;") } ?: return null
+        val header = rawLine.substringBefore(':')
+        val value = rawLine.substringAfter(':', missingDelimiterValue = "")
+        val timeZone = Regex("TZID=([^;:]+)").find(header)?.groupValues?.get(1)
+        val isDateOnly = header.contains("VALUE=DATE") || value.length == 8
+
+        return IcsField(
+            value = value.trim(),
+            timeZone = timeZone,
+            isDateOnly = isDateOnly
+        )
+    }
+}
+
+/** Stores one parsed ICS field together with the metadata needed to parse dates. */
+data class IcsField(
+    val value: String,
+    val timeZone: String?,
+    val isDateOnly: Boolean
+)
+
+/** Stores the text content used to display one campus event. */
+private data class CampusEventMetadata(
+    val uid: String,
+    val title: String,
+    val description: String,
+    val location: String
+)
+
+/** Stores the timing values used to place one campus event on the calendar. */
+private data class CampusEventTiming(
+    val startField: IcsField,
+    val endField: IcsField?,
+    val startMillis: Long,
+    val endMillis: Long,
+    val allDay: Boolean
+)

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventFeedRepository.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventFeedRepository.kt
@@ -1,0 +1,87 @@
+package com.example.cinet.feature.calendar.event
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+/** Downloads the live campus ICS feed and converts it into calendar events. */
+class CampusEventFeedRepository(
+    private val parser: CampusEventFeedParser = CampusEventFeedParser()
+) {
+    private val feedUrls = listOf(
+        "https://www.trumba.com/calendars/student-marketing.ics",
+        "https://25livepub.collegenet.com/calendars/csuci-calendar-of-events.ics"
+    )
+
+    /** Tries each known feed URL until one returns a readable event list. */
+    suspend fun loadCampusEvents(): List<EventItem> = withContext(Dispatchers.IO) {
+        for (feedUrl in feedUrls) {
+            val parsedEvents = loadFeedFromUrl(feedUrl)
+            if (parsedEvents != null) {
+                return@withContext parsedEvents
+            }
+        }
+
+        Log.e("CampusEventFeed", "All campus event feed URLs failed.")
+        emptyList()
+    }
+
+    /** Downloads and parses one feed URL, or returns null when that URL fails. */
+    private fun loadFeedFromUrl(feedUrl: String): List<EventItem>? {
+        return try {
+            val icsText = downloadFeed(feedUrl)
+            parser.parse(icsText).takeIf { it.isNotEmpty() }
+        } catch (error: Exception) {
+            Log.e("CampusEventFeed", "Failed to load feed: $feedUrl", error)
+            null
+        }
+    }
+
+    /** Downloads one ICS file as plain text. */
+    private fun downloadFeed(feedUrl: String): String {
+        val connection = openFeedConnection(feedUrl)
+
+        try {
+            throwIfRequestFailed(connection)
+            return readResponseBody(connection)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    /** Opens and configures the HTTP connection used for the feed request. */
+    private fun openFeedConnection(feedUrl: String): HttpURLConnection {
+        return (URL(feedUrl).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 15000
+            readTimeout = 15000
+            setRequestProperty("Accept", "text/calendar,text/plain,*/*")
+            instanceFollowRedirects = true
+        }
+    }
+
+    /** Throws an error when the feed request returns a non-success HTTP code. */
+    private fun throwIfRequestFailed(connection: HttpURLConnection) {
+        val responseCode = connection.responseCode
+        if (responseCode !in 200..299) {
+            throw IllegalStateException("Feed request failed with HTTP $responseCode")
+        }
+    }
+
+    /** Reads the full ICS response body into one string. */
+    private fun readResponseBody(connection: HttpURLConnection): String {
+        return BufferedReader(InputStreamReader(connection.inputStream)).use { reader ->
+            buildString {
+                var line = reader.readLine()
+                while (line != null) {
+                    append(line).append("\n")
+                    line = reader.readLine()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventLinkText.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventLinkText.kt
@@ -1,0 +1,98 @@
+package com.example.cinet.feature.calendar.event
+
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+
+/** Renders event description text and makes any detected links tappable. */
+@Composable
+fun CampusEventLinkText(text: String) {
+    val uriHandler = LocalUriHandler.current
+    val linkColor = MaterialTheme.colorScheme.primary
+    val annotatedText = remember(text, linkColor) { buildLinkedText(text, linkColor) }
+
+    ClickableText(
+        text = annotatedText,
+        style = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurface
+        ),
+        onClick = { offset ->
+            annotatedText
+                .getStringAnnotations(tag = URL_TAG, start = offset, end = offset)
+                .firstOrNull()
+                ?.let { uriHandler.openUri(normalizeUrl(it.item)) }
+        }
+    )
+}
+
+/** Converts plain description text into an annotated string with clickable URL spans. */
+private fun buildLinkedText(text: String, linkColor: Color): AnnotatedString {
+    return buildAnnotatedString {
+        var currentIndex = 0
+
+        URL_REGEX.findAll(text).forEach { match ->
+            appendPlainSegment(text, currentIndex, match.range.first)
+            appendUrlSegment(cleanUrl(match.value), linkColor)
+            currentIndex = match.range.last + 1
+        }
+
+        appendPlainSegment(text, currentIndex, text.length)
+    }
+}
+
+/** Appends one non-link text segment to the annotated string builder. */
+private fun AnnotatedString.Builder.appendPlainSegment(
+    text: String,
+    startIndex: Int,
+    endIndex: Int
+) {
+    if (startIndex >= endIndex) {
+        return
+    }
+
+    append(text.substring(startIndex, endIndex))
+}
+
+/** Appends one clickable URL segment to the annotated string builder. */
+private fun AnnotatedString.Builder.appendUrlSegment(url: String, linkColor: Color) {
+    if (url.isBlank()) {
+        return
+    }
+
+    pushStringAnnotation(tag = URL_TAG, annotation = url)
+    pushStyle(
+        SpanStyle(
+            color = linkColor,
+            textDecoration = TextDecoration.Underline,
+            fontWeight = FontWeight.Medium
+        )
+    )
+    append(url)
+    pop()
+    pop()
+}
+
+/** Removes punctuation that is commonly attached to the end of copied links. */
+private fun cleanUrl(rawUrl: String): String {
+    return rawUrl.trimEnd('.', ',', ';', ':', '!', '?', ')', ']', '}')
+}
+
+/** Adds a scheme when the detected link starts with www instead of http or https. */
+private fun normalizeUrl(url: String): String {
+    return if (url.startsWith("www.", ignoreCase = true)) {
+        "https://$url"
+    } else {
+        url
+    }
+}
+
+private const val URL_TAG = "campus_event_url"
+private val URL_REGEX = Regex("""((https?://|www\.)[^\s]+)""")

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderPreferences.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderPreferences.kt
@@ -1,0 +1,24 @@
+package com.example.cinet.feature.calendar.event
+
+import android.content.Context
+
+/** Persists which campus events the user turned reminders on for. */
+object CampusEventReminderPreferences {
+    private const val PREFS_NAME = "campus_event_reminders"
+
+    /** Returns true when a reminder is currently enabled for the given event occurrence. */
+    fun isReminderEnabled(context: Context, eventId: String): Boolean {
+        return prefs(context).getBoolean(keyFor(eventId), false)
+    }
+
+    /** Saves the latest reminder toggle state for the given event occurrence. */
+    fun setReminderEnabled(context: Context, eventId: String, isEnabled: Boolean) {
+        prefs(context).edit().putBoolean(keyFor(eventId), isEnabled).apply()
+    }
+
+    /** Opens the shared preferences file used by this reminder feature. */
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Creates one stable preference key for a specific event occurrence. */
+    private fun keyFor(eventId: String): String = "reminder_$eventId"
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderReceiver.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderReceiver.kt
@@ -1,0 +1,35 @@
+package com.example.cinet.feature.calendar.event
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.example.cinet.core.notifications.AppNotification
+import com.example.cinet.core.notifications.NotificationHelper
+import com.example.cinet.core.notifications.NotificationType
+
+/** Receives scheduled campus event reminder alarms and shows the notification. */
+class CampusEventReminderReceiver : BroadcastReceiver() {
+
+    /** Builds and displays the reminder notification when the alarm fires. */
+    override fun onReceive(context: Context, intent: Intent) {
+        NotificationHelper.createChannel(context)
+
+        val title = intent.getStringExtra(EXTRA_TITLE).orEmpty()
+        val message = intent.getStringExtra(EXTRA_MESSAGE).orEmpty()
+
+        NotificationHelper.showNotification(
+            context = context,
+            notification = AppNotification(
+                title = title,
+                message = message,
+                type = NotificationType.EVENT,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+    }
+
+    companion object {
+        const val EXTRA_TITLE = "campus_event_title"
+        const val EXTRA_MESSAGE = "campus_event_message"
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderScheduler.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventReminderScheduler.kt
@@ -1,0 +1,199 @@
+package com.example.cinet.feature.calendar.event
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.example.cinet.core.notifications.AppNotification
+import com.example.cinet.core.notifications.NotificationHelper
+import com.example.cinet.core.notifications.NotificationType
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+/** Schedules and cancels reminder alarms for live campus events. */
+object CampusEventReminderScheduler {
+    private const val DEFAULT_MINUTES_BEFORE = 30L
+
+    /** Schedules a reminder and returns true when the request was accepted. */
+    fun scheduleReminder(
+        context: Context,
+        event: EventItem,
+        minutesBefore: Long = DEFAULT_MINUTES_BEFORE
+    ): Boolean {
+        val eventStartDateTime = getEventStartDateTime(event) ?: return false
+        if (!isEventInFuture(eventStartDateTime)) {
+            return false
+        }
+
+        val triggerDateTime = buildTriggerDateTime(event, eventStartDateTime, minutesBefore)
+        return if (shouldNotifyImmediately(triggerDateTime)) {
+            showImmediateReminder(context, event, eventStartDateTime)
+            true
+        } else {
+            scheduleAlarmReminder(context, event, triggerDateTime)
+            true
+        }
+    }
+
+    /** Cancels the reminder alarm for one campus event occurrence. */
+    fun cancelReminder(context: Context, event: EventItem) {
+        val pendingIntent = buildPendingIntent(context, event)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+    }
+
+    /** Converts the event's start time into a local date time, or returns null when missing. */
+    private fun getEventStartDateTime(event: EventItem): LocalDateTime? {
+        val eventStartMillis = event.startEpochMillis ?: return null
+        return toLocalDateTime(eventStartMillis)
+    }
+
+    /** Returns true when the event has not started yet. */
+    private fun isEventInFuture(eventStartDateTime: LocalDateTime): Boolean {
+        return eventStartDateTime.isAfter(LocalDateTime.now())
+    }
+
+    /** Returns true when the reminder time has already passed and should fire now. */
+    private fun shouldNotifyImmediately(triggerDateTime: LocalDateTime): Boolean {
+        return !triggerDateTime.isAfter(LocalDateTime.now())
+    }
+
+    /** Schedules the alarm-based reminder for one campus event. */
+    private fun scheduleAlarmReminder(
+        context: Context,
+        event: EventItem,
+        triggerDateTime: LocalDateTime
+    ) {
+        val pendingIntent = buildPendingIntent(context, event)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val triggerMillis = triggerDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        scheduleAlarm(alarmManager, triggerMillis, pendingIntent)
+    }
+
+    /** Builds the broadcast PendingIntent used to show the reminder notification. */
+    private fun buildPendingIntent(context: Context, event: EventItem): PendingIntent {
+        val intent = buildReminderIntent(context, event)
+        return PendingIntent.getBroadcast(
+            context,
+            requestCodeFor(event),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    /** Picks the notification time for timed and all-day events. */
+    private fun buildTriggerDateTime(
+        event: EventItem,
+        eventStartDateTime: LocalDateTime,
+        minutesBefore: Long
+    ): LocalDateTime {
+        return if (event.allDay) {
+            LocalDateTime.of(eventStartDateTime.toLocalDate(), LocalTime.of(9, 0))
+        } else {
+            eventStartDateTime.minusMinutes(minutesBefore)
+        }
+    }
+
+    /** Creates the broadcast intent used by AlarmManager. */
+    private fun buildReminderIntent(context: Context, event: EventItem): Intent {
+        return Intent(context, CampusEventReminderReceiver::class.java).apply {
+            putExtra(CampusEventReminderReceiver.EXTRA_TITLE, event.name)
+            putExtra(CampusEventReminderReceiver.EXTRA_MESSAGE, buildReminderMessage(event))
+        }
+    }
+
+    /** Builds the message text shown in the notification. */
+    private fun buildReminderMessage(event: EventItem): String {
+        val locationSuffix = event.location.takeIf { it.isNotBlank() }?.let { " at $it" } ?: ""
+
+        return if (event.allDay) {
+            "${event.name} is happening today$locationSuffix."
+        } else {
+            "${event.name} starts at ${event.time}$locationSuffix."
+        }
+    }
+
+    /** Schedules one alarm using the same fallback strategy already used elsewhere in the app. */
+    private fun scheduleAlarm(
+        alarmManager: AlarmManager,
+        triggerMillis: Long,
+        pendingIntent: PendingIntent
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerMillis,
+                    pendingIntent
+                )
+            }
+        } else {
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerMillis,
+                pendingIntent
+            )
+        }
+    }
+
+    /** Shows an immediate reminder when the lead time already passed but the event has not started yet. */
+    private fun showImmediateReminder(
+        context: Context,
+        event: EventItem,
+        eventStartDateTime: LocalDateTime
+    ) {
+        val minutesUntilEvent = calculateMinutesUntilEvent(eventStartDateTime)
+        val message = buildImmediateReminderMessage(event, minutesUntilEvent)
+
+        NotificationHelper.createChannel(context)
+        NotificationHelper.showNotification(
+            context = context,
+            notification = AppNotification(
+                title = event.name,
+                message = message,
+                type = NotificationType.EVENT,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+    }
+
+    /** Calculates how many minutes remain until the event starts. */
+    private fun calculateMinutesUntilEvent(eventStartDateTime: LocalDateTime): Long {
+        return Duration.between(LocalDateTime.now(), eventStartDateTime)
+            .toMinutes()
+            .coerceAtLeast(0)
+    }
+
+    /** Builds the notification text for an immediate reminder. */
+    private fun buildImmediateReminderMessage(event: EventItem, minutesUntilEvent: Long): String {
+        val locationSuffix = event.location.takeIf { it.isNotBlank() }?.let { " at $it" } ?: ""
+
+        return if (event.allDay) {
+            "${event.name} is happening today$locationSuffix."
+        } else {
+            "${event.name} starts in $minutesUntilEvent minutes$locationSuffix."
+        }
+    }
+
+    /** Converts epoch milliseconds into a local date time. */
+    private fun toLocalDateTime(epochMillis: Long): LocalDateTime {
+        return Instant.ofEpochMilli(epochMillis)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime()
+    }
+
+    /** Generates one stable request code per event occurrence. */
+    private fun requestCodeFor(event: EventItem): Int {
+        return event.id.hashCode()
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventTextFormatter.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/CampusEventTextFormatter.kt
@@ -1,0 +1,67 @@
+package com.example.cinet.feature.calendar.event
+
+import androidx.core.text.HtmlCompat
+
+/** Cleans raw ICS text so campus events display as normal readable text. */
+object CampusEventTextFormatter {
+
+    /** Converts escaped ICS text and inline HTML into clean display text. */
+    fun sanitize(value: String): String {
+        val unescapedText = unescapeIcsText(value)
+        val linkReadyText = preserveAnchorLinks(unescapedText)
+        val htmlReadyText = replaceLineBreaksForHtml(linkReadyText)
+        val plainText = convertHtmlToPlainText(htmlReadyText)
+        return normalizeWhitespace(plainText)
+    }
+
+    /** Converts common ICS escape sequences into regular characters. */
+    private fun unescapeIcsText(value: String): String {
+        return value
+            .replace("\\n", "\n")
+            .replace("\\N", "\n")
+            .replace("\\,", ",")
+            .replace("\\;", ";")
+            .replace("\\\\", "\\")
+            .trim()
+    }
+
+
+    /** Converts HTML anchor tags into plain text that keeps the original URL visible. */
+    private fun preserveAnchorLinks(value: String): String {
+        return ANCHOR_TAG_REGEX.replace(value) { match ->
+            val url = match.groupValues.getOrNull(1).orEmpty().trim()
+            val label = match.groupValues.getOrNull(2).orEmpty().trim()
+
+            when {
+                url.isBlank() -> label
+                label.isBlank() -> url
+                label.equals(url, ignoreCase = true) -> url
+                else -> "$label ($url)"
+            }
+        }
+    }
+
+    /** Replaces plain new lines with HTML line breaks before HTML decoding. */
+    private fun replaceLineBreaksForHtml(value: String): String {
+        return value.replace("\n", "<br>")
+    }
+
+    /** Decodes any HTML entities and strips HTML tags from the text. */
+    private fun convertHtmlToPlainText(value: String): String {
+        return HtmlCompat
+            .fromHtml(value, HtmlCompat.FROM_HTML_MODE_LEGACY)
+            .toString()
+    }
+
+    /** Removes extra spacing so the dialog and event cards stay easy to read. */
+    private fun normalizeWhitespace(value: String): String {
+        return value
+            .replace('\u00A0', ' ')
+            .replace(Regex("[ \t]*\n[ \t]*"), "\n")
+            .replace(Regex("\n{3,}"), "\n\n")
+            .trim()
+    }
+}
+
+
+private val ANCHOR_TAG_REGEX = Regex("""<a\b[^>]*href=[\"']([^\"']+)[\"'][^>]*>(.*?)</a>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventItem.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventItem.kt
@@ -1,9 +1,25 @@
 package com.example.cinet.feature.calendar.event
 
+/** Identifies where a calendar event came from. */
+enum class EventSource {
+    USER,
+    CAMPUS
+}
+
+/** Stores one event row shown in the calendar event section. */
 data class EventItem(
     val id: String = "",
     val date: String = "",
     val name: String = "",
     val time: String = "",
-    val location: String = ""
-)
+    val location: String = "",
+    val description: String = "",
+    val source: EventSource = EventSource.USER,
+    val startEpochMillis: Long? = null,
+    val endEpochMillis: Long? = null,
+    val allDay: Boolean = false
+) {
+    /** Returns true when this event came from the live campus ICS feed. */
+    val isCampusEvent: Boolean
+        get() = source == EventSource.CAMPUS
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventSection.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventSection.kt
@@ -1,15 +1,27 @@
 package com.example.cinet.feature.calendar.event
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import java.time.LocalDate
 
+/** Shows the event section for the currently selected calendar date. */
 @Composable
 fun EventsSection(
     selectedDate: LocalDate?,
@@ -20,30 +32,112 @@ fun EventsSection(
     Text("Events", style = MaterialTheme.typography.titleMedium)
     Spacer(modifier = Modifier.height(8.dp))
 
-    if (selectedDate == null) {
-        Text("Select a date to view events.")
-    } else if (eventsForSelectedDate.isEmpty()) {
-        Text("No events for $selectedDate")
-    } else {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            eventsForSelectedDate.forEach { event ->
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onEventClick(event) }
-                ) {
-                    Column(modifier = Modifier.padding(12.dp)) {
-                        Text(text = event.name, style = MaterialTheme.typography.titleSmall)
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(text = event.time)
-                        if (event.location.isNotBlank()) {
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(text = event.location, style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
-                    }
-                }
-            }
+    when {
+        selectedDate == null -> Text("Select a date to view events.")
+        eventsForSelectedDate.isEmpty() -> Text("No events for $selectedDate")
+        else -> EventList(eventsForSelectedDate, onEventClick)
+    }
+}
+
+/** Shows the list of event cards for the selected date. */
+@Composable
+private fun EventList(
+    events: List<EventItem>,
+    onEventClick: (EventItem) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        events.forEach { event ->
+            EventCard(
+                event = event,
+                onClick = { onEventClick(event) }
+            )
         }
     }
+}
+
+/** Shows one event card in the daily event list. */
+@Composable
+private fun EventCard(
+    event: EventItem,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            EventCardHeader(event)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = event.time)
+            EventLocation(event.location)
+        }
+    }
+}
+
+/** Shows the title row and optional campus badge for one event card. */
+@Composable
+private fun EventCardHeader(event: EventItem) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        EventTitle(
+            title = event.name,
+            modifier = Modifier.weight(1f)
+        )
+
+        if (event.isCampusEvent) {
+            Spacer(modifier = Modifier.width(8.dp))
+            CampusBadge()
+        }
+    }
+}
+
+/** Shows the event title and lets it wrap cleanly across multiple lines. */
+@Composable
+private fun EventTitle(
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        modifier = modifier,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/** Shows the campus source badge aligned cleanly within the event card header. */
+@Composable
+private fun CampusBadge() {
+    Box(contentAlignment = Alignment.Center) {
+        Surface(
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+            shape = MaterialTheme.shapes.small
+        ) {
+            Text(
+                text = "Campus",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+            )
+        }
+    }
+}
+
+/** Shows the optional event location text. */
+@Composable
+private fun EventLocation(location: String) {
+    if (location.isBlank()) {
+        return
+    }
+
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = location,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/schedule/CampusEventReminderScheduleText.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/schedule/CampusEventReminderScheduleText.kt
@@ -1,0 +1,12 @@
+package com.example.cinet.feature.calendar.schedule
+
+import com.example.cinet.feature.calendar.event.EventItem
+
+/** Builds the short reminder summary text shown in the schedule section. */
+fun campusEventReminderScheduleText(event: EventItem): String {
+    return if (event.allDay) {
+        "Reminder: 9:00 AM on event day"
+    } else {
+        "Reminder: 30 minutes before"
+    }
+}

--- a/app/src/main/java/com/example/cinet/feature/calendar/schedule/ScheduleSection.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/schedule/ScheduleSection.kt
@@ -1,56 +1,143 @@
 package com.example.cinet.feature.calendar.schedule
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.cinet.feature.calendar.event.EventItem
 import java.time.LocalDate
 
+/** Shows the schedule section for the selected day, including assignments and reminder-enabled campus events. */
 @Composable
 fun ScheduleSection(
     selectedDate: LocalDate?,
     itemsForSelectedDate: List<ScheduleItem>,
-    onItemClick: (ScheduleItem) -> Unit
+    reminderEventsForSelectedDate: List<EventItem>,
+    onItemClick: (ScheduleItem) -> Unit,
+    onReminderClick: (EventItem) -> Unit
 ) {
     Spacer(modifier = Modifier.height(24.dp))
-
     Text("Schedule", style = MaterialTheme.typography.titleMedium)
     Spacer(modifier = Modifier.height(8.dp))
 
-    if (selectedDate == null) {
-        // Depends on parent screen not having a selected date yet.
-        Text("Select a date to view scheduled items.")
-    } else if (itemsForSelectedDate.isEmpty()) {
-        // itemsForSelectedDate is already filtered before reaching this composable,
-        // so empty here means no items match the selected date.
-        Text("No items scheduled for $selectedDate")
-    } else {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            itemsForSelectedDate.forEach { item ->
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        // Click handling is delegated upward, typically to open edit/view behavior.
-                        .clickable { onItemClick(item) }
-                ) {
-                    Column(modifier = Modifier.padding(12.dp)) {
-                        Text(
-                            text = item.className,
-                            style = MaterialTheme.typography.titleSmall
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(text = item.assignmentName)
-                        Spacer(modifier = Modifier.height(4.dp))
+    when {
+        selectedDate == null -> Text("Select a date to view scheduled items.")
+        hasNoScheduleContent(itemsForSelectedDate, reminderEventsForSelectedDate) -> {
+            Text("No items scheduled for $selectedDate")
+        }
+        else -> ScheduleContent(
+            itemsForSelectedDate = itemsForSelectedDate,
+            reminderEventsForSelectedDate = reminderEventsForSelectedDate,
+            onItemClick = onItemClick,
+            onReminderClick = onReminderClick
+        )
+    }
+}
 
-                        // Assumes dueTime is already stored in display-ready format.
-                        Text(text = "Due: ${item.dueTime}")
-                    }
-                }
-            }
+/** Returns true when the selected day has neither assignment items nor reminder items. */
+private fun hasNoScheduleContent(
+    itemsForSelectedDate: List<ScheduleItem>,
+    reminderEventsForSelectedDate: List<EventItem>
+): Boolean {
+    return itemsForSelectedDate.isEmpty() && reminderEventsForSelectedDate.isEmpty()
+}
+
+/** Shows both assignment cards and reminder cards for the selected day. */
+@Composable
+private fun ScheduleContent(
+    itemsForSelectedDate: List<ScheduleItem>,
+    reminderEventsForSelectedDate: List<EventItem>,
+    onItemClick: (ScheduleItem) -> Unit,
+    onReminderClick: (EventItem) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        AssignmentScheduleList(itemsForSelectedDate, onItemClick)
+        CampusReminderScheduleList(reminderEventsForSelectedDate, onReminderClick)
+    }
+}
+
+/** Shows each assignment card already stored in the schedule section. */
+@Composable
+private fun AssignmentScheduleList(
+    itemsForSelectedDate: List<ScheduleItem>,
+    onItemClick: (ScheduleItem) -> Unit
+) {
+    itemsForSelectedDate.forEach { item ->
+        AssignmentScheduleCard(item = item, onItemClick = onItemClick)
+    }
+}
+
+/** Shows one assignment card and delegates click handling upward. */
+@Composable
+private fun AssignmentScheduleCard(
+    item: ScheduleItem,
+    onItemClick: (ScheduleItem) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(item) }
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = item.className,
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = item.assignmentName)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = "Due: ${item.dueTime}")
+        }
+    }
+}
+
+/** Shows each reminder-enabled campus event in the schedule section. */
+@Composable
+private fun CampusReminderScheduleList(
+    reminderEventsForSelectedDate: List<EventItem>,
+    onReminderClick: (EventItem) -> Unit
+) {
+    reminderEventsForSelectedDate.forEach { event ->
+        CampusReminderScheduleCard(event = event, onReminderClick = onReminderClick)
+    }
+}
+
+/** Shows one reminder card for a campus event that has notifications turned on. */
+@Composable
+private fun CampusReminderScheduleCard(
+    event: EventItem,
+    onReminderClick: (EventItem) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onReminderClick(event) }
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = event.name,
+                style = MaterialTheme.typography.titleSmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = campusEventReminderScheduleText(event),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Event: ${event.time}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -27,7 +27,8 @@ import java.util.Calendar
 fun HomeScreen(
     nickname: String,
     scheduleItems: List<Pair<String, String>>,
-    upcomingEventsItems: List<Pair<String, String>>,
+    manualUpcomingEventsItems: List<Pair<String, String>>,
+    displayUpcomingEventsItems: List<HomeUpcomingEventItem>,
     onUpdateSchedule: (List<Pair<String, String>>) -> Unit,
     onUpdateEvents: (List<Pair<String, String>>) -> Unit,
     modifier: Modifier = Modifier,
@@ -146,7 +147,7 @@ fun HomeScreen(
                         val fullTime = "$timeOrDateField $amPmSelection"
                         val newItem = nameField to "$fullTime | ${locationField?.name}"
                         
-                        val newList = upcomingEventsItems.toMutableList()
+                        val newList = manualUpcomingEventsItems.toMutableList()
                         if (editingIndex != null) {
                             newList[editingIndex!!] = newItem
                         } else {
@@ -168,7 +169,7 @@ fun HomeScreen(
                 Row {
                     if (editingIndex != null) {
                         TextButton(onClick = {
-                            val newList = upcomingEventsItems.toMutableList()
+                            val newList = manualUpcomingEventsItems.toMutableList()
                             newList.removeAt(editingIndex!!)
                             onUpdateEvents(newList)
                             showDialog = false
@@ -246,7 +247,7 @@ fun HomeScreen(
         // Upcoming Events Section
         InfoSection(
             title = "Upcoming Events",
-            items = upcomingEventsItems,
+            items = displayUpcomingEventsItems.map { it.title to it.description },
             onAddClick = {
                 editingIndex = null
                 nameField = ""
@@ -255,16 +256,29 @@ fun HomeScreen(
                 showDialog = true
             },
             onItemClick = { index ->
-                editingIndex = index
-                val item = upcomingEventsItems[index]
-                nameField = item.first
-                // Simple parsing for demo purposes
-                val parts = item.second.split(" | ")
-                val timeParts = parts[0].split(" ")
-                timeOrDateField = if (timeParts.isNotEmpty()) timeParts[0] else ""
-                amPmSelection = if (timeParts.size > 1) timeParts[1] else "AM"
-                locationField = academic.find { it.name == if (parts.size > 1) parts[1] else "" }
-                showDialog = true
+                val selectedItem = displayUpcomingEventsItems[index]
+                if (selectedItem.isCampusEvent) {
+                    onCalendarClick()
+                } else {
+                    val manualIndex = manualUpcomingEventsItems.indexOfFirst {
+                        it.first == selectedItem.title && it.second == selectedItem.description
+                    }
+
+                    if (manualIndex == -1) {
+                        onCalendarClick()
+                    } else {
+                        editingIndex = manualIndex
+                        val item = manualUpcomingEventsItems[manualIndex]
+                        nameField = item.first
+                        // Simple parsing for demo purposes
+                        val parts = item.second.split(" | ")
+                        val timeParts = parts[0].split(" ")
+                        timeOrDateField = if (timeParts.isNotEmpty()) timeParts[0] else ""
+                        amPmSelection = if (timeParts.size > 1) timeParts[1] else "AM"
+                        locationField = academic.find { it.name == if (parts.size > 1) parts[1] else "" }
+                        showDialog = true
+                    }
+                }
             },
             onNavigateToLocation = onNavigateToLocation
         )
@@ -278,7 +292,8 @@ fun HomeScreenPreview() {
         HomeScreen(
             nickname = "User",
             scheduleItems = emptyList(),
-            upcomingEventsItems = emptyList(),
+            manualUpcomingEventsItems = emptyList(),
+            displayUpcomingEventsItems = emptyList(),
             onUpdateSchedule = {},
             onUpdateEvents = {},
             onNavigateToLocation = { _ -> }

--- a/app/src/main/java/com/example/cinet/feature/home/HomeUpcomingEventItem.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeUpcomingEventItem.kt
@@ -1,0 +1,8 @@
+package com.example.cinet.feature.home
+
+/** Stores one row shown in the Home screen's Upcoming Events section. */
+data class HomeUpcomingEventItem(
+    val title: String,
+    val description: String,
+    val isCampusEvent: Boolean
+)

--- a/app/src/main/java/com/example/cinet/feature/home/HomeUpcomingEventsBuilder.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeUpcomingEventsBuilder.kt
@@ -1,0 +1,85 @@
+package com.example.cinet.feature.home
+
+import android.content.Context
+import com.example.cinet.feature.calendar.event.CampusEventReminderPreferences
+import com.example.cinet.feature.calendar.event.EventItem
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/** Builds the combined Home screen upcoming-event list from manual items and reminder-enabled campus events. */
+fun buildHomeUpcomingEventItems(
+    context: Context,
+    manualItems: List<Pair<String, String>>,
+    campusEvents: List<EventItem>,
+    currentTimeMillis: Long = System.currentTimeMillis()
+): List<HomeUpcomingEventItem> {
+    val campusItems = buildCampusUpcomingEventItems(context, campusEvents, currentTimeMillis)
+    val manualUpcomingItems = buildManualUpcomingEventItems(manualItems)
+    return campusItems + manualUpcomingItems
+}
+
+/** Converts the user's existing manually managed home-page items into display models. */
+private fun buildManualUpcomingEventItems(
+    manualItems: List<Pair<String, String>>
+): List<HomeUpcomingEventItem> {
+    return manualItems.map { (title, description) ->
+        HomeUpcomingEventItem(
+            title = title,
+            description = description,
+            isCampusEvent = false
+        )
+    }
+}
+
+/** Converts reminder-enabled future campus events into Home screen display models. */
+private fun buildCampusUpcomingEventItems(
+    context: Context,
+    campusEvents: List<EventItem>,
+    currentTimeMillis: Long
+): List<HomeUpcomingEventItem> {
+    return campusEvents
+        .filter { shouldShowCampusEventOnHome(context, it, currentTimeMillis) }
+        .sortedBy { it.startEpochMillis ?: Long.MAX_VALUE }
+        .map(::toHomeUpcomingCampusEventItem)
+}
+
+/** Returns true when a campus event is future-or-current and has reminders enabled. */
+private fun shouldShowCampusEventOnHome(
+    context: Context,
+    event: EventItem,
+    currentTimeMillis: Long
+): Boolean {
+    if (!event.isCampusEvent) return false
+    if (!CampusEventReminderPreferences.isReminderEnabled(context, event.id)) return false
+
+    val eventEndMillis = event.endEpochMillis ?: event.startEpochMillis ?: return false
+    return eventEndMillis >= currentTimeMillis
+}
+
+/** Maps one campus event into the card content shown on the Home screen. */
+private fun toHomeUpcomingCampusEventItem(event: EventItem): HomeUpcomingEventItem {
+    return HomeUpcomingEventItem(
+        title = event.name,
+        description = buildCampusEventHomeDescription(event),
+        isCampusEvent = true
+    )
+}
+
+/** Builds the secondary text for a campus event row on the Home screen. */
+private fun buildCampusEventHomeDescription(event: EventItem): String {
+    val dateText = event.startEpochMillis?.let(::formatEventDate).orEmpty()
+    val timeText = event.time.ifBlank { "All day" }
+    val locationText = event.location.ifBlank { "TBA" }
+    return "$dateText • $timeText | $locationText"
+}
+
+/** Formats one campus event date into a readable Home screen label. */
+private fun formatEventDate(epochMillis: Long): String {
+    val formatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US)
+    return Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .toLocalDate()
+        .format(formatter)
+}

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -19,7 +19,7 @@ import java.util.Calendar
 import java.util.Locale
 import com.example.cinet.feature.auth.*
 import com.example.cinet.feature.map.*
-import com.example.cinet.feature.home.HomeScreen
+import com.example.cinet.feature.home.*
 import com.example.cinet.feature.social.*
 import com.example.cinet.feature.profile.*
 import com.example.cinet.feature.calendar.calendarFiles.*
@@ -119,6 +119,23 @@ private fun MainScaffold(
 
     val context = LocalContext.current
     val sharedPrefs = remember { context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE) }
+    val campusReminderPrefs = remember {
+        context.getSharedPreferences("campus_event_reminders", android.content.Context.MODE_PRIVATE)
+    }
+    var campusReminderRefreshKey by remember { mutableStateOf(0) }
+
+    DisposableEffect(campusReminderPrefs) {
+        val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key?.startsWith("reminder_") == true) {
+                campusReminderRefreshKey++
+            }
+        }
+
+        campusReminderPrefs.registerOnSharedPreferenceChangeListener(listener)
+        onDispose {
+            campusReminderPrefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+    }
 
     fun loadItems(key: String): List<Pair<String, String>> {
         val saved = sharedPrefs.getString(key, null) ?: return emptyList()
@@ -134,6 +151,18 @@ private fun MainScaffold(
     }
 
     var upcomingEventsItems by remember { mutableStateOf(loadItems("event_items")) }
+
+    val homeUpcomingEventsItems = remember(
+        upcomingEventsItems,
+        calendarViewModel.campusEventItems,
+        campusReminderRefreshKey
+    ) {
+        buildHomeUpcomingEventItems(
+            context = context,
+            manualItems = upcomingEventsItems,
+            campusEvents = calendarViewModel.campusEventItems
+        )
+    }
 
     val socialBackStackActive = currentScreen == Screen.Social &&
             (activeConversation != null || selectedProfile != null ||
@@ -203,7 +232,8 @@ private fun MainScaffold(
                 Screen.Home -> HomeScreen(
                     nickname = userProfile.nickname,
                     scheduleItems = calendarScheduleItems,
-                    upcomingEventsItems = upcomingEventsItems,
+                    manualUpcomingEventsItems = upcomingEventsItems,
+                    displayUpcomingEventsItems = homeUpcomingEventsItems,
                     onUpdateSchedule = { },
                     onUpdateEvents = {
                         upcomingEventsItems = it


### PR DESCRIPTION
CINet Calendar / Campus Event Changes Completed In This Session
============================================================

Overview
--------
This session focused on integrating live CSUCI campus events from an iCal/ICS feed into the app's existing calendar without replacing the calendar UI. The work also added reminder support, improved event formatting, and connected reminder-enabled campus events to other parts of the app.

Major Changes Completed
-----------------------
1. Live campus events were added to the calendar using the CSUCI iCal/ICS feed.
2. Campus events were merged into the existing calendar event display instead of replacing the current calendar system.
3. Tapping a campus event now opens a details dialog.
4. The details dialog includes a reminder toggle for campus events.
5. Campus event reminders were scheduled through the app's existing notification helper/channel system.
6. The event detail text formatting was cleaned up so HTML/entity text displays as normal readable English.
7. Event cards were adjusted so long titles wrap correctly and the Campus label stays positioned cleanly.
8. Links in campus event descriptions were made tappable.
9. The Schedule section was updated so reminder-enabled campus events appear there for the selected date.
10. The new campus-event code was refactored into smaller helper files to better match the preferred coding style.
11. The Home screen Upcoming Events section now updates based on campus events that have reminders toggled on or off.

Reminder Behavior
-----------------
- Timed campus events: reminder is scheduled 30 minutes before the event.
- All-day campus events: reminder is scheduled for 9:00 AM on the event day.
- When a campus event reminder is turned on, the app stores that preference and uses it to update related UI sections.
- When a campus event reminder is turned off, the related schedule/home entries are removed.

Home Screen Behavior
--------------------
- Reminder-enabled campus events are now shown in the Home screen Upcoming Events section.
- Manual Upcoming Events entries already supported by the Home screen are still preserved.
- Campus reminder events are displayed together with manual items.
- If the user taps a campus-driven Upcoming Event row on the Home screen, the app routes the user back to the calendar instead of trying to edit it like a manual item.

Notification Framework Notes
----------------------------
Campus event reminders use the app's existing notification helper framework:
- NotificationHelper.createChannel(...)
- NotificationHelper.showNotification(...)
- AppNotification
- NotificationType.EVENT
