### PR TITLE
feat: profile screens, push notification deep links, social improvements, and bug fixes

### DIFF
--- a/app/src/main/java/com/example/cinet/app/MainActivity.kt
+++ b/app/src/main/java/com/example/cinet/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.app
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,6 +9,8 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.example.cinet.core.notifications.NotificationHelper
 import com.example.cinet.core.permissions.PermissionManager
 import com.example.cinet.data.remote.FirestoreRepository
@@ -26,24 +29,30 @@ class MainActivity : ComponentActivity() {
         AuthViewModelFactory(repository)
     }
 
+    // Conversation to open immediately — set from notification tap intent.
+    // Using mutableStateOf so Compose recomposes when onNewIntent updates it.
+    private var pendingConversationId by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NotificationHelper.createChannel(this)
-        
+
         if (!PermissionManager.hasAllPermissions(this)) {
             PermissionManager.requestAllPermissions(this)
         }
-        
+
+        // Read conversationId from a notification tap (cold start or task not running)
+        pendingConversationId = intent.getStringExtra(EXTRA_CONVERSATION_ID)
+
         enableEdgeToEdge()
-        
+
         setContent {
             val authState by authViewModel.authState.collectAsState()
-            
-            // Derive dark mode from the current authenticated user profile
+
             val isDarkMode = when (val state = authState) {
                 is AuthState.Authenticated -> state.userProfile.isDarkMode
                 is AuthState.ProfileSetup -> state.userProfile.isDarkMode
-                else -> AppSettings.isDarkMode // Fallback to local default if not logged in
+                else -> AppSettings.isDarkMode
             }
 
             val currentTheme = when (val state = authState) {
@@ -52,7 +61,6 @@ class MainActivity : ComponentActivity() {
                 else -> AppSettings.selectedTheme
             }
 
-            // Sync global AppSettings for other components (like the Map) - Zack
             LaunchedEffect(isDarkMode) {
                 AppSettings.isDarkMode = isDarkMode
                 AppSettings.selectedTheme = currentTheme
@@ -68,14 +76,24 @@ class MainActivity : ComponentActivity() {
                     onRetry = { authViewModel.retryProfileLoad() },
                     onSaveProfile = { nickname, major, pronouns ->
                         authViewModel.saveProfile(nickname, major, pronouns)
-                    }
+                    },
+                    initialConversationId = pendingConversationId,
+                    onConversationOpened = { pendingConversationId = null },
                 )
             }
         }
     }
 
+    // Called when the app is already running and the user taps a notification.
+    // FLAG_ACTIVITY_SINGLE_TOP ensures this is called instead of a new onCreate.
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingConversationId = intent.getStringExtra(EXTRA_CONVERSATION_ID)
+    }
+
     companion object {
-        // map location key - Zack
+        const val EXTRA_CONVERSATION_ID = "conversationId"
         const val EXTRA_OPEN_MAP_FOR_LOCATION = "extra_open_map_for_location"
     }
 }

--- a/app/src/main/java/com/example/cinet/core/notifications/FireBaseMessagingService.kt
+++ b/app/src/main/java/com/example/cinet/core/notifications/FireBaseMessagingService.kt
@@ -1,5 +1,8 @@
 package com.example.cinet.core.notifications
 
+import android.app.PendingIntent
+import android.content.Intent
+import com.example.cinet.app.MainActivity
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -10,16 +13,27 @@ class FireBaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         val type = remoteMessage.data["type"] ?: "text"
         val conversationId = remoteMessage.data["conversationId"] ?: ""
-
         val isInvite = type == "study_invite" || type == "event_invite"
 
-        // Data payload — used when app is in foreground (system ignores notification payload)
         if (remoteMessage.data.isNotEmpty()) {
             val title = remoteMessage.notification?.title
                 ?: if (isInvite) "New Invite" else "New Message"
             val body = remoteMessage.notification?.body ?: ""
+            val notificationType =
+                if (isInvite) NotificationType.INVITE else NotificationType.MESSAGE
 
-            val notificationType = if (isInvite) NotificationType.INVITE else NotificationType.MESSAGE
+            // Build a PendingIntent so tapping the notification opens MainActivity
+            // and passes conversationId so the app navigates straight to that conversation.
+            val tapIntent = Intent(this, MainActivity::class.java).apply {
+                putExtra(MainActivity.EXTRA_CONVERSATION_ID, conversationId)
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val pendingIntent = PendingIntent.getActivity(
+                this,
+                conversationId.hashCode(),
+                tapIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
 
             NotificationHelper.createChannels(this)
             NotificationHelper.showNotification(
@@ -30,22 +44,17 @@ class FireBaseMessagingService : FirebaseMessagingService() {
                     type = notificationType,
                     timestamp = System.currentTimeMillis(),
                     conversationId = conversationId
-                )
+                ),
+                contentIntent = pendingIntent
             )
             return
         }
 
-        // Notification-only payload fallback (app in background, system delivered it — log only)
         remoteMessage.notification?.let {
             android.util.Log.d("FCM", "Background notification received: ${it.title}")
         }
     }
 
-    /**
-     * Called when FCM assigns a new token to this device.
-     * Saves it to the current user's Firestore document so the Cloud Function
-     * can look it up when sending push notifications.
-     */
     override fun onNewToken(token: String) {
         val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
         FirebaseFirestore.getInstance()

--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -15,6 +15,7 @@ data class Conversation(
     var isGroup: Boolean = false,
     val groupName: String = "",
     @ServerTimestamp val lastUpdated: Date? = null,
+    val lastSenderId: String = "",
     // false = hidden (e.g. after unfriend). Defaults to true so legacy docs
     // without this field are treated as active.
     val active: Boolean = true,

--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -15,4 +15,7 @@ data class Conversation(
     var isGroup: Boolean = false,
     val groupName: String = "",
     @ServerTimestamp val lastUpdated: Date? = null,
+    // false = hidden (e.g. after unfriend). Defaults to true so legacy docs
+    // without this field are treated as active.
+    val active: Boolean = true,
 )

--- a/app/src/main/java/com/example/cinet/data/model/FriendRequest.kt
+++ b/app/src/main/java/com/example/cinet/data/model/FriendRequest.kt
@@ -8,6 +8,7 @@ data class FriendRequest(
     val senderId: String = "",
     val senderNickname: String = "",
     val receiverId: String = "",
+    val receiverNickname: String = "",
     // status: "pending", "accepted", "declined"
     val status: String = "pending",
     @ServerTimestamp val createdAt: Date? = null,

--- a/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
+++ b/app/src/main/java/com/example/cinet/data/model/UserProfile.kt
@@ -11,8 +11,11 @@ data class UserProfile(
     val nicknameLower: String = "",  // lowercase copy used for case-insensitive search
     val major: String = "",
     val pronouns: String = "",
+    val year: String = "",           // Freshman / Sophomore / Junior / Senior / Graduate / Transfer
+    val bio: String = "",            // short free-text blurb
+    val interests: List<String> = emptyList(), // e.g. ["Gaming", "Hiking", "Music"]
     val photoUrl: String = "",
-    val fcmToken: String? = null, // used to send push notifications to this user's device
+    val fcmToken: String? = null,    // used to send push notifications to this user's device
     val isDarkMode: Boolean = false,
     val notificationsEnabled: Boolean = true,
     val selectedTheme: AppThemeColor = AppThemeColor.Green,

--- a/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/FirestoreRepository.kt
@@ -75,6 +75,9 @@ class FirestoreRepository(
         nickname: String,
         major: String,
         pronouns: String,
+        year: String = "",
+        bio: String = "",
+        interests: List<String> = emptyList(),
     ): Result<UserProfile> {
         return try {
             val user = auth.currentUser ?: error("No signed-in user.")
@@ -85,6 +88,9 @@ class FirestoreRepository(
                 "nicknameLower" to nickname.lowercase(),
                 "major"         to major,
                 "pronouns"      to pronouns,
+                "year"          to year,
+                "bio"           to bio,
+                "interests"     to interests,
             )
 
             docRef.set(profileUpdate, SetOptions.merge()).await()

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -177,23 +177,61 @@ class SocialRepository(
         }
     }
 
-    /** Removes a friend by deleting the friend doc from both users' subcollections. */
+    /**
+     * Removes a friend atomically via a WriteBatch:
+     *  1. Deletes both users' friend subcollection docs.
+     *  2. Finds the shared DM conversation (client-side isGroup check to handle
+     *     docs where the field was never written) and sets active = false so it
+     *     disappears from ConversationsListScreen without losing message history.
+     *  3. Deletes both possible friendRequest docs.
+     *
+     * Sending a new message after re-adding calls updateConversationLastMessage
+     * which sets active = true, restoring the conversation automatically.
+     */
     suspend fun removeFriend(friendUid: String): Result<Unit> {
         return try {
-            db.collection("users")
-                .document(currentUid)
-                .collection("friends")
-                .document(friendUid)
-                .delete()
+            val batch = db.batch()
+
+            // 1. Delete both friend subcollection docs
+            batch.delete(
+                db.collection("users").document(currentUid)
+                    .collection("friends").document(friendUid)
+            )
+            batch.delete(
+                db.collection("users").document(friendUid)
+                    .collection("friends").document(currentUid)
+            )
+
+            // 2. Find the shared DM conversation and deactivate it.
+            //    Query by participantIds contains currentUid, then filter client-side
+            //    because whereEqualTo("isGroup", false) misses docs where the field
+            //    was never set.
+            val conversationsSnapshot = db.collection("conversations")
+                .whereArrayContains("participantIds", currentUid)
+                .get()
                 .await()
 
-            db.collection("users")
-                .document(friendUid)
-                .collection("friends")
-                .document(currentUid)
-                .delete()
-                .await()
+            conversationsSnapshot.documents
+                .filter { doc ->
+                    val isGroup = doc.getBoolean("isGroup") ?: false
+                    @Suppress("UNCHECKED_CAST")
+                    val participants = doc.get("participantIds") as? List<String> ?: emptyList()
+                    !isGroup && participants.contains(friendUid)
+                }
+                .forEach { doc ->
+                    batch.update(doc.reference, "active", false)
+                }
 
+            // 3. Delete both possible friendRequest docs (either direction)
+            batch.delete(
+                db.collection("friendRequests").document("${currentUid}_${friendUid}")
+            )
+            batch.delete(
+                db.collection("friendRequests").document("${friendUid}_${currentUid}")
+            )
+
+            batch.commit().await()
+            Log.d("SocialRepository", "removeFriend: removed $friendUid, conversation deactivated")
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e("SocialRepository", "removeFriend failed: ${e.message}")
@@ -668,7 +706,11 @@ class SocialRepository(
             .set(
                 mapOf(
                     "lastMessage" to content,
-                    "lastUpdated" to FieldValue.serverTimestamp()
+                    "lastUpdated" to FieldValue.serverTimestamp(),
+                    // Re-activates the conversation if it was hidden after an unfriend.
+                    // This means sending a message after re-adding a friend restores
+                    // the conversation in the list automatically.
+                    "active" to true
                 ),
                 SetOptions.merge()
             )

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -712,6 +712,7 @@ class SocialRepository(
                 mapOf(
                     "lastMessage" to content,
                     "lastUpdated" to FieldValue.serverTimestamp(),
+                    "lastSenderId" to currentUid,
                     // Re-activates the conversation if it was hidden after an unfriend.
                     // This means sending a message after re-adding a friend restores
                     // the conversation in the list automatically.

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -74,6 +74,7 @@ class SocialRepository(
     suspend fun sendFriendRequest(receiver: UserProfile): Result<Unit> {
         return try {
             if (!canSendFriendRequest(receiver.uid)) {
+                Log.d("SocialRepository", "sendFriendRequest blocked for ${receiver.uid}")
                 return Result.success(Unit)
             }
 
@@ -82,11 +83,14 @@ class SocialRepository(
                 senderId = currentUid,
                 senderNickname = currentUser.nickname,
                 receiverId = receiver.uid,
+                receiverNickname = receiver.nickname,
             )
 
             saveFriendRequest(request)
+            Log.d("SocialRepository", "sendFriendRequest: sent to ${receiver.uid}")
             Result.success(Unit)
         } catch (e: Exception) {
+            Log.e("SocialRepository", "sendFriendRequest failed: ${e.message}")
             Result.failure(e)
         }
     }
@@ -110,15 +114,29 @@ class SocialRepository(
         }
     }
 
-    /** Gets outgoing pending friend requests sent by the current user. */
+    /** Gets outgoing pending friend requests sent by the current user.
+     *  For legacy docs that pre-date the receiverNickname field, the nickname
+     *  is fetched on the fly so the UI never shows a raw UID.
+     */
     suspend fun getSentRequests(): Result<List<FriendRequest>> {
         return try {
             val requests = loadPendingRequestsForSender(currentUid)
                 .sortedByDescending { it.createdAt?.time ?: 0L }
                 .distinctBy { it.receiverId }
 
-            Result.success(requests)
+            // Back-fill receiverNickname for any legacy docs that are missing it
+            val enriched = requests.map { request ->
+                if (request.receiverNickname.isBlank()) {
+                    request.copy(receiverNickname = getUserNickname(request.receiverId))
+                } else {
+                    request
+                }
+            }
+
+            Log.d("SocialRepository", "getSentRequests: found ${enriched.size} for uid $currentUid")
+            Result.success(enriched)
         } catch (e: Exception) {
+            Log.e("SocialRepository", "getSentRequests failed: ${e.message}")
             Result.failure(e)
         }
     }
@@ -387,9 +405,25 @@ class SocialRepository(
     /** Checks whether a new friend request is allowed to be sent. */
     private suspend fun canSendFriendRequest(receiverUid: String): Boolean {
         if (receiverUid == currentUid) return false
-        if (areAlreadyFriends(receiverUid)) return false
-        if (hasPendingRequest(currentUid, receiverUid)) return false
-        if (hasPendingRequest(receiverUid, currentUid)) return false
+        try {
+            if (areAlreadyFriends(receiverUid)) {
+                Log.d("SocialRepository", "canSendFriendRequest: already friends with $receiverUid")
+                return false
+            }
+            if (hasPendingRequest(currentUid, receiverUid)) {
+                Log.d("SocialRepository", "canSendFriendRequest: pending request already sent to $receiverUid")
+                return false
+            }
+            if (hasPendingRequest(receiverUid, currentUid)) {
+                Log.d("SocialRepository", "canSendFriendRequest: $receiverUid already sent us a request")
+                return false
+            }
+        } catch (e: Exception) {
+            // If the index query fails (e.g. missing composite index), log clearly and
+            // allow the send rather than silently blocking it. The saveFriendRequest
+            // document ID is deterministic so a duplicate write is harmless.
+            Log.e("SocialRepository", "canSendFriendRequest check failed — allowing send. Error: ${e.message}")
+        }
         return true
     }
 
@@ -403,6 +437,7 @@ class SocialRepository(
         senderId: String,
         senderNickname: String,
         receiverId: String,
+        receiverNickname: String,
     ): FriendRequest {
         val requestId = friendRequestDocumentId(senderId, receiverId)
 
@@ -411,16 +446,20 @@ class SocialRepository(
             senderId = senderId,
             senderNickname = senderNickname,
             receiverId = receiverId,
+            receiverNickname = receiverNickname,
             status = "pending",
         )
     }
 
-    /** Saves a friend request to Firestore. */
+    /**
+     * Saves a friend request to Firestore.
+     * Deletes any stale doc first (e.g. a previously declined request) so the
+     * write is always a `create` -- which the sender is permitted to do.
+     */
     private suspend fun saveFriendRequest(request: FriendRequest) {
-        db.collection("friendRequests")
-            .document(request.id)
-            .set(request)
-            .await()
+        val docRef = db.collection("friendRequests").document(request.id)
+        try { docRef.delete().await() } catch (_: Exception) { }
+        docRef.set(request).await()
     }
 
     /** Loads the current user's full profile from Firestore. */

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -418,7 +418,7 @@ class SocialRepository(
 
             val items = snapshot.documents.mapNotNull { doc ->
                 mapDocumentToStudySession(doc.id, doc.data ?: emptyMap())
-            }
+            }.distinctBy { Triple(it.className, it.date, it.startTime) }
 
             Result.success(items)
         } catch (e: Exception) {
@@ -437,7 +437,7 @@ class SocialRepository(
 
             val items = snapshot.documents.mapNotNull { doc ->
                 mapDocumentToEventItem(doc.id, doc.data ?: emptyMap())
-            }
+            }.distinctBy { Triple(it.name, it.date, it.time) }
 
             Result.success(items)
         } catch (e: Exception) {

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -222,16 +222,21 @@ class SocialRepository(
                     batch.update(doc.reference, "active", false)
                 }
 
-            // 3. Delete both possible friendRequest docs (either direction)
-            batch.delete(
-                db.collection("friendRequests").document("${currentUid}_${friendUid}")
-            )
-            batch.delete(
-                db.collection("friendRequests").document("${friendUid}_${currentUid}")
-            )
-
             batch.commit().await()
-            Log.d("SocialRepository", "removeFriend: removed $friendUid, conversation deactivated")
+            Log.d("SocialRepository", "removeFriend: friend docs deleted, conversation deactivated")
+
+            // 3. Delete both possible friendRequest docs outside the batch.
+            //    A batch delete on a non-existent doc causes PERMISSION_DENIED
+            //    and fails the whole batch, so each is done individually.
+            for (docId in listOf("${currentUid}_${friendUid}", "${friendUid}_${currentUid}")) {
+                try {
+                    db.collection("friendRequests").document(docId).delete().await()
+                } catch (e: Exception) {
+                    Log.d("SocialRepository", "friendRequest $docId skipped: ${e.message}")
+                }
+            }
+
+            Log.d("SocialRepository", "removeFriend: complete for $friendUid")
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e("SocialRepository", "removeFriend failed: ${e.message}")

--- a/app/src/main/java/com/example/cinet/feature/auth/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/auth/viewmodel/AuthViewModel.kt
@@ -49,6 +49,21 @@ class AuthViewModel(
         }
     }
 
+    /**
+     * Silently reloads the user profile from Firestore without flashing a
+     * Loading state. Called after ProfileEditScreen saves so the UI updates
+     * immediately without a full re-auth cycle.
+     */
+    fun silentReloadProfile() {
+        viewModelScope.launch {
+            repository.createOrLoadUserProfile()
+                .onSuccess { resolveState(it) }
+                .onFailure { e ->
+                    android.util.Log.e(TAG, "silentReloadProfile failed: ${e.message}")
+                }
+        }
+    }
+
     // Saves the user's profile details to Firestore and updates state
     fun saveProfile(nickname: String, major: String, pronouns: String) {
         viewModelScope.launch {
@@ -65,7 +80,7 @@ class AuthViewModel(
      */
     fun updateSettings(isDarkMode: Boolean, notificationsEnabled: Boolean, selectedTheme: AppThemeColor) {
         val currentState = _authState.value
-        
+
         // Optimistic update of local state
         if (currentState is AuthState.Authenticated) {
             _authState.value = AuthState.Authenticated(

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -168,6 +169,17 @@ fun EventInviteSenderDialog(
 
                 } else {
                     // ── Pick from existing events ─────────────────────────────
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("Your Events", style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        TextButton(onClick = { isCreatingNew = true }) {
+                            Text("Create new")
+                        }
+                    }
                     OutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
@@ -184,11 +196,13 @@ fun EventInviteSenderDialog(
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     } else {
-                        val filteredEvents = existingEvents.filter {
-                            searchQuery.isBlank() ||
-                                    it.name.contains(searchQuery, ignoreCase = true) ||
-                                    it.location.contains(searchQuery, ignoreCase = true)
-                        }
+                        val filteredEvents = existingEvents
+                            .distinctBy { it.id }
+                            .filter {
+                                searchQuery.isBlank() ||
+                                        it.name.contains(searchQuery, ignoreCase = true) ||
+                                        it.location.contains(searchQuery, ignoreCase = true)
+                            }
                         LazyColumn {
                             items(filteredEvents) { event ->
                                 Card(
@@ -226,11 +240,6 @@ fun EventInviteSenderDialog(
                                 HorizontalDivider()
                             }
                         }
-                    }
-
-                    Spacer(modifier = Modifier.height(8.dp))
-                    TextButton(onClick = { isCreatingNew = true }) {
-                        Text("Create new instead")
                     }
                 }
             }

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
@@ -6,20 +6,28 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.example.cinet.feature.map.CampusLocation
-import com.google.firebase.firestore.FirebaseFirestore
-import kotlinx.coroutines.tasks.await
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.cinet.core.time.openTimePicker
+import com.example.cinet.data.model.CampusRegistry
+import com.example.cinet.feature.map.SearchLocationBar
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
-import com.example.cinet.core.time.openTimePicker
+
+// Category key → display label pairs shown as filter chips above the search bar.
+private val locationCategories = listOf(
+    "academic"         to "Academic",
+    "dining"           to "Dining",
+    "commuter_parking" to "Parking",
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,31 +35,32 @@ fun EventInviteSenderDialog(
     existingEvents: List<EventItem> = emptyList(),
     onDismiss: () -> Unit,
     onSend: (name: String, date: String, time: String, location: String) -> Unit,
+    campusRegistryViewModel: CampusRegistry = viewModel<CampusRegistry>(),
 ) {
     val context = LocalContext.current
+
     // false = pick from existing, true = create new manually
     var isCreatingNew by remember { mutableStateOf(false) }
     var eventName by remember { mutableStateOf("") }
     var eventDate by remember { mutableStateOf("") }
     var eventTime by remember { mutableStateOf("") }
-    var eventLocation by remember { mutableStateOf("") }
     var searchQuery by remember { mutableStateOf("") }
-    var locationsByCategory by remember { mutableStateOf<Map<String, List<CampusLocation>>>(emptyMap()) }
-    var locationCategory by remember { mutableStateOf("academic") }
     var showDatePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
 
-    LaunchedEffect(Unit) {
-        try {
-            val db = FirebaseFirestore.getInstance()
-            val result = mutableMapOf<String, List<CampusLocation>>()
-            for (col in listOf("academic", "dining", "commuter_parking")) {
-                result[col] = db.collection(col).get().await()
-                    .toObjects(CampusLocation::class.java)
-                    .sortedBy { it.name }
-            }
-            locationsByCategory = result
-        } catch (_: Exception) { }
+    // Location state — shared ViewModel instead of a private Firestore fetch
+    val campusRegistry by campusRegistryViewModel.campusRegistry.collectAsState()
+    var locationCategory by remember { mutableStateOf("academic") }
+    val locationTextFieldState = rememberTextFieldState()
+
+    // Names in the selected category, filtered by whatever is typed
+    val filteredLocationNames = remember(
+        locationTextFieldState.text, locationCategory, campusRegistry
+    ) {
+        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+        categoryLocations
+            .filter { it.name.contains(locationTextFieldState.text.toString(), ignoreCase = true) }
+            .map { it.name }
     }
 
     if (showDatePicker) {
@@ -60,7 +69,6 @@ fun EventInviteSenderDialog(
             confirmButton = {
                 TextButton(onClick = {
                     datePickerState.selectedDateMillis?.let { millis ->
-                        // Format to yyyy-MM-dd to match CalendarFirestoreRepository date format
                         val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
                         sdf.timeZone = TimeZone.getTimeZone("UTC")
                         eventDate = sdf.format(Date(millis))
@@ -82,7 +90,7 @@ fun EventInviteSenderDialog(
         text = {
             Column {
                 if (isCreatingNew) {
-                    // Manual form for creating a new event invite on the spot
+                    // ── Manual form for creating a new event invite ───────────
                     Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                         OutlinedTextField(
                             value = eventName,
@@ -91,6 +99,7 @@ fun EventInviteSenderDialog(
                             modifier = Modifier.fillMaxWidth()
                         )
                         Spacer(modifier = Modifier.height(8.dp))
+
                         OutlinedTextField(
                             value = eventDate,
                             onValueChange = {},
@@ -102,13 +111,13 @@ fun EventInviteSenderDialog(
                                 .clickable { showDatePicker = true }
                         )
                         Spacer(modifier = Modifier.height(8.dp))
+
                         Button(
                             onClick = { showDatePicker = true },
                             modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text("Pick Date")
-                        }
+                        ) { Text("Pick Date") }
                         Spacer(modifier = Modifier.height(8.dp))
+
                         OutlinedTextField(
                             value = eventTime,
                             onValueChange = {},
@@ -117,60 +126,48 @@ fun EventInviteSenderDialog(
                             modifier = Modifier.fillMaxWidth()
                         )
                         Spacer(modifier = Modifier.height(8.dp))
+
                         Button(
                             onClick = { openTimePicker(context) { eventTime = it } },
                             modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text("Pick Time")
-                        }
-                        Spacer(modifier = Modifier.height(8.dp))
-                        OutlinedTextField(
-                            value = eventLocation,
-                            onValueChange = { eventLocation = it },
-                            label = { Text("Location (optional)") },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth()
+                        ) { Text("Pick Time") }
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // ── Location: category chips + search bar ─────────────
+                        Text(
+                            text = "Location (optional)",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
-                        if (locationsByCategory.isNotEmpty()) {
-                            Spacer(modifier = Modifier.height(6.dp))
-                            Text(
-                                text = "Campus locations",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Row(
-                                modifier = Modifier.horizontalScroll(rememberScrollState()),
-                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            ) {
-                                listOf("academic" to "Academic", "dining" to "Dining", "commuter_parking" to "Parking")
-                                    .forEach { (key, label) ->
-                                        FilterChip(
-                                            selected = locationCategory == key,
-                                            onClick = { locationCategory = key },
-                                            label = { Text(label, style = MaterialTheme.typography.labelSmall) },
-                                        )
-                                    }
-                            }
-                            val categoryLocations = locationsByCategory[locationCategory] ?: emptyList()
-                            if (categoryLocations.isNotEmpty()) {
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Row(
-                                    modifier = Modifier.horizontalScroll(rememberScrollState()),
-                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                ) {
-                                    categoryLocations.forEach { loc ->
-                                        SuggestionChip(
-                                            onClick = { eventLocation = loc.name },
-                                            label = { Text(loc.name, style = MaterialTheme.typography.labelSmall) },
-                                        )
-                                    }
-                                }
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        Row(
+                            modifier = Modifier.horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            locationCategories.forEach { (key, label) ->
+                                FilterChip(
+                                    selected = locationCategory == key,
+                                    onClick = { locationCategory = key },
+                                    label = {
+                                        Text(label, style = MaterialTheme.typography.labelSmall)
+                                    },
+                                )
                             }
                         }
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        SearchLocationBar(
+                            textFieldState = locationTextFieldState,
+                            searchResults = filteredLocationNames,
+                            onSearch = { query ->
+                                locationTextFieldState.edit { replace(0, length, query) }
+                            }
+                        )
                     }
+
                 } else {
-                    // Pick from existing events
+                    // ── Pick from existing events ─────────────────────────────
                     OutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
@@ -179,6 +176,7 @@ fun EventInviteSenderDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
+
                     if (existingEvents.isEmpty()) {
                         Text(
                             "No events found — create a new invite below.",
@@ -197,13 +195,20 @@ fun EventInviteSenderDialog(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .padding(vertical = 4.dp)
-                                        // Tapping sends immediately
                                         .clickable {
-                                            onSend(event.name, event.date, event.time, event.location)
+                                            onSend(
+                                                event.name,
+                                                event.date,
+                                                event.time,
+                                                event.location
+                                            )
                                         }
                                 ) {
                                     Column(modifier = Modifier.padding(12.dp)) {
-                                        Text(text = event.name, style = MaterialTheme.typography.titleSmall)
+                                        Text(
+                                            text = event.name,
+                                            style = MaterialTheme.typography.titleSmall
+                                        )
                                         Text(
                                             text = "${event.time} on ${event.date}",
                                             style = MaterialTheme.typography.bodySmall,
@@ -222,6 +227,7 @@ fun EventInviteSenderDialog(
                             }
                         }
                     }
+
                     Spacer(modifier = Modifier.height(8.dp))
                     TextButton(onClick = { isCreatingNew = true }) {
                         Text("Create new instead")
@@ -233,13 +239,17 @@ fun EventInviteSenderDialog(
             if (isCreatingNew) {
                 Button(onClick = {
                     if (eventName.isNotBlank() && eventDate.isNotBlank() && eventTime.isNotBlank()) {
-                        onSend(eventName, eventDate, eventTime, eventLocation)
+                        onSend(
+                            eventName,
+                            eventDate,
+                            eventTime,
+                            locationTextFieldState.text.toString(),
+                        )
                     }
                 }) { Text("Send") }
             }
         },
         dismissButton = {
-            // Back returns to picker, Cancel closes entirely
             if (isCreatingNew) {
                 OutlinedButton(onClick = { isCreatingNew = false }) { Text("Back") }
             } else {

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventItemDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventItemDialog.kt
@@ -1,20 +1,31 @@
 package com.example.cinet.feature.calendar.event
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.SearchLocationBar
+
+// Category key → display label pairs shown as filter chips above the search bar.
+private val locationCategories = listOf(
+    "academic"         to "Academic",
+    "dining"           to "Dining",
+    "commuter_parking" to "Parking",
+)
 
 @Composable
 fun EventItemDialog(
@@ -31,13 +42,22 @@ fun EventItemDialog(
     onDelete: (() -> Unit)?,
     viewModel: CampusRegistry = viewModel<CampusRegistry>()
 ) {
-    val academic by viewModel.academic.collectAsState(initial = emptyList())
+    // Full registry — contains academic, dining, commuter_parking, transit
+    val campusRegistry by viewModel.campusRegistry.collectAsState()
+
     val textFieldState = rememberTextFieldState()
-    val academicNames = remember(textFieldState.text, academic) {
-        academic
+
+    // Which category the user has selected (default: Academic)
+    var locationCategory by remember { mutableStateOf("academic") }
+
+    // Locations in the selected category, filtered by whatever is typed
+    val filteredNames = remember(textFieldState.text, locationCategory, campusRegistry) {
+        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+        categoryLocations
             .filter { it.name.contains(textFieldState.text.toString(), ignoreCase = true) }
             .map { it.name }
     }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(if (editingEvent == null) "Add Event" else "Edit Event") },
@@ -45,6 +65,7 @@ fun EventItemDialog(
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 Text("Date: $date")
                 Spacer(modifier = Modifier.height(12.dp))
+
                 OutlinedTextField(
                     value = eventName,
                     onValueChange = onEventNameChange,
@@ -52,6 +73,7 @@ fun EventItemDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(8.dp))
+
                 OutlinedTextField(
                     value = eventTime,
                     onValueChange = {},
@@ -60,13 +82,36 @@ fun EventItemDialog(
                     readOnly = true
                 )
                 Spacer(modifier = Modifier.height(8.dp))
+
                 Button(onClick = onPickTime) { Text("Pick Time") }
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Category filter chips — Academic / Dining / Parking
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    locationCategories.forEach { (key, label) ->
+                        FilterChip(
+                            selected = locationCategory == key,
+                            onClick = {
+                                locationCategory = key
+                                // Clear selection when switching category
+                                onLocationChange(null)
+                            },
+                            label = { Text(label) },
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Search bar — results come from the selected category only
                 SearchLocationBar(
                     textFieldState = textFieldState,
-                    searchResults = academicNames,
+                    searchResults = filteredNames,
                     onSearch = { query ->
-                        val found = academic.find { it.name.equals(query, ignoreCase = true) }
+                        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+                        val found = categoryLocations.find { it.name.equals(query, ignoreCase = true) }
                         onLocationChange(found)
                         textFieldState.edit { replace(0, length, query) }
                     }
@@ -83,7 +128,9 @@ fun EventItemDialog(
                 if (onDelete != null) {
                     Button(
                         onClick = onDelete,
-                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        )
                     ) { Text("Delete") }
                 }
                 OutlinedButton(onClick = onDismiss) { Text("Cancel") }

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -181,6 +182,17 @@ fun StudyInviteDialog(
                     val hasAnyItems =
                         existingItems.isNotEmpty() || existingStudySessions.isNotEmpty()
 
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("Your Sessions", style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        TextButton(onClick = { isCreatingNew = true }) {
+                            Text("Create new")
+                        }
+                    }
                     OutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
@@ -275,10 +287,6 @@ fun StudyInviteDialog(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(8.dp))
-                    TextButton(onClick = { isCreatingNew = true }) {
-                        Text("Create new instead")
-                    }
                 }
             }
         },

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
@@ -6,19 +6,27 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.example.cinet.feature.map.CampusLocation
-import com.google.firebase.firestore.FirebaseFirestore
-import kotlinx.coroutines.tasks.await
 import androidx.compose.ui.unit.dp
-import com.example.cinet.feature.calendar.schedule.ScheduleItem
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.core.time.openTimePicker
+import com.example.cinet.data.model.CampusRegistry
+import com.example.cinet.feature.calendar.schedule.ScheduleItem
+import com.example.cinet.feature.map.SearchLocationBar
 import java.text.SimpleDateFormat
 import java.util.*
+
+// Category key → display label pairs shown as filter chips above the search bar.
+private val locationCategories = listOf(
+    "academic"         to "Academic",
+    "dining"           to "Dining",
+    "commuter_parking" to "Parking",
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,33 +37,33 @@ fun StudyInviteDialog(
     onSendExisting: (ScheduleItem) -> Unit,
     onSendExistingSession: (StudySession) -> Unit = {},
     onSendNew: (className: String, assignmentName: String, date: String, time: String, location: String) -> Unit,
+    campusRegistryViewModel: CampusRegistry = viewModel<CampusRegistry>(),
 ) {
     val context = LocalContext.current
+
     // false = pick from existing, true = create new
     var isCreatingNew by remember { mutableStateOf(false) }
     var newClassName by remember { mutableStateOf("") }
     var newAssignmentName by remember { mutableStateOf("") }
     var newDate by remember { mutableStateOf("") }
     var newTime by remember { mutableStateOf("") }
-    var newLocation by remember { mutableStateOf("") }
     var searchQuery by remember { mutableStateOf("") }
-    var locationsByCategory by remember { mutableStateOf<Map<String, List<CampusLocation>>>(emptyMap()) }
-    var locationCategory by remember { mutableStateOf("academic") }
     var showDatePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
 
-    // Fetch campus locations once when the dialog opens
-    LaunchedEffect(Unit) {
-        try {
-            val db = FirebaseFirestore.getInstance()
-            val result = mutableMapOf<String, List<CampusLocation>>()
-            for (col in listOf("academic", "dining", "commuter_parking")) {
-                result[col] = db.collection(col).get().await()
-                    .toObjects(CampusLocation::class.java)
-                    .sortedBy { it.name }
-            }
-            locationsByCategory = result
-        } catch (_: Exception) { }
+    // Location state — shared ViewModel instead of a private Firestore fetch
+    val campusRegistry by campusRegistryViewModel.campusRegistry.collectAsState()
+    var locationCategory by remember { mutableStateOf("academic") }
+    val locationTextFieldState = rememberTextFieldState()
+
+    // Names in the selected category, filtered by whatever is typed
+    val filteredLocationNames = remember(
+        locationTextFieldState.text, locationCategory, campusRegistry
+    ) {
+        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+        categoryLocations
+            .filter { it.name.contains(locationTextFieldState.text.toString(), ignoreCase = true) }
+            .map { it.name }
     }
 
     if (showDatePicker) {
@@ -64,7 +72,6 @@ fun StudyInviteDialog(
             confirmButton = {
                 TextButton(onClick = {
                     datePickerState.selectedDateMillis?.let { millis ->
-                        // Format to yyyy-MM-dd to match CalendarFirestoreRepository date format
                         val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
                         sdf.timeZone = TimeZone.getTimeZone("UTC")
                         newDate = sdf.format(Date(millis))
@@ -86,7 +93,7 @@ fun StudyInviteDialog(
         text = {
             Column {
                 if (isCreatingNew) {
-                    // Option B — create new study session on the spot
+                    // ── Create new study session on the spot ──────────────────
                     OutlinedTextField(
                         value = newClassName,
                         onValueChange = { newClassName = it },
@@ -95,6 +102,7 @@ fun StudyInviteDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
+
                     OutlinedTextField(
                         value = newAssignmentName,
                         onValueChange = { newAssignmentName = it },
@@ -103,6 +111,7 @@ fun StudyInviteDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
+
                     OutlinedTextField(
                         value = newDate,
                         onValueChange = {},
@@ -114,10 +123,13 @@ fun StudyInviteDialog(
                             .clickable { showDatePicker = true }
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    Button(onClick = { showDatePicker = true }, modifier = Modifier.fillMaxWidth()) {
-                        Text("Pick Date")
-                    }
+
+                    Button(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) { Text("Pick Date") }
                     Spacer(modifier = Modifier.height(8.dp))
+
                     OutlinedTextField(
                         value = newTime,
                         onValueChange = {},
@@ -126,62 +138,47 @@ fun StudyInviteDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
+
                     Button(
                         onClick = { openTimePicker(context) { newTime = it } },
                         modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text("Pick Time")
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = newLocation,
-                        onValueChange = { newLocation = it },
-                        label = { Text("Location (optional)") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
+                    ) { Text("Pick Time") }
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // ── Location: category chips + search bar ─────────────────
+                    Text(
+                        text = "Location (optional)",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    if (locationsByCategory.isNotEmpty()) {
-                        Spacer(modifier = Modifier.height(6.dp))
-                        Text(
-                            text = "Campus locations",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        // Category filter chips
-                        Row(
-                            modifier = Modifier.horizontalScroll(rememberScrollState()),
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        ) {
-                            listOf("academic" to "Academic", "dining" to "Dining", "commuter_parking" to "Parking")
-                                .forEach { (key, label) ->
-                                    FilterChip(
-                                        selected = locationCategory == key,
-                                        onClick = { locationCategory = key },
-                                        label = { Text(label, style = MaterialTheme.typography.labelSmall) },
-                                    )
-                                }
-                        }
-                        val categoryLocations = locationsByCategory[locationCategory] ?: emptyList()
-                        if (categoryLocations.isNotEmpty()) {
-                            Spacer(modifier = Modifier.height(4.dp))
-                            // Tapping a suggestion fills the location field
-                            Row(
-                                modifier = Modifier.horizontalScroll(rememberScrollState()),
-                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            ) {
-                                categoryLocations.forEach { loc ->
-                                    SuggestionChip(
-                                        onClick = { newLocation = loc.name },
-                                        label = { Text(loc.name, style = MaterialTheme.typography.labelSmall) },
-                                    )
-                                }
-                            }
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Row(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        locationCategories.forEach { (key, label) ->
+                            FilterChip(
+                                selected = locationCategory == key,
+                                onClick = { locationCategory = key },
+                                label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+                            )
                         }
                     }
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    SearchLocationBar(
+                        textFieldState = locationTextFieldState,
+                        searchResults = filteredLocationNames,
+                        onSearch = { query ->
+                            locationTextFieldState.edit { replace(0, length, query) }
+                        }
+                    )
+
                 } else {
-                    // Option A — pick from existing calendar items
-                    val hasAnyItems = existingItems.isNotEmpty() || existingStudySessions.isNotEmpty()
+                    // ── Pick from existing calendar items ────────────────────
+                    val hasAnyItems =
+                        existingItems.isNotEmpty() || existingStudySessions.isNotEmpty()
 
                     OutlinedTextField(
                         value = searchQuery,
@@ -191,6 +188,7 @@ fun StudyInviteDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
                     Spacer(modifier = Modifier.height(8.dp))
+
                     if (!hasAnyItems) {
                         Text(
                             "No items found — create a new invite below.",
@@ -222,11 +220,13 @@ fun StudyInviteDialog(
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .padding(vertical = 4.dp)
-                                            // Tapping sends immediately without going to create mode
                                             .clickable { onSendExisting(item) }
                                     ) {
                                         Column(modifier = Modifier.padding(12.dp)) {
-                                            Text(text = item.className, style = MaterialTheme.typography.titleSmall)
+                                            Text(
+                                                text = item.className,
+                                                style = MaterialTheme.typography.titleSmall
+                                            )
                                             Text(text = item.assignmentName)
                                             Text(
                                                 text = "Due: ${item.dueTime} on ${item.date}",
@@ -256,7 +256,10 @@ fun StudyInviteDialog(
                                             .clickable { onSendExistingSession(session) }
                                     ) {
                                         Column(modifier = Modifier.padding(12.dp)) {
-                                            Text(text = session.className, style = MaterialTheme.typography.titleSmall)
+                                            Text(
+                                                text = session.className,
+                                                style = MaterialTheme.typography.titleSmall
+                                            )
                                             Text(text = session.topic)
                                             Text(
                                                 text = "${session.startTime} on ${session.date}",
@@ -270,6 +273,7 @@ fun StudyInviteDialog(
                             }
                         }
                     }
+
                     Spacer(modifier = Modifier.height(8.dp))
                     TextButton(onClick = { isCreatingNew = true }) {
                         Text("Create new instead")
@@ -284,14 +288,19 @@ fun StudyInviteDialog(
                         if (newClassName.isNotBlank() && newAssignmentName.isNotBlank()
                             && newDate.isNotBlank() && newTime.isNotBlank()
                         ) {
-                            onSendNew(newClassName, newAssignmentName, newDate, newTime, newLocation)
+                            onSendNew(
+                                newClassName,
+                                newAssignmentName,
+                                newDate,
+                                newTime,
+                                locationTextFieldState.text.toString(),
+                            )
                         }
                     }
                 ) { Text("Send") }
             }
         },
         dismissButton = {
-            // Back returns to picker, Cancel closes entirely
             TextButton(onClick = {
                 if (isCreatingNew) isCreatingNew = false else onDismiss()
             }) {

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -206,7 +207,7 @@ fun StudyInviteDialog(
                                     it.className.contains(searchQuery, ignoreCase = true) ||
                                     it.topic.contains(searchQuery, ignoreCase = true)
                         }
-                        LazyColumn {
+                        LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
                             if (filteredItems.isNotEmpty()) {
                                 item {
                                     Text(

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
@@ -1,26 +1,31 @@
 package com.example.cinet.feature.calendar.study
 
-
-import android.text.TextUtils.replace
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.cinet.feature.calendar.study.StudySession
+import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.SearchLocationBar
-import com.example.cinet.data.model.CampusRegistry
-import androidx.compose.runtime.getValue
+
+// Category key → display label pairs shown as filter chips above the search bar.
+private val locationCategories = listOf(
+    "academic"         to "Academic",
+    "dining"           to "Dining",
+    "commuter_parking" to "Parking",
+)
 
 @Composable
 fun StudySessionDialog(
@@ -39,13 +44,22 @@ fun StudySessionDialog(
     onDelete: (() -> Unit)?,
     viewModel: CampusRegistry = viewModel<CampusRegistry>()
 ) {
-    val academic by viewModel.academic.collectAsState(initial = emptyList())
+    // Full registry — contains academic, dining, commuter_parking, transit
+    val campusRegistry by viewModel.campusRegistry.collectAsState()
+
     val textFieldState = rememberTextFieldState()
-    val academicNames = remember(textFieldState.text, academic) {
-        academic
+
+    // Which category the user has selected (default: Academic)
+    var locationCategory by remember { mutableStateOf("academic") }
+
+    // Locations in the selected category, filtered by whatever is typed
+    val filteredNames = remember(textFieldState.text, locationCategory, campusRegistry) {
+        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+        categoryLocations
             .filter { it.name.contains(textFieldState.text.toString(), ignoreCase = true) }
             .map { it.name }
     }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(if (editingSession == null) "Add Study Session" else "Edit Study Session") },
@@ -53,6 +67,7 @@ fun StudySessionDialog(
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 Text("Date: $date")
                 Spacer(modifier = Modifier.height(12.dp))
+
                 OutlinedTextField(
                     value = className,
                     onValueChange = onClassNameChange,
@@ -60,6 +75,7 @@ fun StudySessionDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(8.dp))
+
                 OutlinedTextField(
                     value = topic,
                     onValueChange = onTopicChange,
@@ -67,6 +83,7 @@ fun StudySessionDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(8.dp))
+
                 OutlinedTextField(
                     value = startTime,
                     onValueChange = {},
@@ -75,13 +92,36 @@ fun StudySessionDialog(
                     readOnly = true
                 )
                 Spacer(modifier = Modifier.height(8.dp))
+
                 Button(onClick = onPickStartTime) { Text("Pick Start Time") }
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Category filter chips — Academic / Dining / Parking
+                Row(
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    locationCategories.forEach { (key, label) ->
+                        FilterChip(
+                            selected = locationCategory == key,
+                            onClick = {
+                                locationCategory = key
+                                // Clear selection when switching category
+                                onLocationChange(null)
+                            },
+                            label = { Text(label) },
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Search bar — results come from the selected category only
                 SearchLocationBar(
                     textFieldState = textFieldState,
-                    searchResults = academicNames,
+                    searchResults = filteredNames,
                     onSearch = { query ->
-                        val found = academic.find { it.name.equals(query, ignoreCase = true) }
+                        val categoryLocations = campusRegistry[locationCategory] ?: emptyList()
+                        val found = categoryLocations.find { it.name.equals(query, ignoreCase = true) }
                         onLocationChange(found)
                         textFieldState.edit { replace(0, length, query) }
                     }
@@ -98,7 +138,9 @@ fun StudySessionDialog(
                 if (onDelete != null) {
                     Button(
                         onClick = onDelete,
-                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        )
                     ) { Text("Delete") }
                 }
                 OutlinedButton(onClick = onDismiss) { Text("Cancel") }

--- a/app/src/main/java/com/example/cinet/feature/profile/ProfileEditScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/ProfileEditScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -22,24 +23,41 @@ import coil.request.ImageRequest
 import com.example.cinet.feature.profile.viewmodel.ProfileEditState
 import com.example.cinet.feature.profile.viewmodel.ProfileEditViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
+private val yearOptions = listOf(
+    "Freshman", "Sophomore", "Junior", "Senior", "Graduate", "Transfer"
+)
+
+private val interestOptions = listOf(
+    "Gaming", "Music", "Sports", "Fitness", "Art", "Photography",
+    "Cooking", "Reading", "Travel", "Hiking", "Movies", "Technology",
+    "Coffee", "Anime", "Dance", "Yoga", "Volunteering", "Study Groups"
+)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ProfileEditScreen(
     onBack: () -> Unit,
+    onSaved: () -> Unit = {},
     viewModel: ProfileEditViewModel = viewModel()
 ) {
     val profile by viewModel.profile.collectAsState()
-    val state   by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsState()
 
-    // Pre-fill fields from the loaded profile; resets if profile reloads
-    var nickname by remember(profile) { mutableStateOf(profile?.nickname  ?: "") }
-    var major    by remember(profile) { mutableStateOf(profile?.major     ?: "") }
-    var pronouns by remember(profile) { mutableStateOf(profile?.pronouns  ?: "") }
+    var nickname by remember(profile) { mutableStateOf(profile?.nickname ?: "") }
+    var major by remember(profile) { mutableStateOf(profile?.major ?: "") }
+    var pronouns by remember(profile) { mutableStateOf(profile?.pronouns ?: "") }
+    var year by remember(profile) { mutableStateOf(profile?.year ?: "") }
+    var bio by remember(profile) { mutableStateOf(profile?.bio ?: "") }
+    var selectedInterests by remember(profile) {
+        mutableStateOf(profile?.interests?.toSet() ?: emptySet())
+    }
+    var yearExpanded by remember { mutableStateOf(false) }
 
     // Navigate back automatically once save succeeds
     LaunchedEffect(state) {
         if (state is ProfileEditState.Success) {
             viewModel.resetState()
+            onSaved()
             onBack()
         }
     }
@@ -50,12 +68,12 @@ fun ProfileEditScreen(
                 title = { Text("Edit Profile") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                )
             )
         }
     ) { padding ->
@@ -68,24 +86,19 @@ fun ProfileEditScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(8.dp))
 
-            // Profile photo — pulled from Google account, display only
+            // Avatar (display only — upload coming later)
             val photoUrl = profile?.photoUrl?.takeIf { it.isNotBlank() }
             if (photoUrl != null) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
-                        .data(photoUrl)
-                        .crossfade(true)
-                        .build(),
+                        .data(photoUrl).crossfade(true).build(),
                     contentDescription = "Profile photo",
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(CircleShape)
+                    modifier = Modifier.size(100.dp).clip(CircleShape)
                 )
             } else {
-                // Fallback: circle with first letter of nickname
                 Box(
                     modifier = Modifier
                         .size(100.dp)
@@ -95,23 +108,18 @@ fun ProfileEditScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = profile?.nickname
-                            ?.firstOrNull()
-                            ?.uppercaseChar()
-                            ?.toString() ?: "?",
+                        text = profile?.nickname?.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                         style = MaterialTheme.typography.headlineLarge
                     )
                 }
             }
-
             Text(
                 "Profile photo synced from Google",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
-            Spacer(Modifier.height(8.dp))
-
+            // Nickname
             OutlinedTextField(
                 value = nickname,
                 onValueChange = { nickname = it },
@@ -120,6 +128,7 @@ fun ProfileEditScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
+            // Major
             OutlinedTextField(
                 value = major,
                 onValueChange = { major = it },
@@ -128,6 +137,7 @@ fun ProfileEditScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
+            // Pronouns
             OutlinedTextField(
                 value = pronouns,
                 onValueChange = { pronouns = it },
@@ -135,6 +145,79 @@ fun ProfileEditScreen(
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth()
             )
+
+            // Year dropdown
+            ExposedDropdownMenuBox(
+                expanded = yearExpanded,
+                onExpandedChange = { yearExpanded = it },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = year,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Year / Class Standing") },
+                    placeholder = { Text("Select year") },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = yearExpanded)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                )
+                ExposedDropdownMenu(
+                    expanded = yearExpanded,
+                    onDismissRequest = { yearExpanded = false }
+                ) {
+                    yearOptions.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = { year = option; yearExpanded = false }
+                        )
+                    }
+                }
+            }
+
+            // Bio
+            OutlinedTextField(
+                value = bio,
+                onValueChange = { if (it.length <= 150) bio = it },
+                label = { Text("Bio") },
+                placeholder = { Text("Tell other students a bit about yourself…") },
+                minLines = 3,
+                maxLines = 4,
+                supportingText = { Text("${bio.length}/150") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Interests
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Interests",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    interestOptions.forEach { interest ->
+                        FilterChip(
+                            selected = interest in selectedInterests,
+                            onClick = {
+                                selectedInterests = if (interest in selectedInterests)
+                                    selectedInterests - interest
+                                else
+                                    selectedInterests + interest
+                            },
+                            label = { Text(interest) }
+                        )
+                    }
+                }
+            }
 
             if (state is ProfileEditState.Error) {
                 Text(
@@ -144,14 +227,19 @@ fun ProfileEditScreen(
                 )
             }
 
-            Spacer(Modifier.height(8.dp))
-
             Button(
-                onClick = { viewModel.saveProfile(nickname, major, pronouns) },
+                onClick = {
+                    viewModel.saveProfile(
+                        nickname = nickname,
+                        major = major,
+                        pronouns = pronouns,
+                        year = year,
+                        bio = bio,
+                        interests = selectedInterests.toList()
+                    )
+                },
                 enabled = state !is ProfileEditState.Loading && nickname.isNotBlank(),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(50.dp)
+                modifier = Modifier.fillMaxWidth().height(50.dp)
             ) {
                 if (state is ProfileEditState.Loading) {
                     CircularProgressIndicator(

--- a/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
@@ -1,136 +1,331 @@
 package com.example.cinet.feature.profile
 
-import androidx.compose.runtime.remember
-import kotlinx.coroutines.launch
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.model.UserProfile
 import com.example.cinet.data.remote.SocialRepository
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun ProfileScreen(
     user: UserProfile,
     currentUserProfile: UserProfile,
     onOpenConversation: (Conversation) -> Unit,
     onBack: () -> Unit,
+    onEditProfile: () -> Unit = {},
 ) {
+    val isOwnProfile = user.uid == currentUserProfile.uid
     val repository = remember { SocialRepository() }
     val scope = rememberCoroutineScope()
 
     var isFriend by remember { mutableStateOf(false) }
+    var requestSent by remember { mutableStateOf(false) }
+    var isLoadingAction by remember { mutableStateOf(false) }
 
-    // Check friendship status on load
     LaunchedEffect(user.uid) {
-        repository.getFriends().onSuccess { friends ->
-            isFriend = friends.any { it.uid == user.uid }
+        if (!isOwnProfile) {
+            repository.getFriends().onSuccess { friends ->
+                isFriend = friends.any { it.uid == user.uid }
+            }
+            repository.getSentRequests().onSuccess { requests ->
+                requestSent = requests.any { it.receiverId == user.uid }
+            }
         }
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
-    ) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                )
+            )
+        }
+    ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(32.dp),
+                .padding(padding)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
         ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
             // Avatar
             val photoUrl = user.photoUrl.takeIf { it.isNotBlank() }
             if (photoUrl != null) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
-                        .data(photoUrl)
-                        .crossfade(true)
-                        .build(),
+                        .data(photoUrl).crossfade(true).build(),
                     contentDescription = "Profile photo",
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .size(96.dp)
+                        .size(108.dp)
                         .clip(CircleShape)
-                        .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape)
                 )
             } else {
                 Box(
                     modifier = Modifier
-                        .size(96.dp)
+                        .size(108.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.secondaryContainer)
-                        .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                        .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = user.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = MaterialTheme.typography.displaySmall,
                         color = MaterialTheme.colorScheme.onSecondaryContainer
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(text = user.nickname, style = MaterialTheme.typography.headlineMedium)
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = user.pronouns,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = user.major,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(32.dp))
 
-            if (isFriend) {
-                Button(
-                    onClick = {
-                        // Use GlobalScope so the coroutine survives navigation away from this screen
-                        kotlinx.coroutines.GlobalScope.launch {
-                            repository.getOrCreateConversation(
-                                participantIds = listOf(currentUserProfile.uid, user.uid),
-                                participantNicknames = mapOf(
-                                    currentUserProfile.uid to currentUserProfile.nickname,
-                                    user.uid to user.nickname
-                                )
-                            ).onSuccess { onOpenConversation(it) }
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Message")
-                }
-            } else {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Name
+            Text(
+                text = user.nickname,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+
+            // Pronouns
+            if (user.pronouns.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    text = "Add ${user.nickname} as a friend to send a message",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    text = user.pronouns,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(
-                onClick = onBack,
-                modifier = Modifier.fillMaxWidth()
+            // Bio
+            if (user.bio.isNotBlank()) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = user.bio,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 32.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // Info cards — Major and Year
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Text("Back")
+                if (user.major.isNotBlank()) {
+                    ProfileInfoCard(
+                        icon = {
+                            Icon(
+                                Icons.Default.Person,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
+                        label = "Major",
+                        value = user.major
+                    )
+                }
+                if (user.year.isNotBlank()) {
+                    ProfileInfoCard(
+                        icon = {
+                            Icon(
+                                Icons.Default.School,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
+                        label = "Year",
+                        value = user.year
+                    )
+                }
+            }
+
+            // Interests chips
+            if (user.interests.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(20.dp))
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "Interests",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        user.interests.forEach { interest ->
+                            SuggestionChip(
+                                onClick = {},
+                                label = { Text(interest) }
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // Action buttons
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (isOwnProfile) {
+                    Button(
+                        onClick = onEditProfile,
+                        modifier = Modifier.fillMaxWidth().height(50.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Edit Profile")
+                    }
+                } else {
+                    if (isFriend) {
+                        Button(
+                            onClick = {
+                                isLoadingAction = true
+                                scope.launch {
+                                    repository.getOrCreateConversation(
+                                        participantIds = listOf(
+                                            currentUserProfile.uid, user.uid
+                                        ),
+                                        participantNicknames = mapOf(
+                                            currentUserProfile.uid to currentUserProfile.nickname,
+                                            user.uid to user.nickname
+                                        )
+                                    ).onSuccess { onOpenConversation(it) }
+                                    isLoadingAction = false
+                                }
+                            },
+                            enabled = !isLoadingAction,
+                            modifier = Modifier.fillMaxWidth().height(50.dp)
+                        ) {
+                            if (isLoadingAction) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    color = MaterialTheme.colorScheme.onPrimary,
+                                    strokeWidth = 2.dp
+                                )
+                            } else {
+                                Text("Message")
+                            }
+                        }
+                    } else {
+                        Button(
+                            onClick = {
+                                if (!requestSent) {
+                                    isLoadingAction = true
+                                    scope.launch {
+                                        repository.sendFriendRequest(user).onSuccess {
+                                            requestSent = true
+                                        }
+                                        isLoadingAction = false
+                                    }
+                                }
+                            },
+                            enabled = !requestSent && !isLoadingAction,
+                            modifier = Modifier.fillMaxWidth().height(50.dp)
+                        ) {
+                            Text(
+                                when {
+                                    isLoadingAction -> "Sending..."
+                                    requestSent -> "Request Sent"
+                                    else -> "Add Friend"
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun ProfileInfoCard(
+    icon: @Composable () -> Unit,
+    label: String,
+    value: String,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 2.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            icon()
+            Column {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
@@ -2,6 +2,14 @@ package com.example.cinet.feature.profile
 
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.launch
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -43,6 +51,38 @@ fun ProfileScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            // Avatar
+            val photoUrl = user.photoUrl.takeIf { it.isNotBlank() }
+            if (photoUrl != null) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(photoUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "Profile photo",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(96.dp)
+                        .clip(CircleShape)
+                        .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(96.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                        .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = user.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                        style = MaterialTheme.typography.headlineMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
             Text(text = user.nickname, style = MaterialTheme.typography.headlineMedium)
             Spacer(modifier = Modifier.height(4.dp))
             Text(

--- a/app/src/main/java/com/example/cinet/feature/profile/viewmodel/ProfileEditViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/viewmodel/ProfileEditViewModel.kt
@@ -51,6 +51,9 @@ class ProfileEditViewModel(
                     _state.value = ProfileEditState.Error(it.message ?: "Save failed")
                     return@launch
                 }
+                // Reload so the next edit session shows fresh data rather than
+                // the pre-save snapshot the ViewModel was holding in memory.
+                _profile.value = repo.loadCurrentUserProfile()
                 _state.value = ProfileEditState.Success
             } catch (e: Exception) {
                 _state.value = ProfileEditState.Error(e.message ?: "Save failed")

--- a/app/src/main/java/com/example/cinet/feature/profile/viewmodel/ProfileEditViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/viewmodel/ProfileEditViewModel.kt
@@ -35,11 +35,18 @@ class ProfileEditViewModel(
         }
     }
 
-    fun saveProfile(nickname: String, major: String, pronouns: String) {
+    fun saveProfile(
+        nickname: String,
+        major: String,
+        pronouns: String,
+        year: String = "",
+        bio: String = "",
+        interests: List<String> = emptyList(),
+    ) {
         _state.value = ProfileEditState.Loading
         viewModelScope.launch {
             try {
-                val result = repo.saveProfileDetails(nickname, major, pronouns)
+                val result = repo.saveProfileDetails(nickname, major, pronouns, year, bio, interests)
                 result.onFailure {
                     _state.value = ProfileEditState.Error(it.message ?: "Save failed")
                     return@launch

--- a/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
+++ b/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
@@ -11,6 +11,19 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.cinet.data.model.UserProfile
 import com.example.cinet.ui.theme.AppThemeColor
 import com.example.cinet.ui.theme.ThemeSelector
 
@@ -34,6 +47,8 @@ fun SettingScreen(
     notificationsEnabled: Boolean,
     selectedTheme: AppThemeColor,
     onSettingsChange: (Boolean, Boolean, AppThemeColor) -> Unit,
+    userProfile: UserProfile? = null,
+    onViewProfile: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -41,6 +56,79 @@ fun SettingScreen(
             .padding(16.dp),
         horizontalAlignment = Alignment.Start
     ) {
+        // Profile header card - tap to view own profile
+        if (userProfile != null) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+                    .clickable { onViewProfile() },
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                tonalElevation = 2.dp
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    val photoUrl = userProfile.photoUrl.takeIf { it.isNotBlank() }
+                    if (photoUrl != null) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(photoUrl).crossfade(true).build(),
+                            contentDescription = "Profile photo",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(52.dp)
+                                .clip(CircleShape)
+                                .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(52.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.secondaryContainer)
+                                .border(2.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = userProfile.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        }
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = userProfile.nickname,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        if (userProfile.major.isNotBlank()) {
+                            Text(
+                                text = userProfile.major,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Text(
+                            text = "View Profile",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    Icon(
+                        Icons.Default.Person,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+
         // Header section
         Row(
             modifier = Modifier
@@ -115,7 +203,7 @@ fun SettingScreen(
             Switch(
                 checked = notificationsEnabled,
                 onCheckedChange = { newValue ->
-                    onSettingsChange(isDarkMode, newValue, selectedTheme)
+                    onSettingsChange(newValue, notificationsEnabled, selectedTheme)
                 }
             )
         }

--- a/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
+++ b/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
@@ -115,7 +115,7 @@ fun SettingScreen(
             Switch(
                 checked = notificationsEnabled,
                 onCheckedChange = { newValue ->
-                    onSettingsChange(newValue, notificationsEnabled, selectedTheme)
+                    onSettingsChange(isDarkMode, newValue, selectedTheme)
                 }
             )
         }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -32,12 +32,12 @@ import com.example.cinet.feature.calendar.calendarFiles.CalendarFirestoreReposit
 import com.example.cinet.feature.calendar.event.EventItem
 import com.example.cinet.feature.calendar.schedule.ScheduleItem
 import com.example.cinet.feature.calendar.study.StudySession
+import com.example.cinet.feature.calendar.study.StudyInviteDialog
+import com.example.cinet.feature.calendar.event.EventInviteSenderDialog
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import com.example.cinet.feature.calendar.study.*
-import com.example.cinet.feature.calendar.event.*
 
 @Composable
 fun ConversationScreen(
@@ -67,6 +67,19 @@ fun ConversationScreen(
     var myEvents by remember { mutableStateOf<List<EventItem>>(emptyList()) }
     var otherUserPhotoUrl by remember { mutableStateOf("") }
     var currentUserPhotoUrl by remember { mutableStateOf("") }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Returns true if the same invite was sent in this conversation within
+    // the last 5 minutes, preventing accidental double-sends.
+    fun isDuplicateInvite(type: String, name: String, date: String): Boolean {
+        val fiveMinutesAgo = System.currentTimeMillis() - 5 * 60 * 1000L
+        return messages.any { msg ->
+            msg.type == type &&
+                    (msg.metadata["name"] ?: msg.metadata["className"] ?: "") == name &&
+                    (msg.metadata["date"] ?: "") == date &&
+                    (msg.createdAt?.time ?: 0L) >= fiveMinutesAgo
+        }
+    }
 
     val otherUid = conversation.participantIds.firstOrNull { it != currentUid } ?: ""
 
@@ -186,234 +199,263 @@ fun ConversationScreen(
         )
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
-    ) {
-        Column(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
 
-            // Header
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // iOS-style back: bare chevron + conversation count pill
+                // Header
                 Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.clickable(onClick = onBack),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.ChevronLeft,
-                        contentDescription = "Back",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(32.dp),
-                    )
-                    if (conversationCount > 0) {
-                        Surface(
-                            shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
-                            color = MaterialTheme.colorScheme.primary,
+                    // iOS-style back: bare chevron + conversation count pill
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.clickable(onClick = onBack),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ChevronLeft,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(32.dp),
+                        )
+                        if (conversationCount > 0) {
+                            Surface(
+                                shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+                                color = MaterialTheme.colorScheme.primary,
+                            ) {
+                                Text(
+                                    text = conversationCount.toString(),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onPrimary,
+                                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                )
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    // Avatar — uses secondaryContainer for consistent green branding
+                    val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() && !conversation.isGroup }
+                    if (headerPhoto != null) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(headerPhoto)
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = "Profile photo",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.secondaryContainer)
+                                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                            contentAlignment = Alignment.Center
                         ) {
                             Text(
-                                text = conversationCount.toString(),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onPrimary,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                text = conversationTitle.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                style = MaterialTheme.typography.titleMedium
                             )
                         }
                     }
-                }
-                Spacer(modifier = Modifier.width(12.dp))
 
-                // Avatar — uses secondaryContainer for consistent green branding
-                val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() && !conversation.isGroup }
-                if (headerPhoto != null) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(headerPhoto)
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = "Profile photo",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                            .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
-                    )
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.secondaryContainer)
-                            .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
-                        contentAlignment = Alignment.Center
-                    ) {
+                    Spacer(modifier = Modifier.width(10.dp))
+
+                    // Group name is tappable to rename; DM name is static
+                    if (conversation.isGroup) {
                         Text(
-                            text = conversationTitle.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
-                            style = MaterialTheme.typography.titleMedium
+                            text = conversationTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier
+                                .weight(1f)
+                                .clickable {
+                                    renameInput = displayGroupName
+                                    showRenameDialog = true
+                                }
                         )
+                    } else {
+                        Text(
+                            text = conversationTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+
+                    // Remove Friend button — only for direct (non-group) conversations
+                    if (!conversation.isGroup && otherUid.isNotBlank()) {
+                        OutlinedButton(
+                            onClick = { showRemoveFriendDialog = true },
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error
+                            )
+                        ) {
+                            Text("Remove Friend", style = MaterialTheme.typography.labelSmall)
+                        }
                     }
                 }
 
-                Spacer(modifier = Modifier.width(10.dp))
+                HorizontalDivider()
 
-                // Group name is tappable to rename; DM name is static
-                if (conversation.isGroup) {
-                    Text(
-                        text = conversationTitle,
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier
-                            .weight(1f)
-                            .clickable {
-                                renameInput = displayGroupName
-                                showRenameDialog = true
-                            }
-                    )
-                } else {
-                    Text(
-                        text = conversationTitle,
-                        style = MaterialTheme.typography.titleLarge,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-
-                // Remove Friend button — only for direct (non-group) conversations
-                if (!conversation.isGroup && otherUid.isNotBlank()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     OutlinedButton(
-                        onClick = { showRemoveFriendDialog = true },
-                        colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error
-                        )
-                    ) {
-                        Text("Remove Friend", style = MaterialTheme.typography.labelSmall)
-                    }
-                }
-            }
-
-            HorizontalDivider()
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                OutlinedButton(
-                    onClick = {
-                        scope.launch {
-                            repository.getMyScheduleItems().onSuccess { myScheduleItems = it }
-                            repository.getMyStudySessions().onSuccess { myStudySessions = it }
-                            showStudyInviteDialog = true
-                        }
-                    }
-                ) {
-                    Text("Study Invite", style = MaterialTheme.typography.labelSmall)
-                }
-                OutlinedButton(
-                    onClick = {
-                        scope.launch {
-                            repository.getMyEvents().onSuccess { myEvents = it }
-                            showEventInviteDialog = true
-                        }
-                    }
-                ) {
-                    Text("Event Invite", style = MaterialTheme.typography.labelSmall)
-                }
-            }
-
-            HorizontalDivider()
-
-            LazyColumn(
-                state = listState,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(messages) { message ->
-                    val alreadyResponded = message.metadata["response"] != null
-                    MessageBubble(
-                        message = message,
-                        isCurrentUser = message.senderId == currentUid,
-                        currentUserPhotoUrl = currentUserPhotoUrl,
-                        onNavigateToLocation = onNavigateToLocation,
-                        onAccept = if (!alreadyResponded && message.senderId != currentUid &&
-                            (message.type == "study_invite" || message.type == "event_invite")) {
-                            {
-                                scope.launch {
-                                    if (message.type == "study_invite") {
-                                        val className = message.metadata["className"] ?: ""
-                                        val topic = message.metadata["topic"] ?: ""
-                                        val date = message.metadata["date"] ?: ""
-                                        val time = message.metadata["time"] ?: ""
-                                        val location = message.metadata["location"] ?: ""
-                                        android.util.Log.d("CalendarSave", "Saving study session: $className $topic $date $time")
-                                        if (date.isNotBlank()) {
-                                            android.util.Log.d("CalendarSave", "metadata: ${message.metadata}")
-                                            android.util.Log.d("CalendarSave", "date: ${message.metadata["date"]}")
-                                            calendarRepository.addStudySession(date, className, topic, time, location)
-                                            android.util.Log.d("CalendarSave", "Study session saved successfully")
-                                        } else {
-                                            android.util.Log.e("CalendarSave", "Date is blank — metadata: ${message.metadata}")
-                                        }
-                                    } else {
-                                        val name = message.metadata["name"] ?: ""
-                                        val date = message.metadata["date"] ?: ""
-                                        val time = message.metadata["time"] ?: ""
-                                        val location = message.metadata["location"] ?: ""
-                                        if (date.isNotBlank()) {
-                                            calendarRepository.addEvent(date, name, time, location)
-                                        }
-                                    }
-                                    repository.respondToInvite(conversation.id, message.id, "accepted")
-                                    repository.sendMessage(conversation.id, "Accepted your invite!", "text")
-                                }
-                            }
-                        } else null,
-                        onDecline = if (!alreadyResponded && message.senderId != currentUid &&
-                            (message.type == "study_invite" || message.type == "event_invite")) {
-                            {
-                                scope.launch {
-                                    repository.respondToInvite(conversation.id, message.id, "declined")
-                                    repository.sendMessage(conversation.id, "Declined your invite.", "text")
-                                }
-                            }
-                        } else null
-                    )
-                }
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                OutlinedTextField(
-                    value = messageInput,
-                    onValueChange = { messageInput = it },
-                    label = { Text("Message") },
-                    modifier = Modifier.weight(1f),
-                    singleLine = true
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = {
-                        val content = messageInput.trim()
-                        if (content.isNotBlank()) {
+                        onClick = {
                             scope.launch {
-                                repository.sendMessage(conversation.id, content)
-                                messageInput = ""
+                                repository.getMyScheduleItems().onSuccess { myScheduleItems = it }
+                                repository.getMyStudySessions().onSuccess { myStudySessions = it }
+                                showStudyInviteDialog = true
                             }
                         }
+                    ) {
+                        Text("Study Invite", style = MaterialTheme.typography.labelSmall)
                     }
-                ) { Text("Send") }
+                    OutlinedButton(
+                        onClick = {
+                            scope.launch {
+                                repository.getMyEvents().onSuccess { myEvents = it }
+                                showEventInviteDialog = true
+                            }
+                        }
+                    ) {
+                        Text("Event Invite", style = MaterialTheme.typography.labelSmall)
+                    }
+                }
+
+                HorizontalDivider()
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(messages) { message ->
+                        val alreadyResponded = message.metadata["response"] != null
+                        MessageBubble(
+                            message = message,
+                            isCurrentUser = message.senderId == currentUid,
+                            currentUserPhotoUrl = currentUserPhotoUrl,
+                            onNavigateToLocation = onNavigateToLocation,
+                            onAccept = if (!alreadyResponded && message.senderId != currentUid &&
+                                (message.type == "study_invite" || message.type == "event_invite")) {
+                                {
+                                    scope.launch {
+                                        if (message.type == "study_invite") {
+                                            val className = message.metadata["className"] ?: ""
+                                            val topic = message.metadata["topic"] ?: ""
+                                            val date = message.metadata["date"] ?: ""
+                                            val time = message.metadata["time"] ?: ""
+                                            val location = message.metadata["location"] ?: ""
+                                            android.util.Log.d("CalendarSave", "Saving study session: $className $topic $date $time")
+                                            if (date.isNotBlank()) {
+                                                android.util.Log.d("CalendarSave", "metadata: ${message.metadata}")
+                                                android.util.Log.d("CalendarSave", "date: ${message.metadata["date"]}")
+                                                calendarRepository.addStudySession(date, className, topic, time, location)
+                                                android.util.Log.d("CalendarSave", "Study session saved successfully")
+                                            } else {
+                                                android.util.Log.e("CalendarSave", "Date is blank — metadata: ${message.metadata}")
+                                            }
+                                        } else {
+                                            val name = message.metadata["name"] ?: ""
+                                            val date = message.metadata["date"] ?: ""
+                                            val time = message.metadata["time"] ?: ""
+                                            val location = message.metadata["location"] ?: ""
+                                            if (date.isNotBlank()) {
+                                                calendarRepository.addEvent(date, name, time, location)
+                                            }
+                                        }
+                                        repository.respondToInvite(conversation.id, message.id, "accepted")
+                                        repository.sendMessage(conversation.id, "Accepted your invite!", "text")
+                                    }
+                                }
+                            } else null,
+                            onDecline = if (!alreadyResponded && message.senderId != currentUid &&
+                                (message.type == "study_invite" || message.type == "event_invite")) {
+                                {
+                                    scope.launch {
+                                        repository.respondToInvite(conversation.id, message.id, "declined")
+                                        repository.sendMessage(conversation.id, "Declined your invite.", "text")
+                                    }
+                                }
+                            } else null
+                        )
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = messageInput,
+                        onValueChange = { messageInput = it },
+                        label = { Text("Message") },
+                        modifier = Modifier.weight(1f),
+                        singleLine = true
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = {
+                            val content = messageInput.trim()
+                            if (content.isNotBlank()) {
+                                scope.launch {
+                                    repository.sendMessage(conversation.id, content)
+                                    messageInput = ""
+                                }
+                            }
+                        }
+                    ) { Text("Send") }
+                }
             }
         }
-    }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 80.dp)
+                .padding(horizontal = 16.dp)
+        ) { data ->
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.inverseSurface,
+                tonalElevation = 6.dp,
+                shadowElevation = 8.dp,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = data.visuals.message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                    )
+                }
+            }
+        }
+    } // outer Box
 
     if (showStudyInviteDialog) {
         StudyInviteDialog(
@@ -422,6 +464,11 @@ fun ConversationScreen(
             onDismiss = { showStudyInviteDialog = false },
             onSendExisting = { item ->
                 scope.launch {
+                    if (isDuplicateInvite("study_invite", item.className, item.date)) {
+                        showStudyInviteDialog = false
+                        snackbarHostState.showSnackbar("Already sent this study invite recently — try again in a few minutes.")
+                        return@launch
+                    }
                     val content = "Study invite: ${item.className} — ${item.assignmentName} on ${item.date} at ${item.dueTime}"
                     repository.sendMessage(
                         conversationId = conversation.id,
@@ -444,6 +491,11 @@ fun ConversationScreen(
             },
             onSendExistingSession = { session ->
                 scope.launch {
+                    if (isDuplicateInvite("study_invite", session.className, session.date)) {
+                        showStudyInviteDialog = false
+                        snackbarHostState.showSnackbar("Already sent this study invite recently — try again in a few minutes.")
+                        return@launch
+                    }
                     val content = "Study invite: ${session.className} — ${session.topic} on ${session.date} at ${session.startTime}"
                     repository.sendMessage(
                         conversationId = conversation.id,
@@ -463,6 +515,11 @@ fun ConversationScreen(
             },
             onSendNew = { cls, topic, date, time, location ->
                 scope.launch {
+                    if (isDuplicateInvite("study_invite", cls, date)) {
+                        showStudyInviteDialog = false
+                        snackbarHostState.showSnackbar("Already sent this study invite recently — try again in a few minutes.")
+                        return@launch
+                    }
                     val content = "Study invite: $cls — $topic on $date at $time"
                     repository.sendMessage(
                         conversationId = conversation.id,
@@ -486,6 +543,11 @@ fun ConversationScreen(
             onDismiss = { showEventInviteDialog = false },
             onSend = { name, date, time, location ->
                 scope.launch {
+                    if (isDuplicateInvite("event_invite", name, date)) {
+                        showEventInviteDialog = false
+                        snackbarHostState.showSnackbar("Already sent this invite recently — try again in a few minutes.")
+                        return@launch
+                    }
                     val content = "Event invite: $name on $date at $time"
                     repository.sendMessage(
                         conversationId = conversation.id,
@@ -870,7 +932,7 @@ fun LocationShareBubble(
                     onClick = { onNavigateToLocation(locationName) },
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.secondary
+                        containerColor = MaterialTheme.colorScheme.primary
                     )
                 ) {
                     Text("View on Map")

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -37,7 +37,9 @@ fun ConversationsListScreen(
     onNewConversation: () -> Unit,
     onOpenFriends: () -> Unit,
     sessionStartTime: Long = 0L,
-    openedConversationIds: Set<String> = emptySet(),
+    // Maps conversationId -> timestamp when it was last opened this session.
+    // A message arriving AFTER that timestamp shows a dot even for opened convos.
+    openedConversationTimestamps: Map<String, Long> = emptyMap(),
 ) {
     val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val repository = remember { SocialRepository() }
@@ -54,7 +56,6 @@ fun ConversationsListScreen(
             .addSnapshotListener { snapshot, _ ->
                 if (snapshot != null) {
                     conversations = snapshot.toObjects(Conversation::class.java)
-                        .filter { it.active }  // hide deactivated (unfriended) conversations
                         .sortedByDescending { it.lastUpdated?.time ?: 0L }
                     isLoading = false
                 }
@@ -153,9 +154,13 @@ fun ConversationsListScreen(
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(conversations, key = { it.id }) { conversation ->
-                        val hasUnread = conversation.id !in openedConversationIds &&
-                                (conversation.lastUpdated?.time ?: 0L) > sessionStartTime &&
-                                conversation.lastMessage.isNotBlank()
+                        // Baseline: the later of sessionStartTime or when this convo
+                        // was last opened. A message after that timestamp = unread.
+                        val openedAt = openedConversationTimestamps[conversation.id] ?: 0L
+                        val baseline = maxOf(sessionStartTime, openedAt)
+                        val hasUnread = (conversation.lastUpdated?.time ?: 0L) > baseline &&
+                                conversation.lastMessage.isNotBlank() &&
+                                conversation.lastSenderId != currentUid
                         ConversationListItem(
                             conversation = conversation,
                             currentUid = currentUid,

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -54,6 +54,7 @@ fun ConversationsListScreen(
             .addSnapshotListener { snapshot, _ ->
                 if (snapshot != null) {
                     conversations = snapshot.toObjects(Conversation::class.java)
+                        .filter { it.active }  // hide deactivated (unfriended) conversations
                         .sortedByDescending { it.lastUpdated?.time ?: 0L }
                     isLoading = false
                 }

--- a/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
@@ -189,10 +189,10 @@ fun SocialScreen(
                         }
                     } else {
                         items(friends) { friend ->
-                            // Friends tap straight to conversation
+                            // Tap opens profile; message button is on the profile screen
                             UserRow(
                                 user = friend,
-                                onClick = { onOpenConversation(friend) }
+                                onClick = { onOpenProfile(friend) }
                             )
                             HorizontalDivider()
                         }

--- a/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
@@ -25,6 +25,8 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import androidx.compose.foundation.layout.size
 import com.example.cinet.core.designsystem.PullToRefreshContainer
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
 
 @Composable
 fun SocialScreen(
@@ -203,51 +205,80 @@ fun SocialScreen(
                             Spacer(modifier = Modifier.height(8.dp))
                         }
                         items(sentRequests) { request ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 8.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                // Initials fallback only — sent requests don't carry photoUrl
-                                Box(
-                                    modifier = Modifier
-                                        .size(44.dp)
-                                        .clip(CircleShape)
-                                        .background(MaterialTheme.colorScheme.secondaryContainer)
-                                        .border(
-                                            width = 1.5.dp,
-                                            color = MaterialTheme.colorScheme.primary,
-                                            shape = CircleShape
-                                        ),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    val nickname = request.receiverNickname.ifBlank { "?" }
-                                    Text(
-                                        text = nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
-                                        style = MaterialTheme.typography.titleMedium
-                                    )
-                                }
-
-                                Spacer(modifier = Modifier.width(12.dp))
-
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = request.receiverNickname.ifBlank { request.receiverId },
-                                        style = MaterialTheme.typography.bodyLarge
-                                    )
-                                    Text(
-                                        text = "Request pending",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
+                            SentRequestRow(request = request)
                             HorizontalDivider()
                         }
                     }
                 }
             }
+        }
+    }
+}
+
+// Fetches the receiver's photo from Firestore on first render.
+@Composable
+private fun SentRequestRow(request: com.example.cinet.data.model.FriendRequest) {
+    var receiverPhotoUrl by remember(request.receiverId) { mutableStateOf("") }
+
+    LaunchedEffect(request.receiverId) {
+        try {
+            val snap = FirebaseFirestore.getInstance()
+                .collection("users")
+                .document(request.receiverId)
+                .get()
+                .await()
+            receiverPhotoUrl = snap.getString("photoUrl") ?: ""
+        } catch (_: Exception) {}
+    }
+
+    val nickname = request.receiverNickname.ifBlank { "?" }
+    val initial = nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val photoUrl = receiverPhotoUrl.takeIf { it.isNotBlank() }
+        if (photoUrl != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(photoUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "Profile photo",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer)
+                    .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = initial, style = MaterialTheme.typography.titleMedium)
+            }
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = request.receiverNickname.ifBlank { request.receiverId },
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Text(
+                text = "Request pending",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/SocialScreen.kt
@@ -37,7 +37,6 @@ fun SocialScreen(
     var friends by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
     var pendingRequests by remember { mutableStateOf<List<FriendRequest>>(emptyList()) }
     var sentRequests by remember { mutableStateOf<List<FriendRequest>>(emptyList()) }
-    var sentRequestNicknames by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var searchQuery by remember { mutableStateOf("") }
     var searchResults by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
@@ -49,14 +48,7 @@ fun SocialScreen(
         if (refreshKey > 0) isRefreshing = true
         repository.getFriends().onSuccess { friends = it }
         repository.getPendingRequests().onSuccess { pendingRequests = it }
-        repository.getSentRequests().onSuccess { requests ->
-            sentRequests = requests
-            val nicknames = mutableMapOf<String, String>()
-            requests.forEach { request ->
-                nicknames[request.receiverId] = repository.getUserNickname(request.receiverId)
-            }
-            sentRequestNicknames = nicknames
-        }
+        repository.getSentRequests().onSuccess { sentRequests = it }
         isLoading = false
         isRefreshing = false
     }
@@ -124,16 +116,10 @@ fun SocialScreen(
                                 trailingContent = {
                                     OutlinedButton(onClick = {
                                         scope.launch {
-                                            repository.sendFriendRequest(user)
-                                            searchResults = searchResults - user
-                                            repository.getSentRequests().onSuccess { requests ->
-                                                sentRequests = requests
-                                                val nicknames = mutableMapOf<String, String>()
-                                                requests.forEach { request ->
-                                                    nicknames[request.receiverId] =
-                                                        repository.getUserNickname(request.receiverId)
-                                                }
-                                                sentRequestNicknames = nicknames
+                                            val result = repository.sendFriendRequest(user)
+                                            if (result.isSuccess) {
+                                                searchResults = searchResults - user
+                                                repository.getSentRequests().onSuccess { sentRequests = it }
                                             }
                                         }
                                     }) {
@@ -236,7 +222,7 @@ fun SocialScreen(
                                         ),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    val nickname = sentRequestNicknames[request.receiverId] ?: "?"
+                                    val nickname = request.receiverNickname.ifBlank { "?" }
                                     Text(
                                         text = nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
                                         style = MaterialTheme.typography.titleMedium
@@ -247,7 +233,7 @@ fun SocialScreen(
 
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        text = sentRequestNicknames[request.receiverId] ?: request.receiverId,
+                                        text = request.receiverNickname.ifBlank { request.receiverId },
                                         style = MaterialTheme.typography.bodyLarge
                                     )
                                     Text(

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -217,7 +217,7 @@ private fun MainScaffold(
             (activeConversation != null || selectedProfile != null ||
                     showNewConversation || showSocialScreen)
 
-    BackHandler(enabled = currentScreen != Screen.Home || socialBackStackActive || showProfileEdit || isShowingNews) {
+    BackHandler(enabled = currentScreen != Screen.Home || socialBackStackActive || showProfileEdit || isShowingNews || selectedProfile != null) {
         when {
             selectedNewsArticle != null -> {
                 selectedNewsArticle = null
@@ -350,10 +350,11 @@ private fun MainScaffold(
                             }
                         )
                         selectedProfile != null -> ProfileScreen(
-                            user = selectedProfile!!,
+                            user = if (selectedProfile!!.uid == userProfile.uid) userProfile else selectedProfile!!,
                             currentUserProfile = userProfile,
                             onOpenConversation = { activeConversation = it },
-                            onBack = { selectedProfile = null }
+                            onBack = { selectedProfile = null },
+                            onEditProfile = { showProfileEdit = true },
                         )
                         showNewConversation -> NewConversationScreen(
                             currentUserProfile = userProfile,
@@ -417,7 +418,20 @@ private fun MainScaffold(
 
                     Screen.Settings -> if (showProfileEdit) {
                         ProfileEditScreen(
-                            onBack = { showProfileEdit = false }
+                            onBack = { showProfileEdit = false },
+                            onSaved = { authViewModel.silentReloadProfile() },
+                        )
+                    } else if (selectedProfile != null) {
+                        // For own profile, pass userProfile (live) so saved changes
+                        // are reflected immediately without needing a refresh.
+                        val displayProfile = if (selectedProfile!!.uid == userProfile.uid)
+                            userProfile else selectedProfile!!
+                        ProfileScreen(
+                            user = displayProfile,
+                            currentUserProfile = userProfile,
+                            onOpenConversation = { activeConversation = it; currentScreen = Screen.Social },
+                            onBack = { selectedProfile = null },
+                            onEditProfile = { showProfileEdit = true },
                         )
                     } else {
                         SettingScreen(
@@ -428,7 +442,9 @@ private fun MainScaffold(
                             selectedTheme = AppSettings.selectedTheme,
                             onSettingsChange = { dark, notify, theme ->
                                 authViewModel.updateSettings(dark, notify, theme)
-                            }
+                            },
+                            userProfile = userProfile,
+                            onViewProfile = { selectedProfile = userProfile },
                         )
                     }
                 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -57,6 +57,7 @@ import com.example.cinet.feature.social.ConversationsListScreen
 import com.example.cinet.feature.social.NewConversationScreen
 import com.example.cinet.feature.social.SocialScreen
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import java.util.Calendar
 import java.util.Locale
 
@@ -73,7 +74,9 @@ fun NavigationHandler(
     authState: AuthState,
     onSignOut: () -> Unit,
     onRetry: () -> Unit,
-    onSaveProfile: (String, String, String) -> Unit
+    onSaveProfile: (String, String, String) -> Unit,
+    initialConversationId: String? = null,
+    onConversationOpened: () -> Unit = {},
 ) {
     LaunchedEffect(authState) {
         if (authState is AuthState.Authenticated) {
@@ -93,7 +96,9 @@ fun NavigationHandler(
         )
         is AuthState.Authenticated -> MainScaffold(
             userProfile = authState.userProfile,
-            onSignOut = onSignOut
+            onSignOut = onSignOut,
+            initialConversationId = initialConversationId,
+            onConversationOpened = onConversationOpened,
         )
     }
 }
@@ -101,7 +106,9 @@ fun NavigationHandler(
 @Composable
 private fun MainScaffold(
     userProfile: UserProfile,
-    onSignOut: () -> Unit
+    onSignOut: () -> Unit,
+    initialConversationId: String? = null,
+    onConversationOpened: () -> Unit = {},
 ) {
     val authViewModel: AuthViewModel = viewModel()
     val calendarViewModel: CalendarViewModel = viewModel()
@@ -146,15 +153,45 @@ private fun MainScaffold(
     var showNewConversation by remember { mutableStateOf(false) }
     var showSocialScreen by remember { mutableStateOf(false) }
 
+    val context = LocalContext.current
+    val sharedPrefs = remember { context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE) }
+    // Persisted: last time the user had the conversations list visible.
+    // Default to currentTimeMillis on first launch so existing conversations
+    // don't all appear as unread.
+    var lastConversationsVisit by remember {
+        mutableStateOf(
+            sharedPrefs.getLong("last_conversations_visit", 0L).let { saved ->
+                if (saved == 0L) System.currentTimeMillis() else saved
+            }
+        )
+    }
+    // Maps conversationId -> timestamp when opened; dot shows if new message arrived after
+    var openedConversationTimestamps by remember { mutableStateOf(mapOf<String, Long>()) }
+
+    // When the user taps a push notification, open the referenced conversation directly.
+    LaunchedEffect(initialConversationId) {
+        val id = initialConversationId ?: return@LaunchedEffect
+        try {
+            val snap = com.google.firebase.firestore.FirebaseFirestore.getInstance()
+                .collection("conversations")
+                .document(id)
+                .get()
+                .await()
+            val conversation = snap.toObject(Conversation::class.java)
+            if (conversation != null) {
+                currentScreen = Screen.Social
+                openedConversationTimestamps = openedConversationTimestamps + (conversation.id to System.currentTimeMillis())
+                activeConversation = conversation
+                onConversationOpened()
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("NavigationHandler", "Failed to open conversation from notification: ${e.message}")
+        }
+    }
+
     // News / CIView state
     var showCIView by remember { mutableStateOf(false) }
     var selectedNewsArticle by remember { mutableStateOf<NewsArticle?>(null) }
-
-    val context = LocalContext.current
-    val sharedPrefs = remember { context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE) }
-    // Persisted: last time the user had the conversations list visible
-    var lastConversationsVisit by remember { mutableStateOf(sharedPrefs.getLong("last_conversations_visit", 0L)) }
-    var openedConversationIds by remember { mutableStateOf(setOf<String>()) }
 
     fun loadItems(key: String): List<Pair<String, String>> {
         val saved = sharedPrefs.getString(key, null) ?: return emptyList()
@@ -353,13 +390,13 @@ private fun MainScaffold(
                             }
                             ConversationsListScreen(
                                 onOpenConversation = {
-                                    openedConversationIds = openedConversationIds + it.id
+                                    openedConversationTimestamps = openedConversationTimestamps + (it.id to System.currentTimeMillis())
                                     activeConversation = it
                                 },
                                 onNewConversation = { showNewConversation = true },
                                 onOpenFriends = { showSocialScreen = true },
                                 sessionStartTime = lastConversationsVisit,
-                                openedConversationIds = openedConversationIds,
+                                openedConversationTimestamps = openedConversationTimestamps,
                             )
                         }
                     }

--- a/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
@@ -84,8 +84,8 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
 
     return if (isDark) {
         darkColorScheme(
-            primary = CINetBlue,
-            secondary = selectedTheme.dark,
+            primary = selectedTheme.dark,
+            secondary = CINetBlue,
             tertiary = CINetTertiaryDark,
             secondaryContainer = selectedTheme.darkButton,
             background = Color(0xFF121212),
@@ -98,8 +98,8 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
         )
     } else {
         lightColorScheme(
-            primary = CINetBlue,
-            secondary = selectedTheme.light,
+            primary = selectedTheme.light,
+            secondary = CINetBlue,
             tertiary = CINetTertiaryLight,
             secondaryContainer = selectedTheme.lightButton,
             background = CINetBackground,


### PR DESCRIPTION
## Overview
This PR covers profile screens, push notification tap-to-open, 
several social/messaging improvements, and a collection of bug fixes 
accumulated during this development cycle.

## New Features

### Profile Screens
- Full `ProfileScreen` redesign for both own and other user profiles
- Avatar (photo or initials), name, pronouns, bio, Major/Year info 
  cards, and interests chips

### Push Notification Deep Links
- Tapping a push notification opens the referenced conversation directly

### Real-Time Unread Dots
- Replace `openedConversationIds: Set<String>` with 
  `openedConversationTimestamps: Map<String, Long>` so a new message 
  arriving after a conversation was opened correctly shows a dot
- Add `lastSenderId` to `Conversation` — own messages never show a dot
- Fix `lastConversationsVisit` defaulting to `0L` on first launch