### PR TITLE
Calendar UI with style changes

### DIFF
--- a/app/src/main/java/com/example/cinet/PreferenceManager.kt
+++ b/app/src/main/java/com/example/cinet/PreferenceManager.kt
@@ -1,2 +1,0 @@
-// This file was removed to favor Firebase persistence over local DataStore.
-// If you see this, you can safely delete this file from your project.

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
@@ -87,11 +87,11 @@ fun CalendarDailyAgendaCard(
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(22.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
             elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
             border = BorderStroke(
                 1.dp,
-                MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.10f)
+                MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f)
             )
         ) {
             if (agendaItems.isEmpty()) {
@@ -125,7 +125,7 @@ private fun AgendaDateHeader(
     onTodayClick: () -> Unit
 ) {
     val formatter = remember { DateTimeFormatter.ofPattern("EEEE, d MMMM") }
-    val green = MaterialTheme.colorScheme.secondaryContainer
+    val green = MaterialTheme.colorScheme.onSecondary
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -188,7 +188,7 @@ private fun EmptyAgendaMessage(selectedDate: LocalDate) {
             text = if (isToday) "No saved calendar items for today yet" else "No saved calendar items for this day yet",
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSecondary
         )
 
         Spacer(modifier = Modifier.height(4.dp))
@@ -196,7 +196,7 @@ private fun EmptyAgendaMessage(selectedDate: LocalDate) {
         Text(
             text = "Use Classes, Study, or Events below to add and view today's items.",
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSecondary
         )
     }
 }
@@ -208,7 +208,7 @@ private fun AgendaTimelineRow(
     isFirst: Boolean,
     isLast: Boolean
 ) {
-    val green = MaterialTheme.colorScheme.secondaryContainer
+    val green = MaterialTheme.colorScheme.onSecondary
 
     Row(
         modifier = Modifier
@@ -221,7 +221,7 @@ private fun AgendaTimelineRow(
             text = item.timeText,
             modifier = Modifier.width(66.dp),
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSecondary,
             fontWeight = FontWeight.Medium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
@@ -260,7 +260,7 @@ private fun AgendaTimelineRow(
                 text = item.title,
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -270,7 +270,7 @@ private fun AgendaTimelineRow(
             Text(
                 text = item.subtitle,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -293,7 +293,7 @@ private fun AgendaTimelineRow(
                 Text(
                     text = item.location,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.onSecondary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
@@ -1,6 +1,5 @@
 package com.example.cinet.feature.calendar.calendarFiles
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -8,28 +7,25 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -78,87 +74,60 @@ fun CalendarDailyAgendaCard(
     Column(modifier = modifier.fillMaxWidth()) {
         AgendaDateHeader(
             selectedDate = selectedDate,
+            itemCount = agendaItems.size,
             onTodayClick = onTodayClick
         )
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(7.dp))
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(22.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
-            elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
-            border = BorderStroke(
-                1.dp,
-                MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f)
-            )
-        ) {
-            if (agendaItems.isEmpty()) {
-                EmptyAgendaMessage(selectedDate = selectedDate)
-            } else {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    agendaItems.forEachIndexed { index, item ->
-                        AgendaTimelineRow(
-                            item = item,
-                            isFirst = index == 0,
-                            isLast = index == agendaItems.lastIndex
-                        )
-
-                        if (index != agendaItems.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(start = 86.dp),
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)
-                            )
-                        }
-                    }
+        if (agendaItems.isEmpty()) {
+            EmptyAgendaMessage(selectedDate = selectedDate)
+        } else {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                agendaItems.forEach { item ->
+                    AgendaEventCard(item = item)
                 }
             }
         }
     }
 }
 
-/** Shows the date title and the Today shortcut above the agenda card. */
+/** Shows the selected schedule heading and the total number of items. */
 @Composable
 private fun AgendaDateHeader(
     selectedDate: LocalDate,
+    itemCount: Int,
     onTodayClick: () -> Unit
 ) {
-    val formatter = remember { DateTimeFormatter.ofPattern("EEEE, MMMM d") }
-    val accentColor = MaterialTheme.colorScheme.primary
+    val selectedFormatter = remember { DateTimeFormatter.ofPattern("MMM d") }
+    val isToday = selectedDate == LocalDate.now()
+    val title = if (isToday) "Today’s Schedule" else "Schedule • ${selectedDate.format(selectedFormatter)}"
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            imageVector = Icons.Default.CalendarMonth,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.size(30.dp)
-        )
-
-        Spacer(modifier = Modifier.width(14.dp))
-
         Text(
-            text = selectedDate.format(formatter),
+            text = title,
             modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.ExtraBold,
-            fontSize = 18.sp,
             color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 22.sp,
+            lineHeight = 26.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
 
         Text(
-            text = "Today",
-            modifier = Modifier
-                .clip(RoundedCornerShape(18.dp))
-                .clickable(onClick = onTodayClick)
-                .padding(horizontal = 8.dp, vertical = 6.dp),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
+            text = buildEventCountLabel(itemCount),
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 15.sp,
+            modifier = Modifier.clickable(onClick = onTodayClick),
+            maxLines = 1
         )
     }
 }
@@ -168,126 +137,118 @@ private fun AgendaDateHeader(
 private fun EmptyAgendaMessage(selectedDate: LocalDate) {
     val isToday = selectedDate == LocalDate.now()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 4.dp
     ) {
-        Text(
-            text = if (isToday) "No saved calendar items for today yet" else "No saved calendar items for this day yet",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSecondary
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(22.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = if (isToday) "No saved calendar items for today yet" else "No saved calendar items for this day yet",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
 
-        Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(2.dp))
 
-        Text(
-            text = "Use Classes, Study, or Events below to add and view today's items.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSecondary
-        )
+            Text(
+                text = "Saved classes, study sessions, and reminder events will appear here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.84f)
+            )
+        }
     }
 }
 
-/** Draws one timeline row for one class, study session, event, or reminder-enabled campus event. */
+/** Draws one individual event card using the same bold purple card style as the home news cards. */
 @Composable
-private fun AgendaTimelineRow(
-    item: AgendaItem,
-    isFirst: Boolean,
-    isLast: Boolean
-) {
-    val green = MaterialTheme.colorScheme.onSecondary
-
-    Row(
+private fun AgendaEventCard(item: AgendaItem) {
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { item.onClick() }
-            .padding(horizontal = 10.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .height(62.dp)
+            .clickable { item.onClick() },
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 4.dp
     ) {
-        Text(
-            text = item.timeText,
-            modifier = Modifier.width(66.dp),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSecondary,
-            fontWeight = FontWeight.Medium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
-
-        Column(
-            modifier = Modifier.width(22.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .width(2.dp)
-                    .height(if (isFirst) 12.dp else 22.dp)
-                    .background(if (isFirst) Color.Transparent else green.copy(alpha = 0.55f))
+                    .width(4.dp)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.42f))
             )
 
-            Box(
-                modifier = Modifier
-                    .size(15.dp)
-                    .clip(CircleShape)
-                    .background(green)
-            )
+            Spacer(modifier = Modifier.width(10.dp))
 
-            Box(
-                modifier = Modifier
-                    .width(2.dp)
-                    .height(if (isLast) 12.dp else 22.dp)
-                    .background(if (isLast) Color.Transparent else green.copy(alpha = 0.55f))
-            )
-        }
-
-        Spacer(modifier = Modifier.width(12.dp))
-
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = item.title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSecondary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-
-            Spacer(modifier = Modifier.height(3.dp))
-
-            Text(
-                text = item.subtitle,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-
-        if (item.location.isNotBlank()) {
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
-                    tint = green.copy(alpha = 0.80f),
-                    modifier = Modifier.size(18.dp)
-                )
-
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = item.location,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondary,
+                    text = item.title,
+                    fontSize = 15.sp,
+                    lineHeight = 18.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    text = item.timeText,
+                    fontSize = 12.sp,
+                    lineHeight = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.88f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.90f),
+                        modifier = Modifier.size(13.dp)
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    Text(
+                        text = item.location.ifBlank { item.subtitle },
+                        fontSize = 12.sp,
+                        lineHeight = 14.sp,
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.88f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Icon(
+                imageVector = Icons.Default.Notifications,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(19.dp)
+            )
         }
     }
 }
@@ -381,6 +342,11 @@ private fun parseTimeToMinutes(time: String): Int {
     if (period == "AM" && hour == 12) hour = 0
 
     return hour * 60 + minute
+}
+
+/** Builds a readable event-count label. */
+private fun buildEventCountLabel(itemCount: Int): String {
+    return if (itemCount == 1) "1 Event" else "$itemCount Events"
 }
 
 /** Stores one unified row used by the daily agenda card. */

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
@@ -18,13 +18,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -35,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.cinet.feature.calendar.classEvent.ClassItem
 import com.example.cinet.feature.calendar.event.EventItem
 import com.example.cinet.feature.calendar.study.StudySession
@@ -124,52 +123,43 @@ private fun AgendaDateHeader(
     selectedDate: LocalDate,
     onTodayClick: () -> Unit
 ) {
-    val formatter = remember { DateTimeFormatter.ofPattern("EEEE, d MMMM") }
-    val green = MaterialTheme.colorScheme.primary
+    val formatter = remember { DateTimeFormatter.ofPattern("EEEE, MMMM d") }
+    val accentColor = MaterialTheme.colorScheme.primary
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(44.dp)
-                .clip(CircleShape)
-                .background(green.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Default.CalendarMonth,
-                contentDescription = null,
-                tint = green,
-                modifier = Modifier.size(24.dp)
-            )
-        }
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(30.dp)
+        )
 
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(14.dp))
 
         Text(
             text = selectedDate.format(formatter),
             modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 18.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Text(
+            text = "Today",
+            modifier = Modifier
+                .clip(RoundedCornerShape(18.dp))
+                .clickable(onClick = onTodayClick)
+                .padding(horizontal = 8.dp, vertical = 6.dp),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface
         )
-
-        OutlinedButton(
-            onClick = onTodayClick,
-            shape = RoundedCornerShape(22.dp),
-            border = BorderStroke(1.dp, green.copy(alpha = 0.30f)),
-            colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = green,
-                containerColor = Color.Transparent
-            )
-        ) {
-            Text(
-                text = "Today",
-                fontWeight = FontWeight.Bold
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarDailyAgendaCard.kt
@@ -125,7 +125,7 @@ private fun AgendaDateHeader(
     onTodayClick: () -> Unit
 ) {
     val formatter = remember { DateTimeFormatter.ofPattern("EEEE, d MMMM") }
-    val green = MaterialTheme.colorScheme.onSecondary
+    val green = MaterialTheme.colorScheme.primary
 
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarHeader.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarHeader.kt
@@ -1,54 +1,28 @@
 package com.example.cinet.feature.calendar.calendarFiles
-
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 
-/** Shows the calendar page title while keeping the existing back behavior. */
+/** Shows the calendar back button and page title. */
 @Composable
 fun CalendarHeader(
     onBack: () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = "Back",
-                    tint = MaterialTheme.colorScheme.secondaryContainer
-                )
-            }
-
-            Spacer(modifier = Modifier.size(4.dp))
-        }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
         Text(
             text = "Calendar",
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        Text(
-            text = "Stay on top of your classes and events",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 22.sp,
+            lineHeight = 26.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarHeader.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarHeader.kt
@@ -1,4 +1,5 @@
 package com.example.cinet.feature.calendar.calendarFiles
+
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
@@ -9,19 +10,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 
-/** Shows the calendar back button and page title. */
+/** Shows the calendar page heading in the same bold style as the home greeting. */
 @Composable
-fun CalendarHeader(
-    onBack: () -> Unit
-) {
+fun CalendarHeader() {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = "Calendar",
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
-            fontSize = 22.sp,
-            lineHeight = 26.sp,
-            maxLines = 2,
+            fontSize = 34.sp,
+            lineHeight = 40.sp,
+            maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
     }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -50,6 +51,11 @@ fun CalendarModeTabs(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .shadow(
+                elevation = 10.dp,
+                shape = RoundedCornerShape(28.dp),
+                clip = false
+            )
             .clip(RoundedCornerShape(32.dp))
             // This changes the outside selector background to green
             .background(MaterialTheme.colorScheme.primary)
@@ -245,7 +251,6 @@ private fun WeekCalendarView(
                     WeekStripDate(
                         date = date,
                         isSelected = date == selectedDate,
-                        itemCount = activityCountByDate[date] ?: 0,
                         onClick = { onDateSelected(date) },
                         modifier = Modifier.weight(1f)
                     )
@@ -302,7 +307,7 @@ private fun SectionCard(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(22.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
-        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         border = BorderStroke(
             1.dp,
             MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f)
@@ -395,7 +400,6 @@ private fun WeekdayHeader(firstDayOfWeek: DayOfWeek) {
 private fun WeekStripDate(
     date: LocalDate,
     isSelected: Boolean,
-    itemCount: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -426,9 +430,9 @@ private fun WeekStripDate(
                 .border(
                     width = 2.dp,
                     color = if (isSelected) MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.55f) else MaterialTheme.colorScheme.primary,
-                    shape = RoundedCornerShape(16.dp)
+                    shape = CircleShape
                 )
-                .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent),
+                .background(if (isSelected) Color.Transparent else Color.Transparent),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -441,7 +445,29 @@ private fun WeekStripDate(
         }
 
         Spacer(modifier = Modifier.height(6.dp))
-        ActivityDots(itemCount = itemCount, isSelected = isSelected)
+        WeekStripDot(isSelected = isSelected)
+    }
+}
+
+/** Shows the always-visible dot under each date in the week strip. */
+@Composable
+private fun WeekStripDot(isSelected: Boolean) {
+    val dotColor = if (isSelected) {
+        Color.White
+    } else {
+        Color.White.copy(alpha = 0.48f)
+    }
+
+    Box(
+        modifier = Modifier.height(5.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(5.dp)
+                .clip(CircleShape)
+                .background(dotColor)
+        )
     }
 }
 
@@ -453,7 +479,7 @@ private fun MonthGrid(
     activityCountByDate: Map<LocalDate, Int>,
     onDateSelected: (LocalDate) -> Unit
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
         monthCells.chunked(7).forEach { week ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -482,8 +508,8 @@ private fun MonthGrid(
 private fun EmptyDateCell(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
-            .height(58.dp)
-            .padding(2.dp)
+            .height(46.dp)
+            .padding(1.dp)
     )
 }
 
@@ -498,7 +524,7 @@ private fun MonthDateCell(
 ) {
     Column(
         modifier = modifier
-            .height(58.dp)
+            .height(46.dp)
             .clip(RoundedCornerShape(16.dp))
             .background(if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary)
             .border(
@@ -507,7 +533,7 @@ private fun MonthDateCell(
                 shape = RoundedCornerShape(16.dp)
             )
             .clickable(onClick = onClick)
-            .padding(vertical = 7.dp),
+            .padding(vertical = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
@@ -52,7 +52,7 @@ fun CalendarModeTabs(
             .fillMaxWidth()
             .clip(RoundedCornerShape(32.dp))
             // This changes the outside selector background to green
-            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .background(MaterialTheme.colorScheme.primary)
             .border(
                 width = 1.dp,
                 // This changes the border to white
@@ -81,7 +81,7 @@ private fun CalendarModeButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val green = MaterialTheme.colorScheme.secondaryContainer
+    val green = MaterialTheme.colorScheme.primary
 
     // Selected button becomes white.
     // Unselected buttons stay transparent so the green parent background shows through.
@@ -182,7 +182,7 @@ private fun DayCalendarView(
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(22.dp))
-                .background(MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.10f))
+                .background(MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f))
                 .padding(vertical = 20.dp),
             contentAlignment = Alignment.Center
         ) {
@@ -191,12 +191,12 @@ private fun DayCalendarView(
                     modifier = Modifier
                         .size(70.dp)
                         .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.secondaryContainer),
+                        .background(MaterialTheme.colorScheme.onSecondary),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = selectedDate.dayOfMonth.toString(),
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.primary,
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold
                     )
@@ -207,7 +207,7 @@ private fun DayCalendarView(
                 Text(
                     text = buildItemCountText(itemCount),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.onSecondary,
                     textAlign = TextAlign.Center
                 )
             }
@@ -301,11 +301,11 @@ private fun SectionCard(
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(22.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
         elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
         border = BorderStroke(
             1.dp,
-            MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.10f)
+            MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f)
         )
     ) {
         Column(
@@ -337,7 +337,7 @@ private fun HeaderWithArrows(
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSecondary
         )
 
         NavigationButton(symbol = "›", onClick = onNext)
@@ -359,7 +359,7 @@ private fun NavigationButton(
     ) {
         Text(
             text = symbol,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.onSecondary,
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold
         )
@@ -383,7 +383,7 @@ private fun WeekdayHeader(firstDayOfWeek: DayOfWeek) {
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onSecondary,
                 fontWeight = FontWeight.SemiBold
             )
         }
@@ -399,10 +399,9 @@ private fun WeekStripDate(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val green = MaterialTheme.colorScheme.secondaryContainer
-    val weekdayColor = if (isSelected) green else MaterialTheme.colorScheme.onSurfaceVariant
-    val dayColor = if (isSelected) Color.White else MaterialTheme.colorScheme.onSurface
-
+    val green = MaterialTheme.colorScheme.onSecondary
+    val weekdayColor = if (isSelected) green else MaterialTheme.colorScheme.onSecondary
+    val dayColor = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(16.dp))
@@ -424,7 +423,12 @@ private fun WeekStripDate(
             modifier = Modifier
                 .size(if (isSelected) 44.dp else 40.dp)
                 .clip(CircleShape)
-                .background(if (isSelected) green else Color.Transparent),
+                .border(
+                    width = 2.dp,
+                    color = if (isSelected) MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.55f) else MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .background(if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -496,10 +500,10 @@ private fun MonthDateCell(
         modifier = modifier
             .height(58.dp)
             .clip(RoundedCornerShape(16.dp))
-            .background(if (isSelected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface)
+            .background(if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary)
             .border(
-                width = 1.dp,
-                color = if (isSelected) Color.Transparent else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f),
+                width = 2.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.55f) else MaterialTheme.colorScheme.primary,
                 shape = RoundedCornerShape(16.dp)
             )
             .clickable(onClick = onClick)
@@ -510,7 +514,7 @@ private fun MonthDateCell(
         Text(
             text = date.dayOfMonth.toString(),
             style = MaterialTheme.typography.bodyLarge,
-            color = if (isSelected) Color.White else MaterialTheme.colorScheme.onSurface,
+            color = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary,
             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.SemiBold
         )
 
@@ -525,7 +529,7 @@ private fun ActivityDots(
     itemCount: Int,
     isSelected: Boolean
 ) {
-    val dotColor = if (isSelected) Color.White else MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.65f)
+    val dotColor = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.65f)
 
     Box(
         modifier = Modifier.height(5.dp),

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarModeViews.kt
@@ -1,8 +1,6 @@
 package com.example.cinet.feature.calendar.calendarFiles
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,13 +17,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -41,41 +38,82 @@ import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
 import java.util.Locale
 
-
-/** Shows the Day, Week, and Month selector as one rounded segmented control. */
+/** Shows the Day, Week, and Month selector as a pill control. */
 @Composable
 fun CalendarModeTabs(
     selectedMode: CalendarMode,
-    onModeSelected: (CalendarMode) -> Unit
+    onModeSelected: (CalendarMode) -> Unit,
+    modifier: Modifier = Modifier,
+    mergedWithCalendarGrid: Boolean = false
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .shadow(
-                elevation = 10.dp,
-                shape = RoundedCornerShape(28.dp),
-                clip = false
-            )
-            .clip(RoundedCornerShape(32.dp))
-            // This changes the outside selector background to green
-            .background(MaterialTheme.colorScheme.primary)
-            .border(
-                width = 1.dp,
-                // This changes the border to white
-                color = Color.White.copy(alpha = 0.45f),
-                shape = RoundedCornerShape(32.dp)
-            )
-            .padding(6.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    val containerColor = if (mergedWithCalendarGrid) {
+        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.14f)
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = CircleShape,
+        color = containerColor,
+        shadowElevation = if (mergedWithCalendarGrid) 0.dp else 5.dp
     ) {
-        listOf(CalendarMode.DAY, CalendarMode.WEEK, CalendarMode.MONTH).forEach { mode ->
-            CalendarModeButton(
-                mode = mode,
-                isSelected = selectedMode == mode,
-                modifier = Modifier.weight(1f),
-                onClick = { onModeSelected(mode) }
-            )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(5.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
+            listOf(CalendarMode.DAY, CalendarMode.WEEK, CalendarMode.MONTH).forEach { mode ->
+                CalendarModeButton(
+                    mode = mode,
+                    isSelected = selectedMode == mode,
+                    modifier = Modifier.weight(1f),
+                    onClick = { onModeSelected(mode) }
+                )
+            }
         }
+    }
+}
+
+/** Shows the mode selector and active calendar grid as one merged purple section. */
+@Composable
+fun CalendarModeSection(
+    selectedMode: CalendarMode,
+    onModeSelected: (CalendarMode) -> Unit,
+    currentMonth: YearMonth,
+    selectedDate: LocalDate,
+    activityCountByDate: Map<LocalDate, Int>,
+    onDateSelected: (LocalDate) -> Unit,
+    onPreviousDay: () -> Unit,
+    onNextDay: () -> Unit,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    PurpleSectionCard(contentPadding = 7.dp) {
+        CalendarModeTabs(
+            selectedMode = selectedMode,
+            onModeSelected = onModeSelected,
+            mergedWithCalendarGrid = true
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        CalendarModeContentBody(
+            mode = selectedMode,
+            currentMonth = currentMonth,
+            selectedDate = selectedDate,
+            activityCountByDate = activityCountByDate,
+            onDateSelected = onDateSelected,
+            onPreviousDay = onPreviousDay,
+            onNextDay = onNextDay,
+            onPreviousWeek = onPreviousWeek,
+            onNextWeek = onNextWeek,
+            onPreviousMonth = onPreviousMonth,
+            onNextMonth = onNextMonth
+        )
     }
 }
 
@@ -87,28 +125,13 @@ private fun CalendarModeButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val green = MaterialTheme.colorScheme.primary
-
-    // Selected button becomes white.
-    // Unselected buttons stay transparent so the green parent background shows through.
-    val containerColor = if (isSelected) {
-        Color.White
-    } else {
-        Color.Transparent
-    }
-
-    // Selected text becomes green.
-    // Unselected text becomes white.
-    val textColor = if (isSelected) {
-        green
-    } else {
-        Color.White
-    }
+    val containerColor = if (isSelected) MaterialTheme.colorScheme.surface else Color.Transparent
+    val textColor = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimary
 
     Box(
         modifier = modifier
-            .height(46.dp)
-            .clip(RoundedCornerShape(28.dp))
+            .height(36.dp)
+            .clip(CircleShape)
             .background(containerColor)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
@@ -116,8 +139,8 @@ private fun CalendarModeButton(
         Text(
             text = mode.displayName(),
             color = textColor,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.ExtraBold,
             textAlign = TextAlign.Center
         )
     }
@@ -165,6 +188,48 @@ fun CalendarModeContent(
     }
 }
 
+/** Chooses the active calendar control without adding another outer card. */
+@Composable
+private fun CalendarModeContentBody(
+    mode: CalendarMode,
+    currentMonth: YearMonth,
+    selectedDate: LocalDate,
+    activityCountByDate: Map<LocalDate, Int>,
+    onDateSelected: (LocalDate) -> Unit,
+    onPreviousDay: () -> Unit,
+    onNextDay: () -> Unit,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    when (mode) {
+        CalendarMode.DAY -> DayCalendarBody(
+            selectedDate = selectedDate,
+            itemCount = activityCountByDate[selectedDate] ?: 0,
+            onPreviousDay = onPreviousDay,
+            onNextDay = onNextDay
+        )
+
+        CalendarMode.WEEK -> WeekCalendarBody(
+            selectedDate = selectedDate,
+            activityCountByDate = activityCountByDate,
+            onDateSelected = onDateSelected,
+            onPreviousWeek = onPreviousWeek,
+            onNextWeek = onNextWeek
+        )
+
+        CalendarMode.MONTH -> MonthCalendarBody(
+            currentMonth = currentMonth,
+            selectedDate = selectedDate,
+            activityCountByDate = activityCountByDate,
+            onDateSelected = onDateSelected,
+            onPreviousMonth = onPreviousMonth,
+            onNextMonth = onNextMonth
+        )
+    }
+}
+
 /** Shows one selected day with arrows and a compact activity summary. */
 @Composable
 private fun DayCalendarView(
@@ -173,57 +238,94 @@ private fun DayCalendarView(
     onPreviousDay: () -> Unit,
     onNextDay: () -> Unit
 ) {
-    val formatter = remember { DateTimeFormatter.ofPattern("EEEE, MMM d") }
-
-    SectionCard {
-        HeaderWithArrows(
-            title = selectedDate.format(formatter),
-            onPrevious = onPreviousDay,
-            onNext = onNextDay
+    PurpleSectionCard(contentPadding = 12.dp) {
+        DayCalendarBody(
+            selectedDate = selectedDate,
+            itemCount = itemCount,
+            onPreviousDay = onPreviousDay,
+            onNextDay = onNextDay
         )
+    }
+}
 
-        Spacer(modifier = Modifier.height(14.dp))
+/** Shows the selected day content without adding an outer card. */
+@Composable
+private fun DayCalendarBody(
+    selectedDate: LocalDate,
+    itemCount: Int,
+    onPreviousDay: () -> Unit,
+    onNextDay: () -> Unit
+) {
+    val formatter = remember { DateTimeFormatter.ofPattern("EEEE, MMMM d") }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(22.dp))
-                .background(MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f))
-                .padding(vertical = 20.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Box(
-                    modifier = Modifier
-                        .size(70.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.onSecondary),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = selectedDate.dayOfMonth.toString(),
-                        color = MaterialTheme.colorScheme.primary,
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                }
+    HeaderWithArrows(
+        title = selectedDate.format(formatter),
+        onPrevious = onPreviousDay,
+        onNext = onNextDay
+    )
 
-                Spacer(modifier = Modifier.height(10.dp))
+    Spacer(modifier = Modifier.height(8.dp))
 
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.14f))
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface),
+                contentAlignment = Alignment.Center
+            ) {
                 Text(
-                    text = buildItemCountText(itemCount),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSecondary,
-                    textAlign = TextAlign.Center
+                    text = selectedDate.dayOfMonth.toString(),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.ExtraBold
                 )
             }
+
+            Spacer(modifier = Modifier.height(5.dp))
+
+            Text(
+                text = buildItemCountText(itemCount),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.86f),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Medium
+            )
         }
     }
 }
 
-/** Shows a rounded week strip similar to the attached reference image. */
+/** Shows a purple rounded week strip. */
 @Composable
 private fun WeekCalendarView(
+    selectedDate: LocalDate,
+    activityCountByDate: Map<LocalDate, Int>,
+    onDateSelected: (LocalDate) -> Unit,
+    onPreviousWeek: () -> Unit,
+    onNextWeek: () -> Unit
+) {
+    PurpleSectionCard(contentPadding = 12.dp) {
+        WeekCalendarBody(
+            selectedDate = selectedDate,
+            activityCountByDate = activityCountByDate,
+            onDateSelected = onDateSelected,
+            onPreviousWeek = onPreviousWeek,
+            onNextWeek = onNextWeek
+        )
+    }
+}
+
+/** Shows the selected week content without adding an outer card. */
+@Composable
+private fun WeekCalendarBody(
     selectedDate: LocalDate,
     activityCountByDate: Map<LocalDate, Int>,
     onDateSelected: (LocalDate) -> Unit,
@@ -235,36 +337,57 @@ private fun WeekCalendarView(
         buildWeekDates(selectedDate, firstDayOfWeek)
     }
 
-    SectionCard(contentPadding = 12.dp) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        NavigationButton(symbol = "‹", onClick = onPreviousWeek)
+
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(3.dp)
         ) {
-            NavigationButton(symbol = "‹", onClick = onPreviousWeek)
-
-            Row(
-                modifier = Modifier.weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                weekDates.forEach { date ->
-                    WeekStripDate(
-                        date = date,
-                        isSelected = date == selectedDate,
-                        onClick = { onDateSelected(date) },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
+            weekDates.forEach { date ->
+                WeekStripDate(
+                    date = date,
+                    isSelected = date == selectedDate,
+                    itemCount = activityCountByDate[date] ?: 0,
+                    onClick = { onDateSelected(date) },
+                    modifier = Modifier.weight(1f)
+                )
             }
-
-            NavigationButton(symbol = "›", onClick = onNextWeek)
         }
+
+        NavigationButton(symbol = "›", onClick = onNextWeek)
     }
 }
 
-/** Shows the full month grid with a cleaner white-card style. */
+/** Shows the full month grid in the same bold card style used elsewhere on the page. */
 @Composable
 private fun MonthCalendarView(
+    currentMonth: YearMonth,
+    selectedDate: LocalDate,
+    activityCountByDate: Map<LocalDate, Int>,
+    onDateSelected: (LocalDate) -> Unit,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit
+) {
+    PurpleSectionCard(contentPadding = 12.dp) {
+        MonthCalendarBody(
+            currentMonth = currentMonth,
+            selectedDate = selectedDate,
+            activityCountByDate = activityCountByDate,
+            onDateSelected = onDateSelected,
+            onPreviousMonth = onPreviousMonth,
+            onNextMonth = onNextMonth
+        )
+    }
+}
+
+/** Shows the month grid content without adding an outer card. */
+@Composable
+private fun MonthCalendarBody(
     currentMonth: YearMonth,
     selectedDate: LocalDate,
     activityCountByDate: Map<LocalDate, Int>,
@@ -277,41 +400,35 @@ private fun MonthCalendarView(
         buildMonthCells(currentMonth, firstDayOfWeek)
     }
 
-    SectionCard {
-        HeaderWithArrows(
-            title = currentMonth.format(DateTimeFormatter.ofPattern("MMMM yyyy")),
-            onPrevious = onPreviousMonth,
-            onNext = onNextMonth
-        )
+    HeaderWithArrows(
+        title = currentMonth.format(DateTimeFormatter.ofPattern("MMMM yyyy")),
+        onPrevious = onPreviousMonth,
+        onNext = onNextMonth
+    )
 
-        Spacer(modifier = Modifier.height(14.dp))
-        WeekdayHeader(firstDayOfWeek = firstDayOfWeek)
-        Spacer(modifier = Modifier.height(10.dp))
-        MonthGrid(
-            monthCells = monthCells,
-            selectedDate = selectedDate,
-            activityCountByDate = activityCountByDate,
-            onDateSelected = onDateSelected
-        )
-    }
+    Spacer(modifier = Modifier.height(8.dp))
+    WeekdayHeader(firstDayOfWeek = firstDayOfWeek)
+    Spacer(modifier = Modifier.height(5.dp))
+    MonthGrid(
+        monthCells = monthCells,
+        selectedDate = selectedDate,
+        activityCountByDate = activityCountByDate,
+        onDateSelected = onDateSelected
+    )
 }
 
-/** Wraps calendar view pieces in the rounded white card used on the calendar screen. */
+/** Wraps calendar view pieces in a filled purple rounded card. */
 @Composable
-private fun SectionCard(
+private fun PurpleSectionCard(
     modifier: Modifier = Modifier,
     contentPadding: Dp = 16.dp,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
+        shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
-        border = BorderStroke(
-            1.dp,
-            MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.10f)
-        )
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
             modifier = Modifier
@@ -341,8 +458,8 @@ private fun HeaderWithArrows(
             modifier = Modifier.weight(1f),
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSecondary
+            fontWeight = FontWeight.ExtraBold,
+            color = MaterialTheme.colorScheme.onPrimary
         )
 
         NavigationButton(symbol = "›", onClick = onNext)
@@ -357,16 +474,16 @@ private fun NavigationButton(
 ) {
     Box(
         modifier = Modifier
-            .size(40.dp)
+            .size(34.dp)
             .clip(CircleShape)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = symbol,
-            color = MaterialTheme.colorScheme.onSecondary,
+            color = MaterialTheme.colorScheme.onPrimary,
             style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold
+            fontWeight = FontWeight.ExtraBold
         )
     }
 }
@@ -380,94 +497,65 @@ private fun WeekdayHeader(firstDayOfWeek: DayOfWeek) {
 
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         orderedDays.forEach { day ->
             Text(
-                text = day.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
+                text = day.getDisplayName(TextStyle.SHORT, Locale.getDefault()).uppercase(),
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSecondary,
-                fontWeight = FontWeight.SemiBold
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.82f),
+                fontWeight = FontWeight.ExtraBold
             )
         }
     }
 }
 
-/** Shows one date in the week strip with a selected green circle and activity dots. */
+/** Shows one date in the week strip with a selected circle and activity dot. */
 @Composable
 private fun WeekStripDate(
     date: LocalDate,
     isSelected: Boolean,
+    itemCount: Int,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val green = MaterialTheme.colorScheme.onSecondary
-    val weekdayColor = if (isSelected) green else MaterialTheme.colorScheme.onSecondary
-    val dayColor = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(16.dp))
             .clickable(onClick = onClick)
-            .padding(vertical = 8.dp),
+            .padding(vertical = 5.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()),
             style = MaterialTheme.typography.labelMedium,
-            color = weekdayColor,
-            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.82f),
+            fontWeight = FontWeight.ExtraBold,
             textAlign = TextAlign.Center
         )
 
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(5.dp))
 
         Box(
             modifier = Modifier
-                .size(if (isSelected) 44.dp else 40.dp)
+                .size(if (isSelected) 38.dp else 34.dp)
                 .clip(CircleShape)
-                .border(
-                    width = 2.dp,
-                    color = if (isSelected) MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.55f) else MaterialTheme.colorScheme.primary,
-                    shape = CircleShape
-                )
-                .background(if (isSelected) Color.Transparent else Color.Transparent),
+                .background(if (isSelected) MaterialTheme.colorScheme.surface else Color.Transparent),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = date.dayOfMonth.toString(),
-                color = dayColor,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimary,
                 style = MaterialTheme.typography.titleLarge,
-                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                fontWeight = FontWeight.ExtraBold,
                 textAlign = TextAlign.Center
             )
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
-        WeekStripDot(isSelected = isSelected)
-    }
-}
-
-/** Shows the always-visible dot under each date in the week strip. */
-@Composable
-private fun WeekStripDot(isSelected: Boolean) {
-    val dotColor = if (isSelected) {
-        Color.White
-    } else {
-        Color.White.copy(alpha = 0.48f)
-    }
-
-    Box(
-        modifier = Modifier.height(5.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .size(5.dp)
-                .clip(CircleShape)
-                .background(dotColor)
-        )
+        Spacer(modifier = Modifier.height(3.dp))
+        ActivityDots(itemCount = itemCount, isSelected = isSelected)
     }
 }
 
@@ -479,11 +567,11 @@ private fun MonthGrid(
     activityCountByDate: Map<LocalDate, Int>,
     onDateSelected: (LocalDate) -> Unit
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         monthCells.chunked(7).forEach { week ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 week.forEach { date ->
                     if (date == null) {
@@ -506,11 +594,7 @@ private fun MonthGrid(
 /** Shows one blank placeholder used before or after real month dates. */
 @Composable
 private fun EmptyDateCell(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .height(46.dp)
-            .padding(1.dp)
-    )
+    Box(modifier = modifier.height(38.dp))
 }
 
 /** Shows one clickable date cell in the month grid. */
@@ -524,47 +608,52 @@ private fun MonthDateCell(
 ) {
     Column(
         modifier = modifier
-            .height(46.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primary)
-            .border(
-                width = 2.dp,
-                color = if (isSelected) MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.55f) else MaterialTheme.colorScheme.primary,
-                shape = RoundedCornerShape(16.dp)
-            )
+            .height(38.dp)
+            .clip(RoundedCornerShape(14.dp))
             .clickable(onClick = onClick)
-            .padding(vertical = 4.dp),
+            .padding(vertical = 3.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Text(
-            text = date.dayOfMonth.toString(),
-            style = MaterialTheme.typography.bodyLarge,
-            color = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary,
-            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.SemiBold
-        )
+        Box(
+            modifier = Modifier
+                .size(if (isSelected) 26.dp else 22.dp)
+                .clip(CircleShape)
+                .background(if (isSelected) MaterialTheme.colorScheme.surface else Color.Transparent),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = date.dayOfMonth.toString(),
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimary,
+                fontWeight = FontWeight.ExtraBold
+            )
+        }
 
-        Spacer(modifier = Modifier.height(4.dp))
         ActivityDots(itemCount = itemCount, isSelected = isSelected)
     }
 }
 
-/** Draws one small activity dot under dates that have at least one custom event. */
+/** Draws a small activity dot under dates that have at least one item. */
 @Composable
 private fun ActivityDots(
     itemCount: Int,
     isSelected: Boolean
 ) {
-    val dotColor = if (isSelected) Color.White else MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.65f)
+    val dotColor = if (isSelected) {
+        MaterialTheme.colorScheme.surface
+    } else {
+        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.55f)
+    }
 
     Box(
-        modifier = Modifier.height(5.dp),
+        modifier = Modifier.height(4.dp),
         contentAlignment = Alignment.Center
     ) {
         if (itemCount > 0) {
             Box(
                 modifier = Modifier
-                    .size(5.dp)
+                    .size(4.dp)
                     .clip(CircleShape)
                     .background(dotColor)
             )
@@ -624,8 +713,8 @@ private fun CalendarMode.displayName(): String {
 /** Builds the summary line for day view. */
 private fun buildItemCountText(itemCount: Int): String {
     return when (itemCount) {
-        0 -> "No events scheduled for this day yet."
-        1 -> "1 event scheduled for this day."
-        else -> "$itemCount events scheduled for this day."
+        0 -> "No saved items for this day yet."
+        1 -> "1 saved item for this day."
+        else -> "$itemCount saved items for this day."
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessCards.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessCards.kt
@@ -1,38 +1,33 @@
 package com.example.cinet.feature.calendar.calendarFiles
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material.icons.filled.School
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
-/** Shows the square cards that open today's category popups. */
+/** Shows the circular calendar action buttons at the bottom of the card. */
 @Composable
 fun CalendarQuickAccessCards(
     onClassesClick: () -> Unit,
@@ -40,102 +35,69 @@ fun CalendarQuickAccessCards(
     onEventsClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        Text(
-            text = "Quick Access",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.Top
+    ) {
+        CalendarQuickAccessCircle(
+            title = "Classes",
+            icon = Icons.Default.School,
+            onClick = onClassesClick
         )
 
-        Spacer(modifier = Modifier.height(10.dp))
+        CalendarQuickAccessCircle(
+            title = "Study",
+            icon = Icons.Default.MenuBook,
+            onClick = onStudyClick
+        )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            CalendarQuickAccessCard(
-                title = "Classes",
-                icon = Icons.Default.School,
-                onClick = onClassesClick,
-                modifier = Modifier.weight(1f)
-            )
-
-            CalendarQuickAccessCard(
-                title = "Study",
-                icon = Icons.Default.MenuBook,
-                onClick = onStudyClick,
-                modifier = Modifier.weight(1f)
-            )
-
-            CalendarQuickAccessCard(
-                title = "Events",
-                icon = Icons.Default.CalendarMonth,
-                onClick = onEventsClick,
-                modifier = Modifier.weight(1f)
-            )
-        }
+        CalendarQuickAccessCircle(
+            title = "Events",
+            icon = Icons.Default.CalendarMonth,
+            onClick = onEventsClick
+        )
     }
 }
 
-/** Draws one square calendar action card. */
+/** Draws one circular quick access button with its label below it. */
 @Composable
-private fun CalendarQuickAccessCard(
+private fun CalendarQuickAccessCircle(
     title: String,
     icon: ImageVector,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val green = MaterialTheme.colorScheme.onSecondary
-    val softGreen = MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.12f)
-
-    Card(
-        modifier = modifier
-            .aspectRatio(1f)
-            .clickable { onClick() },
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primary
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.18f))
+    Column(
+        modifier = modifier.clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+        Surface(
+            modifier = Modifier.size(75.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            shadowElevation = 5.dp
         ) {
-            Box(
-                modifier = Modifier
-                    .size(44.dp)
-                    .clip(MaterialTheme.shapes.large)
-                    .background(softGreen),
-                contentAlignment = Alignment.Center
-            ) {
+            Box(contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = icon,
-                    contentDescription = null,
-                    tint = green,
-                    modifier = Modifier.size(26.dp)
+                    contentDescription = title,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(30.dp)
                 )
             }
-
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSecondary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-            }
         }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessCards.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessCards.kt
@@ -86,8 +86,8 @@ private fun CalendarQuickAccessCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val green = MaterialTheme.colorScheme.secondaryContainer
-    val softGreen = MaterialTheme.colorScheme.secondary.copy(alpha = 0.12f)
+    val green = MaterialTheme.colorScheme.onSecondary
+    val softGreen = MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.12f)
 
     Card(
         modifier = modifier
@@ -95,16 +95,17 @@ private fun CalendarQuickAccessCard(
             .clickable { onClick() },
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
+            containerColor = MaterialTheme.colorScheme.primary
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondary.copy(alpha = 0.18f))
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.18f))
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(12.dp),
-            verticalArrangement = Arrangement.SpaceBetween
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Box(
                 modifier = Modifier
@@ -125,7 +126,7 @@ private fun CalendarQuickAccessCard(
                 text = title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSecondary,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessPopup.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarQuickAccessPopup.kt
@@ -71,9 +71,9 @@ fun CalendarQuickAccessPopup(
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(28.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
             elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.16f))
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.16f))
         ) {
             Column(
                 modifier = Modifier
@@ -91,7 +91,7 @@ fun CalendarQuickAccessPopup(
                 Text(
                     text = popupDescription(type),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSecondary
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -99,7 +99,7 @@ fun CalendarQuickAccessPopup(
                 Text(
                     text = selectedDate.format(DateTimeFormatter.ofPattern("EEEE, MMM d")),
                     style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    color = MaterialTheme.colorScheme.onSecondary,
                     fontWeight = FontWeight.SemiBold
                 )
 
@@ -156,14 +156,14 @@ private fun PopupHeader(
             modifier = Modifier.weight(1f),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSecondary
         )
 
         IconButton(onClick = onAddClick) {
             Icon(
                 imageVector = Icons.Default.Add,
                 contentDescription = "Add",
-                tint = MaterialTheme.colorScheme.secondaryContainer
+                tint = MaterialTheme.colorScheme.onSecondary
             )
         }
 
@@ -171,7 +171,7 @@ private fun PopupHeader(
             Icon(
                 imageVector = Icons.Default.Close,
                 contentDescription = "Close",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                tint = MaterialTheme.colorScheme.onSecondary
             )
         }
     }
@@ -180,7 +180,7 @@ private fun PopupHeader(
 /** Shows the icon bubble for the selected popup type. */
 @Composable
 private fun PopupIcon(type: CalendarQuickAccessType) {
-    val green = MaterialTheme.colorScheme.secondaryContainer
+    val green = MaterialTheme.colorScheme.onSecondary
 
     Surface(
         modifier = Modifier.size(44.dp),
@@ -288,16 +288,16 @@ private fun PopupItemCard(
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(18.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.06f)
+            containerColor = MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.06f)
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.12f))
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.12f))
     ) {
         Column(modifier = Modifier.padding(14.dp)) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSecondary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
@@ -315,7 +315,7 @@ private fun PopupItemCard(
                 Text(
                     text = secondaryDetail,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.onSecondary,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -345,14 +345,14 @@ private fun DetailRow(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.82f),
+            tint = MaterialTheme.colorScheme.onSecondary.copy(alpha = 0.82f),
             modifier = Modifier.size(16.dp)
         )
 
         Text(
             text = text,
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = MaterialTheme.colorScheme.onSecondary,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
@@ -371,7 +371,7 @@ private fun EmptyPopupMessage(text: String) {
         Text(
             text = text,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSecondary
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
@@ -1,14 +1,29 @@
 package com.example.cinet.feature.calendar.calendarFiles
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
 import java.time.YearMonth
@@ -27,7 +42,9 @@ import com.example.cinet.core.time.*
 @Composable
 fun CalendarScreen(
     onBack: () -> Unit,
-    initialShowClassDialog: Boolean = false
+    initialShowClassDialog: Boolean = false,
+    onProfileClick: () -> Unit = {},
+    onSettingsClick: () -> Unit = {}
 ) {
     val viewModel: CalendarViewModel = viewModel()
     val context = LocalContext.current
@@ -188,57 +205,66 @@ fun CalendarScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
             .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp)
+            .padding(top = 15.dp, bottom = 4.dp)
     ) {
-        CalendarHeader(onBack = onBack)
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        CalendarModeTabs(
-            selectedMode = calendarMode,
-            onModeSelected = { viewModel.updateMode(it) }
+        CalendarTopBar(
+            onProfileClick = onProfileClick,
+            onSettingsClick = onSettingsClick
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(10.dp))
 
-        CalendarModeContent(
-            mode = calendarMode,
-            currentMonth = currentMonth,
-            selectedDate = activeDate,
-            activityCountByDate = agendaCountByDate,
-            onDateSelected = ::handleDateClick,
-            onPreviousDay = { viewModel.previousDay() },
-            onNextDay = { viewModel.nextDay() },
-            onPreviousWeek = { viewModel.previousWeek() },
-            onNextWeek = { viewModel.nextWeek() },
-            onPreviousMonth = { viewModel.previousMonth() },
-            onNextMonth = { viewModel.nextMonth() }
-        )
+        CalendarMainCard {
+            CalendarHeader(onBack = onBack)
 
-        Spacer(modifier = Modifier.height(18.dp))
+            Spacer(modifier = Modifier.height(14.dp))
 
-        CalendarDailyAgendaCard(
-            selectedDate = activeDate,
-            classes = classesForSelectedDate,
-            studySessions = studySessionsForSelectedDate,
-            events = customEventsForSelectedDate,
-            reminderCampusEvents = reminderEventsForSelectedDate,
-            onTodayClick = { viewModel.onDateSelected(today) },
-            onClassClick = ::openClassEditor,
-            onStudySessionClick = ::openStudySessionEditor,
-            onEventClick = ::openEventEditor
-        )
+            CalendarModeTabs(
+                selectedMode = calendarMode,
+                onModeSelected = { viewModel.updateMode(it) }
+            )
 
-        Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(18.dp))
 
-        CalendarQuickAccessCards(
-            onClassesClick = { selectedQuickAccessType = CalendarQuickAccessType.CLASSES },
-            onStudyClick = { selectedQuickAccessType = CalendarQuickAccessType.STUDY },
-            onEventsClick = { selectedQuickAccessType = CalendarQuickAccessType.EVENTS }
-        )
+            CalendarModeContent(
+                mode = calendarMode,
+                currentMonth = currentMonth,
+                selectedDate = activeDate,
+                activityCountByDate = agendaCountByDate,
+                onDateSelected = ::handleDateClick,
+                onPreviousDay = { viewModel.previousDay() },
+                onNextDay = { viewModel.nextDay() },
+                onPreviousWeek = { viewModel.previousWeek() },
+                onNextWeek = { viewModel.nextWeek() },
+                onPreviousMonth = { viewModel.previousMonth() },
+                onNextMonth = { viewModel.nextMonth() }
+            )
 
+            Spacer(modifier = Modifier.height(20.dp))
 
+            CalendarDailyAgendaCard(
+                selectedDate = activeDate,
+                classes = classesForSelectedDate,
+                studySessions = studySessionsForSelectedDate,
+                events = customEventsForSelectedDate,
+                reminderCampusEvents = reminderEventsForSelectedDate,
+                onTodayClick = { viewModel.onDateSelected(today) },
+                onClassClick = ::openClassEditor,
+                onStudySessionClick = ::openStudySessionEditor,
+                onEventClick = ::openEventEditor
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            CalendarQuickAccessCards(
+                onClassesClick = { selectedQuickAccessType = CalendarQuickAccessType.CLASSES },
+                onStudyClick = { selectedQuickAccessType = CalendarQuickAccessType.STUDY },
+                onEventsClick = { selectedQuickAccessType = CalendarQuickAccessType.EVENTS }
+            )
+        }
     }
 
     selectedQuickAccessType?.let { quickAccessType ->
@@ -533,6 +559,90 @@ fun CalendarScreen(
 
 
 /** Builds the day-dot map for the content shown in the main agenda card. */
+
+/** Displays the top CINET title and the two circular action buttons. */
+@Composable
+private fun CalendarTopBar(
+    onProfileClick: () -> Unit,
+    onSettingsClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "CINET",
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 26.sp,
+            letterSpacing = 0.3.sp
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        CalendarHeaderIconButton(
+            icon = Icons.Default.Person,
+            contentDescription = "Open profile",
+            onClick = onProfileClick
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        CalendarHeaderIconButton(
+            icon = Icons.Default.MoreVert,
+            contentDescription = "Open settings",
+            onClick = onSettingsClick
+        )
+    }
+}
+
+/** Draws one circular button in the CINET header. */
+@Composable
+private fun CalendarHeaderIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .size(44.dp)
+            .clickable(onClick = onClick),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+        shadowElevation = 0.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+    }
+}
+
+/** Holds the calendar content inside the large rounded white card. */
+@Composable
+private fun CalendarMainCard(
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(38.dp),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 10.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 22.dp, vertical = 24.dp)
+        ) {
+            content()
+        }
+    }
+}
+
 private fun buildAgendaActivityCountByDate(
     context: android.content.Context,
     currentMonth: YearMonth,

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
@@ -5,25 +5,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
 import java.time.YearMonth
@@ -205,66 +195,63 @@ fun CalendarScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f))
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp)
-            .padding(top = 15.dp, bottom = 4.dp)
+            .padding(horizontal = 24.dp)
+            .padding(top = 18.dp, bottom = 110.dp)
     ) {
-        CalendarTopBar(
-            onProfileClick = onProfileClick,
-            onSettingsClick = onSettingsClick
-        )
+        CalendarHeader()
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        CalendarMainCard {
-            CalendarHeader(onBack = onBack)
+        CalendarModeSection(
+            selectedMode = calendarMode,
+            onModeSelected = { viewModel.updateMode(it) },
+            currentMonth = currentMonth,
+            selectedDate = activeDate,
+            activityCountByDate = agendaCountByDate,
+            onDateSelected = ::handleDateClick,
+            onPreviousDay = { viewModel.previousDay() },
+            onNextDay = { viewModel.nextDay() },
+            onPreviousWeek = { viewModel.previousWeek() },
+            onNextWeek = { viewModel.nextWeek() },
+            onPreviousMonth = { viewModel.previousMonth() },
+            onNextMonth = { viewModel.nextMonth() }
+        )
 
-            Spacer(modifier = Modifier.height(14.dp))
+        Spacer(modifier = Modifier.height(14.dp))
 
-            CalendarModeTabs(
-                selectedMode = calendarMode,
-                onModeSelected = { viewModel.updateMode(it) }
-            )
+        CalendarDailyAgendaCard(
+            selectedDate = activeDate,
+            classes = classesForSelectedDate,
+            studySessions = studySessionsForSelectedDate,
+            events = customEventsForSelectedDate,
+            reminderCampusEvents = reminderEventsForSelectedDate,
+            onTodayClick = { viewModel.onDateSelected(today) },
+            onClassClick = ::openClassEditor,
+            onStudySessionClick = ::openStudySessionEditor,
+            onEventClick = ::openEventEditor
+        )
 
-            Spacer(modifier = Modifier.height(18.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
-            CalendarModeContent(
-                mode = calendarMode,
-                currentMonth = currentMonth,
-                selectedDate = activeDate,
-                activityCountByDate = agendaCountByDate,
-                onDateSelected = ::handleDateClick,
-                onPreviousDay = { viewModel.previousDay() },
-                onNextDay = { viewModel.nextDay() },
-                onPreviousWeek = { viewModel.previousWeek() },
-                onNextWeek = { viewModel.nextWeek() },
-                onPreviousMonth = { viewModel.previousMonth() },
-                onNextMonth = { viewModel.nextMonth() }
-            )
+        androidx.compose.material3.HorizontalDivider(
+            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)
+        )
 
-            Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(14.dp))
 
-            CalendarDailyAgendaCard(
-                selectedDate = activeDate,
-                classes = classesForSelectedDate,
-                studySessions = studySessionsForSelectedDate,
-                events = customEventsForSelectedDate,
-                reminderCampusEvents = reminderEventsForSelectedDate,
-                onTodayClick = { viewModel.onDateSelected(today) },
-                onClassClick = ::openClassEditor,
-                onStudySessionClick = ::openStudySessionEditor,
-                onEventClick = ::openEventEditor
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            CalendarQuickAccessCards(
-                onClassesClick = { selectedQuickAccessType = CalendarQuickAccessType.CLASSES },
-                onStudyClick = { selectedQuickAccessType = CalendarQuickAccessType.STUDY },
-                onEventsClick = { selectedQuickAccessType = CalendarQuickAccessType.EVENTS }
-            )
-        }
+        CalendarQuickAccessCards(
+            onClassesClick = {
+                selectedQuickAccessType = CalendarQuickAccessType.CLASSES
+            },
+            onStudyClick = {
+                selectedQuickAccessType = CalendarQuickAccessType.STUDY
+            },
+            onEventsClick = {
+                selectedQuickAccessType = CalendarQuickAccessType.EVENTS
+            }
+        )
     }
 
     selectedQuickAccessType?.let { quickAccessType ->
@@ -559,89 +546,6 @@ fun CalendarScreen(
 
 
 /** Builds the day-dot map for the content shown in the main agenda card. */
-
-/** Displays the top CINET title and the two circular action buttons. */
-@Composable
-private fun CalendarTopBar(
-    onProfileClick: () -> Unit,
-    onSettingsClick: () -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = "CINET",
-            color = MaterialTheme.colorScheme.primary,
-            fontWeight = FontWeight.ExtraBold,
-            fontSize = 26.sp,
-            letterSpacing = 0.3.sp
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        CalendarHeaderIconButton(
-            icon = Icons.Default.Person,
-            contentDescription = "Open profile",
-            onClick = onProfileClick
-        )
-
-        Spacer(modifier = Modifier.width(12.dp))
-
-        CalendarHeaderIconButton(
-            icon = Icons.Default.MoreVert,
-            contentDescription = "Open settings",
-            onClick = onSettingsClick
-        )
-    }
-}
-
-/** Draws one circular button in the CINET header. */
-@Composable
-private fun CalendarHeaderIconButton(
-    icon: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier
-            .size(44.dp)
-            .clickable(onClick = onClick),
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-        shadowElevation = 0.dp
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(22.dp)
-            )
-        }
-    }
-}
-
-/** Holds the calendar content inside the large rounded white card. */
-@Composable
-private fun CalendarMainCard(
-    content: @Composable () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(38.dp),
-        color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 10.dp
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 22.dp, vertical = 24.dp)
-        ) {
-            content()
-        }
-    }
-}
 
 private fun buildAgendaActivityCountByDate(
     context: android.content.Context,

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarViewModel.kt
@@ -17,8 +17,8 @@ import java.time.YearMonth
 
 class CalendarViewModel : ViewModel() {
 
-    // Holds the calendar layout currently selected by the user.
-    var mode by mutableStateOf(CalendarMode.WEEK)
+    // Holds the calendar layout currently selected by the user. Defaults to month view.
+    var mode by mutableStateOf(CalendarMode.MONTH)
         private set
 
     // Holds the month currently shown in the calendar header/grid.

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -1,10 +1,21 @@
 package com.example.cinet.feature.home
 
-import android.R
 import android.util.Log
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -14,8 +25,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -92,9 +113,7 @@ fun HomeScreen(
     )
 }
 
-/**
- * Arranges the full home screen from top to bottom.
- */
+/** Arranges the home screen from top to bottom. */
 @Composable
 private fun HomeScreenContent(
     nickname: String,
@@ -114,53 +133,53 @@ private fun HomeScreenContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f))
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp)
-            .padding(top = 15.dp, bottom = 4.dp)
+            .padding(horizontal = 24.dp)
+            .padding(top = 18.dp, bottom = 24.dp)
     ) {
         HomeTopBar(
             onProfileClick = onProfileClick,
             onSettingsClick = onSettingsClick
         )
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(32.dp))
 
-        HomeMainCard {
-            WelcomeHeader(nickname = nickname)
+        WelcomeHeader(nickname = nickname)
 
-            Spacer(modifier = Modifier.height(14.dp))
+        Spacer(modifier = Modifier.height(18.dp))
 
-            HomeWeatherBanner(
-                temp = weatherInfo.temp,
-                condition = weatherInfo.condition
-            )
+        HomeWeatherBanner(
+            temp = weatherInfo.temp,
+            condition = weatherInfo.condition
+        )
 
-            Spacer(modifier = Modifier.height(18.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
-            LatestNewsCarousel(
-                articles = newsArticles,
-                onSeeAllClick = onSeeAllNewsClick,
-                onArticleClick = onArticleClick
-            )
+        LatestNewsCarousel(
+            articles = newsArticles,
+            onSeeAllClick = onSeeAllNewsClick,
+            onArticleClick = onArticleClick
+        )
 
-            Spacer(modifier = Modifier.height(28.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
-            QuickActionGrid(
-                onMapClick = onMapClick,
-                onCalendarClick = onCalendarClick,
-                onSocialClick = onSocialClick,
-                onStudyRoomsClick = onStudyRoomsClick,
-                onProfileClick = onProfileClick,
-                onNotificationClick = onNotificationClick
-            )
-        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f))
+
+        Spacer(modifier = Modifier.height(22.dp))
+
+        QuickActionGrid(
+            onMapClick = onMapClick,
+            onCalendarClick = onCalendarClick,
+            onSocialClick = onSocialClick,
+            onStudyRoomsClick = onStudyRoomsClick,
+            onProfileClick = onProfileClick,
+            onNotificationClick = onNotificationClick
+        )
     }
 }
 
-/**
- * Displays the top CINET title and action buttons.
- */
+/** Displays the top CINET title and action buttons. */
 @Composable
 private fun HomeTopBar(
     onProfileClick: () -> Unit,
@@ -174,8 +193,8 @@ private fun HomeTopBar(
             text = "CINET",
             color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.ExtraBold,
-            fontSize = 26.sp,
-            letterSpacing = 0.3.sp
+            fontSize = 34.sp,
+            letterSpacing = 0.4.sp
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -196,9 +215,7 @@ private fun HomeTopBar(
     }
 }
 
-/**
- * Displays one circular icon button in the top header.
- */
+/** Displays one soft circular icon button in the top header. */
 @Composable
 private fun HeaderIconButton(
     icon: ImageVector,
@@ -207,68 +224,52 @@ private fun HeaderIconButton(
 ) {
     Surface(
         modifier = Modifier
-            .size(44.dp)
+            .size(54.dp)
             .clickable(onClick = onClick),
         shape = CircleShape,
-        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+        shadowElevation = 0.dp
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = icon,
                 contentDescription = contentDescription,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(30.dp)
+                modifier = Modifier.size(28.dp)
             )
         }
     }
 }
 
-/**
- * Holds all main home page content inside one large rounded card.
- */
-@Composable
-private fun HomeMainCard(
-    content: @Composable () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth()
-            .fillMaxWidth()
-            .height(650.dp),
-        shape = RoundedCornerShape(38.dp),
-        color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 10.dp
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 18.dp, vertical = 24.dp)
-        ){
-            content()
-        }
-    }
-}
-
-/**
- * Displays the greeting at the top of the main card.
- */
+/** Displays the greeting and subtitle at the top of the home page. */
 @Composable
 private fun WelcomeHeader(nickname: String) {
     val displayName = nickname.ifBlank { "there" }
 
-    Text(
-        text = "Welcome back, $displayName 👋",
-        color = MaterialTheme.colorScheme.onSurface,
-        fontWeight = FontWeight.ExtraBold,
-        fontSize = 22.sp,
-        lineHeight = 26.sp,
-        maxLines = 2,
-        overflow = TextOverflow.Ellipsis
-    )
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Welcome back, $displayName 👋",
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 28.sp,
+            lineHeight = 34.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = "Here’s what’s happening on campus",
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f),
+            fontWeight = FontWeight.Medium,
+            fontSize = 17.sp,
+            lineHeight = 22.sp
+        )
+    }
 }
 
-/**
- * Displays the weather summary without the "Campus Weather" label.
- */
+/** Displays the weather summary without the "Campus Weather" label. */
 @Composable
 private fun HomeWeatherBanner(
     temp: String,
@@ -281,28 +282,28 @@ private fun HomeWeatherBanner(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(34.dp),
         color = MaterialTheme.colorScheme.primary,
-        shadowElevation = 5.dp
+        shadowElevation = 4.dp
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
                 imageVector = weatherIcon,
                 contentDescription = displayCondition,
                 tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(28.dp)
+                modifier = Modifier.size(32.dp)
             )
 
-            Spacer(modifier = Modifier.width(14.dp))
+            Spacer(modifier = Modifier.width(16.dp))
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = "$temp • $displayCondition",
                     color = MaterialTheme.colorScheme.onPrimary,
                     fontWeight = FontWeight.ExtraBold,
-                    fontSize = 17.sp,
-                    lineHeight = 21.sp,
+                    fontSize = 21.sp,
+                    lineHeight = 25.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -312,8 +313,8 @@ private fun HomeWeatherBanner(
                 Text(
                     text = "Camarillo, CA",
                     color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.86f),
-                    fontSize = 12.sp,
-                    lineHeight = 15.sp,
+                    fontSize = 15.sp,
+                    lineHeight = 19.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -322,9 +323,7 @@ private fun HomeWeatherBanner(
     }
 }
 
-/**
- * Displays the latest news heading, carousel cards, and page indicators.
- */
+/** Displays the latest news heading, carousel cards, and page indicators. */
 @Composable
 private fun LatestNewsCarousel(
     articles: List<NewsArticle>,
@@ -345,7 +344,7 @@ private fun LatestNewsCarousel(
     Column(modifier = Modifier.fillMaxWidth()) {
         LatestNewsHeader(onSeeAllClick = onSeeAllClick)
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(14.dp))
 
         if (articles.isEmpty()) {
             LoadingNewsCard()
@@ -363,7 +362,7 @@ private fun LatestNewsCarousel(
                 }
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(14.dp))
 
             NewsCarouselIndicators(
                 count = articles.size.coerceAtMost(5),
@@ -373,9 +372,7 @@ private fun LatestNewsCarousel(
     }
 }
 
-/**
- * Displays the latest news title row.
- */
+/** Displays the latest news title row. */
 @Composable
 private fun LatestNewsHeader(
     onSeeAllClick: () -> Unit
@@ -388,7 +385,7 @@ private fun LatestNewsHeader(
             text = "CI View - Latest News",
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
-            fontSize = 18.sp,
+            fontSize = 22.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
@@ -398,24 +395,23 @@ private fun LatestNewsHeader(
             text = "See all",
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
-            fontSize = 13.sp,
+            fontSize = 15.sp,
             modifier = Modifier.clickable(onClick = onSeeAllClick)
         )
     }
 }
 
-/**
- * Displays a temporary news loading card.
- */
+/** Displays a temporary news loading card. */
 @Composable
 private fun LoadingNewsCard() {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(180.dp),
-        shape = RoundedCornerShape(34.dp),
-        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-        shadowElevation = 2.dp
+            .height(170.dp),
+        shape = RoundedCornerShape(26.dp),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 2.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.14f))
     ) {
         Box(contentAlignment = Alignment.Center) {
             Text(
@@ -427,9 +423,7 @@ private fun LoadingNewsCard() {
     }
 }
 
-/**
- * Displays one simplified purple news card.
- */
+/** Displays one horizontally scrollable news article card. */
 @Composable
 private fun HomeNewsCard(
     article: NewsArticle,
@@ -474,9 +468,7 @@ private fun HomeNewsCard(
     }
 }
 
-/**
- * Displays the small carousel page indicator dots.
- */
+/** Displays the small carousel page indicator dots. */
 @Composable
 private fun NewsCarouselIndicators(
     count: Int,
@@ -506,22 +498,7 @@ private fun NewsCarouselIndicators(
     }
 }
 
-/**
- * Displays a thin divider between the news and quick actions.
- */
-@Composable
-private fun HomeDivider() {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(1.dp)
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
-    )
-}
-
-/**
- * Displays the circular quick action buttons.
- */
+/** Displays the quick action shortcuts as circular buttons that match the calendar page. */
 @Composable
 private fun QuickActionGrid(
     onMapClick: () -> Unit,
@@ -533,75 +510,69 @@ private fun QuickActionGrid(
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(28.dp)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.Top
         ) {
             QuickActionCircleButton(
                 icon = Icons.Default.Map,
-                label = "Map",
-                contentDescription = "Open campus map",
+                title = "Map",
                 onClick = onMapClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.CalendarMonth,
-                label = "Calendar",
-                contentDescription = "Open calendar",
+                title = "Calendar",
                 onClick = onCalendarClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Groups,
-                label = "Social",
-                contentDescription = "Open social",
+                title = "Social",
                 onClick = onSocialClick
             )
         }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.Top
         ) {
             QuickActionCircleButton(
                 icon = Icons.Default.MenuBook,
-                label = "Study Rooms",
-                contentDescription = "Open study rooms",
+                title = "Study Rooms",
                 onClick = onStudyRoomsClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Person,
-                label = "Profile",
-                contentDescription = "Open profile",
+                title = "Profile",
                 onClick = onProfileClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Notifications,
-                label = "Notifications",
-                contentDescription = "Open notifications",
+                title = "Notifications",
                 onClick = onNotificationClick
             )
         }
     }
 }
 
-/**
- * Displays one circular quick action button.
- */
+/** Shows one circular quick action button with its label below it. */
 @Composable
 private fun QuickActionCircleButton(
     icon: ImageVector,
-    label: String,
-    contentDescription: String,
-    onClick: () -> Unit
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier
-            .width(92.dp)
+        modifier = modifier
+            .width(96.dp)
             .clickable(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -614,30 +585,29 @@ private fun QuickActionCircleButton(
             Box(contentAlignment = Alignment.Center) {
                 Icon(
                     imageVector = icon,
-                    contentDescription = contentDescription,
+                    contentDescription = title,
                     tint = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.size(25.dp)
+                    modifier = Modifier.size(30.dp)
                 )
             }
         }
 
-        Spacer(modifier = Modifier.height(6.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = label,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
+            text = title,
             color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            fontSize = 15.sp,
+            lineHeight = 17.sp,
             textAlign = TextAlign.Center,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
     }
 }
 
-/**
- * Removes extra campus text from the weather condition.
- */
+/** Removes extra campus text from the weather condition. */
 private fun cleanedWeatherCondition(condition: String): String {
     val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
     val isNight = hour < 6 || hour >= 19
@@ -652,9 +622,7 @@ private fun cleanedWeatherCondition(condition: String): String {
     }
 }
 
-/**
- * Chooses the best icon for the current weather condition.
- */
+/** Chooses the best icon for the current weather condition. */
 private fun weatherIconFor(condition: String): ImageVector {
     return when {
         condition.contains("Clear Sky", ignoreCase = true) -> Icons.Default.NightsStay
@@ -681,7 +649,16 @@ fun HomeScreenPreview() {
             displayUpcomingEventsItems = emptyList(),
             onUpdateSchedule = {},
             onUpdateEvents = {},
-            onNavigateToLocation = { _ -> }
+            onMapClick = {},
+            onSettingsClick = {},
+            onCalendarClick = {},
+            onAddClassClick = {},
+            onCIViewClick = {},
+            onArticleClick = {},
+            onSocialClick = {},
+            onNotificationClick = {},
+            onProfileClick = {},
+            onNavigateToLocation = {}
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -2,32 +2,36 @@ package com.example.cinet.feature.home
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.home.news.NewsArticle
 import com.example.cinet.feature.home.news.NewsRepository
-import com.example.cinet.feature.home.news.NewsSection
-import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.ui.theme.CINetTheme
-import com.example.cinet.feature.map.*
-import com.example.cinet.core.designsystem.InfoSection
-import com.example.cinet.core.designsystem.WeatherDisplay
 import java.util.Calendar
 
+@Suppress("UNUSED_PARAMETER")
 @Composable
 fun HomeScreen(
     nickname: String,
@@ -43,290 +47,602 @@ fun HomeScreen(
     onAddClassClick: () -> Unit = {},
     onCIViewClick: (NewsArticle?) -> Unit = {},
     onArticleClick: (NewsArticle) -> Unit = {},
+    onSocialClick: () -> Unit = {},
+    onNotificationClick: () -> Unit = {},
+    onProfileClick: () -> Unit = {},
     viewModel: CampusRegistry = androidx.lifecycle.viewmodel.compose.viewModel(),
     onNavigateToLocation: (String) -> Unit
 ) {
-    val academic by viewModel.academic.collectAsState(initial = emptyList())
     val context = LocalContext.current
-    var weatherInfo by remember { mutableStateOf(WeatherInfo("...", "Loading...")) }
-    
-    // Real news data from repository
     val newsRepository = remember { NewsRepository() }
+
+    var weatherInfo by remember { mutableStateOf(WeatherInfo("...", "Loading...")) }
     var newsArticles by remember { mutableStateOf<List<NewsArticle>>(emptyList()) }
 
-    // State for the "Add/Edit" dialog (Now only for Upcoming Events)
-    var showDialog by remember { mutableStateOf(false) }
-    var editingIndex by remember { mutableStateOf<Int?>(null) }
-    
-    var nameField by remember { mutableStateOf("") }
-    var timeOrDateField by remember { mutableStateOf("") }
-
-    var locationField by remember { mutableStateOf<CampusLocation?>(null) }
-    val textFieldState = rememberTextFieldState()
-    val academicNames = remember(textFieldState.text, academic) {
-        academic
-            .filter { it.name.contains(textFieldState.text.toString(), ignoreCase = true) }
-            .map { it.name }
-    }
-
-    var amPmSelection by remember { mutableStateOf("AM") } // AM/PM choice
-
-    // Support Hours logic
-    val supportHoursSubtitle = remember {
-        val calendar = Calendar.getInstance()
-        val info = when (calendar.get(Calendar.DAY_OF_WEEK)) {
-            Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY -> 
-                "11 AM - 7 PM | In Person & Online"
-            Calendar.FRIDAY -> 
-                "10 AM - 2 PM | In Person & Online"
-            Calendar.SUNDAY -> 
-                "5 PM - 7 PM | Online Only"
-            else -> "Closed | No Support Today"
-        }
-        "LRC Availability: $info"
-    }
-
-    // Call the weather fetching logic on launch
     LaunchedEffect(Unit) {
-        Log.d("HomeScreen", "LaunchedEffect triggered")
+        Log.d("HomeScreen", "Home screen launched")
         weatherInfo = WeatherHelper.fetchCampusWeather(context)
-        // Fetch real news
         newsArticles = newsRepository.fetchLatestNews()
     }
 
-    if (showDialog) {
-        AlertDialog(
-            onDismissRequest = { showDialog = false },
-            title = { 
-                Text(if (editingIndex == null) "Add Upcoming Event" else "Edit Upcoming Event") 
-            },
-            text = {
-                Column {
-                    OutlinedTextField(
-                        value = nameField,
-                        onValueChange = { nameField = it },
-                        label = { Text("Event Name") },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        OutlinedTextField(
-                            value = timeOrDateField,
-                            onValueChange = { timeOrDateField = it },
-                            label = { Text("Date/Time") },
-                            modifier = Modifier.weight(1f)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        
-                        // AM/PM Toggle
-                        Row(
-                            modifier = Modifier.padding(top = 8.dp)
-                        ) {
-                            FilterChip(
-                                selected = amPmSelection == "AM",
-                                onClick = { amPmSelection = "AM" },
-                                label = { Text("AM") }
-                            )
-                            Spacer(modifier = Modifier.width(4.dp))
-                            FilterChip(
-                                selected = amPmSelection == "PM",
-                                onClick = { amPmSelection = "PM" },
-                                label = { Text("PM") }
-                            )
-                        }
-                    }
+    HomeScreenContent(
+        nickname = nickname,
+        weatherInfo = weatherInfo,
+        newsArticles = newsArticles,
+        onMapClick = onMapClick,
+        onCalendarClick = onCalendarClick,
+        onSocialClick = onSocialClick,
+        onNotificationClick = onNotificationClick,
+        onProfileClick = onProfileClick,
+        onSettingsClick = onSettingsClick,
+        onSeeAllNewsClick = { onCIViewClick(null) },
+        onArticleClick = { article -> onCIViewClick(article) },
+        onStudyRoomsClick = {
+            onArticleClick(
+                NewsArticle(
+                    title = "Study Rooms",
+                    date = "",
+                    previewText = "Reserve a CSUCI library study room.",
+                    url = "https://csuci.libcal.com/allspaces"
+                )
+            )
+        },
+        modifier = modifier
+    )
+}
 
-                    // Location
-                    Spacer(modifier = Modifier.height(8.dp))
-                    SearchLocationBar(
-                        textFieldState = textFieldState,
-                        searchResults = academicNames,
-                        onSearch = { query ->
-                            locationField = academic.find { it.name.equals(query, ignoreCase = true) }
-                            textFieldState.edit { replace(0, length, query) }
-
-                        }
-                    )
-                }
-            },
-            confirmButton = {
-                @Suppress("DEPRECATION")
-                Button(onClick = {
-                    if (nameField.isNotBlank() && timeOrDateField.isNotBlank() && locationField != null) {
-                        val fullTime = "$timeOrDateField $amPmSelection"
-                        val newItem = nameField to "$fullTime | ${locationField?.name}"
-                        
-                        val newList = manualUpcomingEventsItems.toMutableList()
-                        if (editingIndex != null) {
-                            newList[editingIndex!!] = newItem
-                        } else {
-                            newList.add(newItem)
-                        }
-                        onUpdateEvents(newList)
-                        
-                        showDialog = false
-                        editingIndex = null
-                        nameField = ""
-                        timeOrDateField = ""
-                        locationField = null
-                    }
-                }) {
-                    Text(if (editingIndex == null) "Add" else "Update")
-                }
-            },
-            dismissButton = {
-                Row {
-                    if (editingIndex != null) {
-                        TextButton(onClick = {
-                            val newList = manualUpcomingEventsItems.toMutableList()
-                            newList.removeAt(editingIndex!!)
-                            onUpdateEvents(newList)
-                            showDialog = false
-                            editingIndex = null
-                            nameField = ""
-                            timeOrDateField = ""
-                            locationField = null
-                        }) {
-                            Text("Delete", color = MaterialTheme.colorScheme.error)
-                        }
-                    }
-                    TextButton(onClick = { 
-                        showDialog = false
-                        editingIndex = null
-                        nameField = ""
-                        timeOrDateField = ""
-                        locationField = null
-                    }) {
-                        Text("Cancel")
-                    }
-                }
-            }
-        )
-    }
-
+/**
+ * Arranges the full home screen from top to bottom.
+ */
+@Composable
+private fun HomeScreenContent(
+    nickname: String,
+    weatherInfo: WeatherInfo,
+    newsArticles: List<NewsArticle>,
+    onMapClick: () -> Unit,
+    onCalendarClick: () -> Unit,
+    onSocialClick: () -> Unit,
+    onNotificationClick: () -> Unit,
+    onProfileClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    onSeeAllNewsClick: () -> Unit,
+    onArticleClick: (NewsArticle) -> Unit,
+    onStudyRoomsClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
+            .statusBarsPadding()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(horizontal = 12.dp)
+            .padding(top = 0.dp, bottom = 4.dp)
     ) {
-        // Header Section
-        Surface(
+        HomeTopBar(
+            onProfileClick = onProfileClick,
+            onSettingsClick = onSettingsClick
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        HomeMainCard {
+            WelcomeHeader(nickname = nickname)
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            HomeWeatherBanner(
+                temp = weatherInfo.temp,
+                condition = weatherInfo.condition
+            )
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            LatestNewsCarousel(
+                articles = newsArticles,
+                onSeeAllClick = onSeeAllNewsClick,
+                onArticleClick = onArticleClick
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            QuickActionGrid(
+                onMapClick = onMapClick,
+                onCalendarClick = onCalendarClick,
+                onSocialClick = onSocialClick,
+                onStudyRoomsClick = onStudyRoomsClick,
+                onProfileClick = onProfileClick,
+                onNotificationClick = onNotificationClick
+            )
+        }
+    }
+}
+
+/**
+ * Displays the top CINET title and action buttons.
+ */
+@Composable
+private fun HomeTopBar(
+    onProfileClick: () -> Unit,
+    onSettingsClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "CINET",
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 26.sp,
+            letterSpacing = 0.3.sp
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        HeaderIconButton(
+            icon = Icons.Default.Person,
+            contentDescription = "Open profile",
+            onClick = onProfileClick
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        HeaderIconButton(
+            icon = Icons.Default.MoreVert,
+            contentDescription = "Open settings",
+            onClick = onSettingsClick
+        )
+    }
+}
+
+/**
+ * Displays one circular icon button in the top header.
+ */
+@Composable
+private fun HeaderIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .size(44.dp)
+            .clickable(onClick = onClick),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+    }
+}
+
+/**
+ * Holds all main home page content inside one large rounded card.
+ */
+@Composable
+private fun HomeMainCard(
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth()
+            .fillMaxWidth()
+            .height(600.dp),
+        shape = RoundedCornerShape(38.dp),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 10.dp
+    ) {
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(130.dp),
-            color = MaterialTheme.colorScheme.primary,
-            shape = RoundedCornerShape(12.dp)
+                .padding(horizontal = 18.dp, vertical = 24.dp)
+        ){
+            content()
+        }
+    }
+}
+
+/**
+ * Displays the greeting at the top of the main card.
+ */
+@Composable
+private fun WelcomeHeader(nickname: String) {
+    val displayName = nickname.ifBlank { "there" }
+
+    Text(
+        text = "Welcome back, $displayName 👋",
+        color = MaterialTheme.colorScheme.onSurface,
+        fontWeight = FontWeight.ExtraBold,
+        fontSize = 22.sp,
+        lineHeight = 26.sp,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/**
+ * Displays the weather summary without the "Campus Weather" label.
+ */
+@Composable
+private fun HomeWeatherBanner(
+    temp: String,
+    condition: String
+) {
+    val displayCondition = remember(condition) { cleanedWeatherCondition(condition) }
+    val weatherIcon = remember(displayCondition) { weatherIconFor(displayCondition) }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(34.dp),
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 5.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp)
-            ) {
+            Icon(
+                imageVector = weatherIcon,
+                contentDescription = displayCondition,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(28.dp)
+            )
+
+            Spacer(modifier = Modifier.width(14.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Welcome back to CINet, $nickname",
+                    text = "$temp • $displayCondition",
                     color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 17.sp,
+                    lineHeight = 21.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-                Spacer(modifier = Modifier.height(12.dp))
-                
-                WeatherDisplay(
-                    modifier = Modifier.fillMaxWidth(),
-                    temp = weatherInfo.temp,
-                    condition = weatherInfo.condition + " - Camarillo, CA"
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Text(
+                    text = "Camarillo, CA",
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.86f),
+                    fontSize = 12.sp,
+                    lineHeight = 15.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }
+    }
+}
 
-        Spacer(modifier = Modifier.height(16.dp))
-        
-        // Quick Actions Row
+/**
+ * Displays the latest news heading, carousel cards, and page indicators.
+ */
+@Composable
+private fun LatestNewsCarousel(
+    articles: List<NewsArticle>,
+    onSeeAllClick: () -> Unit,
+    onArticleClick: (NewsArticle) -> Unit
+) {
+    val listState = rememberLazyListState()
+    val activeIndex by remember(articles.size) {
+        derivedStateOf {
+            if (articles.isEmpty()) {
+                0
+            } else {
+                listState.firstVisibleItemIndex.coerceIn(0, articles.lastIndex)
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        LatestNewsHeader(onSeeAllClick = onSeeAllClick)
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        if (articles.isEmpty()) {
+            LoadingNewsCard()
+        } else {
+            LazyRow(
+                state = listState,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(end = 20.dp)
+            ) {
+                itemsIndexed(articles) { _, article ->
+                    HomeNewsCard(
+                        article = article,
+                        onClick = { onArticleClick(article) }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            NewsCarouselIndicators(
+                count = articles.size.coerceAtMost(5),
+                activeIndex = activeIndex.coerceAtMost(4)
+            )
+        }
+    }
+}
+
+/**
+ * Displays the latest news title row.
+ */
+@Composable
+private fun LatestNewsHeader(
+    onSeeAllClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "CI View - Latest News",
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 18.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+
+        Text(
+            text = "See all",
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 13.sp,
+            modifier = Modifier.clickable(onClick = onSeeAllClick)
+        )
+    }
+}
+
+/**
+ * Displays a temporary news loading card.
+ */
+@Composable
+private fun LoadingNewsCard() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(180.dp),
+        shape = RoundedCornerShape(34.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+        shadowElevation = 2.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = "Loading latest campus news...",
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+/**
+ * Displays one simplified purple news card.
+ */
+@Composable
+private fun HomeNewsCard(
+    article: NewsArticle,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .width(165.dp)
+            .height(165.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(28.dp),
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 4.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 10.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Article,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(24.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = article.title,
+                color = MaterialTheme.colorScheme.onPrimary,
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = 13.sp,
+                lineHeight = 16.sp,
+                textAlign = TextAlign.Center,
+                maxLines = 5,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+/**
+ * Displays the small carousel page indicator dots.
+ */
+@Composable
+private fun NewsCarouselIndicators(
+    count: Int,
+    activeIndex: Int
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        repeat(count) { index ->
+            Box(
+                modifier = Modifier
+                    .padding(horizontal = 5.dp)
+                    .width(if (index == activeIndex) 36.dp else 24.dp)
+                    .height(7.dp)
+                    .background(
+                        color = if (index == activeIndex) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
+                        },
+                        shape = RoundedCornerShape(50)
+                    )
+            )
+        }
+    }
+}
+
+/**
+ * Displays a thin divider between the news and quick actions.
+ */
+@Composable
+private fun HomeDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
+    )
+}
+
+/**
+ * Displays the circular quick action buttons.
+ */
+@Composable
+private fun QuickActionGrid(
+    onMapClick: () -> Unit,
+    onCalendarClick: () -> Unit,
+    onSocialClick: () -> Unit,
+    onStudyRoomsClick: () -> Unit,
+    onProfileClick: () -> Unit,
+    onNotificationClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
+            horizontalArrangement = Arrangement.SpaceEvenly
         ) {
-            Button(
-                onClick = { 
-                    val studyRoomsLink = "https://csuci.libcal.com/allspaces"
-                    onArticleClick(NewsArticle("Study Rooms", "", "", studyRoomsLink))
-                },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(8.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-                contentPadding = PaddingValues(vertical = 12.dp)
-            ) {
-                Icon(Icons.Default.Language, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("Study Rooms")
-            }
+            QuickActionCircleButton(
+                icon = Icons.Default.Map,
+                contentDescription = "Open campus map",
+                onClick = onMapClick
+            )
+
+            QuickActionCircleButton(
+                icon = Icons.Default.CalendarMonth,
+                contentDescription = "Open calendar",
+                onClick = onCalendarClick
+            )
+
+            QuickActionCircleButton(
+                icon = Icons.Default.Groups,
+                contentDescription = "Open social",
+                onClick = onSocialClick
+            )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            QuickActionCircleButton(
+                icon = Icons.Default.MenuBook,
+                contentDescription = "Open study rooms",
+                onClick = onStudyRoomsClick
+            )
 
-        // CI View Section
-        NewsSection(
-            articles = newsArticles,
-            onSeeAllClick = { onCIViewClick(null) },
-            onArticleClick = { onCIViewClick(it) }
-        )
+            QuickActionCircleButton(
+                icon = Icons.Default.Person,
+                contentDescription = "Open profile",
+                onClick = onProfileClick
+            )
 
-        Spacer(modifier = Modifier.height(16.dp))
+            QuickActionCircleButton(
+                icon = Icons.Default.Notifications,
+                contentDescription = "Open notifications",
+                onClick = onNotificationClick
+            )
+        }
+    }
+}
 
-        // Today's Schedule Section (Sourced from Calendar)
-        InfoSection(
-            title = "Today's Schedule",
-            subtitle = supportHoursSubtitle,
-            items = scheduleItems,
-            onAddClick = onAddClassClick,
-            onItemClick = { _ -> onCalendarClick() }, // Open calendar on item click
-            onNavigateToLocation = onNavigateToLocation
-        )
+/**
+ * Displays one circular quick action button.
+ */
+@Composable
+private fun QuickActionCircleButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .size(75.dp)
+            .clickable(onClick = onClick),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 5.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(25.dp)
+            )
+        }
+    }
+}
 
-        Spacer(modifier = Modifier.height(16.dp))
+/**
+ * Removes extra campus text from the weather condition.
+ */
+private fun cleanedWeatherCondition(condition: String): String {
+    val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+    val isNight = hour < 6 || hour >= 19
+    val campusText = condition
+        .replace(" - Camarillo, CA", "", ignoreCase = true)
+        .trim()
 
-        // Upcoming Events Section
-        InfoSection(
-            title = "Upcoming Events",
-            items = displayUpcomingEventsItems.map { it.title to it.description },
-            onAddClick = {
-                editingIndex = null
-                nameField = ""
-                timeOrDateField = ""
-                locationField = null
-                showDialog = true
-            },
-            onItemClick = { index ->
-                val selectedItem = displayUpcomingEventsItems[index]
-                if (selectedItem.isCampusEvent) {
-                    onCalendarClick()
-                } else {
-                    val manualIndex = manualUpcomingEventsItems.indexOfFirst {
-                        it.first == selectedItem.title && it.second == selectedItem.description
-                    }
+    return if (isNight && campusText.contains("Sunny", ignoreCase = true)) {
+        "Clear Sky"
+    } else {
+        campusText.ifBlank { "Loading..." }
+    }
+}
 
-                    if (manualIndex == -1) {
-                        onCalendarClick()
-                    } else {
-                        editingIndex = manualIndex
-                        val item = manualUpcomingEventsItems[manualIndex]
-                        nameField = item.first
-                        // Simple parsing for demo purposes
-                        val parts = item.second.split(" | ")
-                        val timeParts = parts[0].split(" ")
-                        timeOrDateField = if (timeParts.isNotEmpty()) timeParts[0] else ""
-                        amPmSelection = if (timeParts.size > 1) timeParts[1] else "AM"
-                        locationField = academic.find { it.name == if (parts.size > 1) parts[1] else "" }
-                        showDialog = true
-                    }
-                }
-            },
-            onNavigateToLocation = onNavigateToLocation
-        )
+/**
+ * Chooses the best icon for the current weather condition.
+ */
+private fun weatherIconFor(condition: String): ImageVector {
+    return when {
+        condition.contains("Clear Sky", ignoreCase = true) -> Icons.Default.NightsStay
+        condition.contains("Sunny", ignoreCase = true) -> Icons.Default.WbSunny
+        condition.contains("Clear", ignoreCase = true) -> Icons.Default.WbSunny
+        condition.contains("Partly Cloudy", ignoreCase = true) -> Icons.Default.WbCloudy
+        condition.contains("Cloudy", ignoreCase = true) -> Icons.Default.Cloud
+        condition.contains("Cloud", ignoreCase = true) -> Icons.Default.Cloud
+        condition.contains("Rain", ignoreCase = true) -> Icons.Default.Umbrella
+        condition.contains("Shower", ignoreCase = true) -> Icons.Default.Umbrella
+        condition.contains("Thunder", ignoreCase = true) -> Icons.Default.Thunderstorm
+        else -> Icons.Default.Cloud
     }
 }
 
@@ -335,7 +651,7 @@ fun HomeScreen(
 fun HomeScreenPreview() {
     CINetTheme {
         HomeScreen(
-            nickname = "User",
+            nickname = "Maddi",
             scheduleItems = emptyList(),
             manualUpcomingEventsItems = emptyList(),
             displayUpcomingEventsItems = emptyList(),

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -138,10 +138,6 @@ private fun HomeScreenContent(
             .padding(horizontal = 24.dp)
             .padding(top = 18.dp, bottom = 24.dp)
     ) {
-        HomeTopBar(
-            onProfileClick = onProfileClick,
-            onSettingsClick = onSettingsClick
-        )
 
         Spacer(modifier = Modifier.height(32.dp))
 
@@ -179,68 +175,6 @@ private fun HomeScreenContent(
     }
 }
 
-/** Displays the top CINET title and action buttons. */
-@Composable
-private fun HomeTopBar(
-    onProfileClick: () -> Unit,
-    onSettingsClick: () -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = "CINET",
-            color = MaterialTheme.colorScheme.primary,
-            fontWeight = FontWeight.ExtraBold,
-            fontSize = 34.sp,
-            letterSpacing = 0.4.sp
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        HeaderIconButton(
-            icon = Icons.Default.Person,
-            contentDescription = "Open profile",
-            onClick = onProfileClick
-        )
-
-        Spacer(modifier = Modifier.width(12.dp))
-
-        HeaderIconButton(
-            icon = Icons.Default.MoreVert,
-            contentDescription = "Open settings",
-            onClick = onSettingsClick
-        )
-    }
-}
-
-/** Displays one soft circular icon button in the top header. */
-@Composable
-private fun HeaderIconButton(
-    icon: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier
-            .size(54.dp)
-            .clickable(onClick = onClick),
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-        shadowElevation = 0.dp
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(28.dp)
-            )
-        }
-    }
-}
-
 /** Displays the greeting and subtitle at the top of the home page. */
 @Composable
 private fun WelcomeHeader(nickname: String) {
@@ -255,16 +189,6 @@ private fun WelcomeHeader(nickname: String) {
             lineHeight = 34.sp,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
-        )
-
-        Spacer(modifier = Modifier.height(6.dp))
-
-        Text(
-            text = "Here’s what’s happening on campus",
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f),
-            fontWeight = FontWeight.Medium,
-            fontSize = 17.sp,
-            lineHeight = 22.sp
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.cinet.NewsArticle
-import com.example.cinet.NewsRepository
-import com.example.cinet.NewsSection
+import com.example.cinet.feature.home.news.NewsArticle
+import com.example.cinet.feature.home.news.NewsRepository
+import com.example.cinet.feature.home.news.NewsSection
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.ui.theme.CINetTheme
 import com.example.cinet.feature.map.*

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -4,18 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -25,20 +14,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -50,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.home.news.NewsArticle
 import com.example.cinet.feature.home.news.NewsRepository
+import com.example.cinet.feature.map.BusScheduleSheet
 import com.example.cinet.ui.theme.CINetTheme
 import java.util.Calendar
 
@@ -80,6 +61,7 @@ fun HomeScreen(
 
     var weatherInfo by remember { mutableStateOf(WeatherInfo("...", "Loading...")) }
     var newsArticles by remember { mutableStateOf<List<NewsArticle>>(emptyList()) }
+    var showBusScheduleSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         Log.d("HomeScreen", "Home screen launched")
@@ -91,10 +73,11 @@ fun HomeScreen(
         nickname = nickname,
         weatherInfo = weatherInfo,
         newsArticles = newsArticles,
+        nextUpcomingEvent = displayUpcomingEventsItems.firstOrNull(),
         onMapClick = onMapClick,
         onCalendarClick = onCalendarClick,
         onSocialClick = onSocialClick,
-        onNotificationClick = onNotificationClick,
+        onNotificationClick = { showBusScheduleSheet = true },
         onProfileClick = onProfileClick,
         onSettingsClick = onSettingsClick,
         onSeeAllNewsClick = { onCIViewClick(null) },
@@ -111,6 +94,12 @@ fun HomeScreen(
         },
         modifier = modifier
     )
+
+    if (showBusScheduleSheet) {
+        BusScheduleSheet(
+            onDismiss = { showBusScheduleSheet = false }
+        )
+    }
 }
 
 /** Arranges the home screen from top to bottom. */
@@ -119,6 +108,7 @@ private fun HomeScreenContent(
     nickname: String,
     weatherInfo: WeatherInfo,
     newsArticles: List<NewsArticle>,
+    nextUpcomingEvent: HomeUpcomingEventItem?,
     onMapClick: () -> Unit,
     onCalendarClick: () -> Unit,
     onSocialClick: () -> Unit,
@@ -158,6 +148,12 @@ private fun HomeScreenContent(
             onArticleClick = onArticleClick
         )
 
+        if (nextUpcomingEvent != null) {
+            Spacer(modifier = Modifier.height(14.dp))
+
+            NextUpcomingEventBanner(nextUpcomingEvent = nextUpcomingEvent)
+        }
+
         Spacer(modifier = Modifier.height(24.dp))
 
         HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f))
@@ -175,7 +171,7 @@ private fun HomeScreenContent(
     }
 }
 
-/** Displays the greeting and subtitle at the top of the home page. */
+/** Displays the greeting and keeps it locked to one line by scaling long names down. */
 @Composable
 private fun WelcomeHeader(nickname: String) {
     val displayName = nickname.ifBlank { "there" }
@@ -185,12 +181,20 @@ private fun WelcomeHeader(nickname: String) {
             text = "Welcome back, $displayName 👋",
             color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
-            fontSize = 28.sp,
-            lineHeight = 34.sp,
-            maxLines = 2,
+            fontSize = greetingFontSizeFor(displayName),
+            maxLines = 1,
+            softWrap = false,
             overflow = TextOverflow.Ellipsis
         )
     }
+}
+
+/** Chooses a smaller greeting size when the name is longer so the greeting stays on one line. */
+private fun greetingFontSizeFor(displayName: String) = when {
+    displayName.length > 22 -> 20.sp
+    displayName.length > 16 -> 22.sp
+    displayName.length > 10 -> 24.sp
+    else -> 26.sp
 }
 
 /** Displays the weather summary without the "Campus Weather" label. */
@@ -244,6 +248,106 @@ private fun HomeWeatherBanner(
                 )
             }
         }
+    }
+}
+
+/** Displays the next upcoming calendar event using the calendar pill style with the home banner shape. */
+@Composable
+private fun NextUpcomingEventBanner(nextUpcomingEvent: HomeUpcomingEventItem) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(34.dp),
+        color = MaterialTheme.colorScheme.primary,
+        shadowElevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(4.dp)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(50))
+                    .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.42f))
+            )
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = nextUpcomingEvent.title,
+                    fontSize = 15.sp,
+                    lineHeight = 18.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    text = nextUpcomingEventTimeText(nextUpcomingEvent),
+                    fontSize = 12.sp,
+                    lineHeight = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.88f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.90f),
+                        modifier = Modifier.size(13.dp)
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    Text(
+                        text = nextUpcomingEventLocationText(nextUpcomingEvent),
+                        fontSize = 12.sp,
+                        lineHeight = 14.sp,
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.88f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Icon(
+                imageVector = Icons.Default.Notifications,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(19.dp)
+            )
+        }
+    }
+}
+
+/** Pulls the date/time part from the Home event description when possible. */
+private fun nextUpcomingEventTimeText(event: HomeUpcomingEventItem): String {
+    return event.description
+        .substringBefore("|")
+        .trim()
+        .ifBlank { if (event.isCampusEvent) "Campus Event" else "Upcoming Event" }
+}
+
+/** Pulls the location part from the Home event description when possible. */
+private fun nextUpcomingEventLocationText(event: HomeUpcomingEventItem): String {
+    val locationText = event.description
+        .substringAfter("|", missingDelimiterValue = "")
+        .trim()
+
+    return locationText.ifBlank {
+        if (event.isCampusEvent) "Campus Event • Reminder on" else "Calendar Event"
     }
 }
 
@@ -440,25 +544,7 @@ private fun QuickActionGrid(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.Top
-        ) {
-            QuickActionCircleButton(
-                icon = Icons.Default.Map,
-                title = "Map",
-                onClick = onMapClick
-            )
-
-            QuickActionCircleButton(
-                icon = Icons.Default.CalendarMonth,
-                title = "Calendar",
-                onClick = onCalendarClick
-            )
-
-            QuickActionCircleButton(
-                icon = Icons.Default.Groups,
-                title = "Social",
-                onClick = onSocialClick
-            )
-        }
+        ) { }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -478,8 +564,8 @@ private fun QuickActionGrid(
             )
 
             QuickActionCircleButton(
-                icon = Icons.Default.Notifications,
-                title = "Notifications",
+                icon = Icons.Default.DirectionsBus,
+                title = "Bus Schedule",
                 onClick = onNotificationClick
             )
         }

--- a/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.feature.home
 
+import android.R
 import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -114,10 +115,9 @@ private fun HomeScreenContent(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f))
-            .statusBarsPadding()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 12.dp)
-            .padding(top = 0.dp, bottom = 4.dp)
+            .padding(top = 15.dp, bottom = 4.dp)
     ) {
         HomeTopBar(
             onProfileClick = onProfileClick,
@@ -217,7 +217,7 @@ private fun HeaderIconButton(
                 imageVector = icon,
                 contentDescription = contentDescription,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(22.dp)
+                modifier = Modifier.size(30.dp)
             )
         }
     }
@@ -233,7 +233,7 @@ private fun HomeMainCard(
     Surface(
         modifier = Modifier.fillMaxWidth()
             .fillMaxWidth()
-            .height(600.dp),
+            .height(650.dp),
         shape = RoundedCornerShape(38.dp),
         color = MaterialTheme.colorScheme.surface,
         shadowElevation = 10.dp
@@ -386,7 +386,7 @@ private fun LatestNewsHeader(
     ) {
         Text(
             text = "CI View - Latest News",
-            color = MaterialTheme.colorScheme.primary,
+            color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
             fontSize = 18.sp,
             maxLines = 1,
@@ -396,7 +396,7 @@ private fun LatestNewsHeader(
 
         Text(
             text = "See all",
-            color = MaterialTheme.colorScheme.primary,
+            color = MaterialTheme.colorScheme.onSurface,
             fontWeight = FontWeight.ExtraBold,
             fontSize = 13.sp,
             modifier = Modifier.clickable(onClick = onSeeAllClick)
@@ -541,18 +541,21 @@ private fun QuickActionGrid(
         ) {
             QuickActionCircleButton(
                 icon = Icons.Default.Map,
+                label = "Map",
                 contentDescription = "Open campus map",
                 onClick = onMapClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.CalendarMonth,
+                label = "Calendar",
                 contentDescription = "Open calendar",
                 onClick = onCalendarClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Groups,
+                label = "Social",
                 contentDescription = "Open social",
                 onClick = onSocialClick
             )
@@ -564,18 +567,21 @@ private fun QuickActionGrid(
         ) {
             QuickActionCircleButton(
                 icon = Icons.Default.MenuBook,
+                label = "Study Rooms",
                 contentDescription = "Open study rooms",
                 onClick = onStudyRoomsClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Person,
+                label = "Profile",
                 contentDescription = "Open profile",
                 onClick = onProfileClick
             )
 
             QuickActionCircleButton(
                 icon = Icons.Default.Notifications,
+                label = "Notifications",
                 contentDescription = "Open notifications",
                 onClick = onNotificationClick
             )
@@ -589,25 +595,43 @@ private fun QuickActionGrid(
 @Composable
 private fun QuickActionCircleButton(
     icon: ImageVector,
+    label: String,
     contentDescription: String,
     onClick: () -> Unit
 ) {
-    Surface(
+    Column(
         modifier = Modifier
-            .size(75.dp)
+            .width(92.dp)
             .clickable(onClick = onClick),
-        shape = CircleShape,
-        color = MaterialTheme.colorScheme.primary,
-        shadowElevation = 5.dp
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Box(contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = icon,
-                contentDescription = contentDescription,
-                tint = MaterialTheme.colorScheme.onPrimary,
-                modifier = Modifier.size(25.dp)
-            )
+        Surface(
+            modifier = Modifier.size(75.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.primary,
+            shadowElevation = 5.dp
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(25.dp)
+                )
+            }
         }
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/java/com/example/cinet/feature/home/news/CIViewScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/news/CIViewScreen.kt
@@ -1,4 +1,4 @@
-package com.example.cinet
+package com.example.cinet.feature.home.news
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 
@@ -41,7 +42,7 @@ fun CIViewScreen(
                         Text(
                             text = selectedArticleTitle ?: "CI View",
                             maxLines = 1,
-                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis
                         ) 
                     },
                     navigationIcon = {

--- a/app/src/main/java/com/example/cinet/feature/home/news/NewsRepository.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/news/NewsRepository.kt
@@ -1,4 +1,4 @@
-package com.example.cinet
+package com.example.cinet.feature.home.news
 
 import android.util.Xml
 import kotlinx.coroutines.Dispatchers
@@ -8,7 +8,7 @@ import okhttp3.Request
 import org.xmlpull.v1.XmlPullParser
 import java.io.InputStream
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 
 /**
  * Repository class to handle fetching and parsing news from the CI View RSS feed.

--- a/app/src/main/java/com/example/cinet/feature/home/news/NewsSection.kt
+++ b/app/src/main/java/com/example/cinet/feature/home/news/NewsSection.kt
@@ -1,6 +1,5 @@
-package com.example.cinet
+package com.example.cinet.feature.home.news
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
@@ -12,13 +11,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 data class NewsArticle(
     val title: String,

--- a/app/src/main/java/com/example/cinet/feature/map/DirectionsSheet.kt
+++ b/app/src/main/java/com/example/cinet/feature/map/DirectionsSheet.kt
@@ -328,19 +328,35 @@ fun BusScheduleSheet(onDismiss: () -> Unit) {
         text = {
             Row(modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.weight(1f),horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("Arriving", style = MaterialTheme.typography.labelLarge)
+                    Text(
+                        text = "Arriving",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
                     HorizontalDivider()
                     arrival.forEach { time ->
-                        Text(text = time, modifier = Modifier.padding(vertical = 8.dp))
+                        Text(
+                            text = time,
+                            modifier = Modifier.padding(vertical = 8.dp),
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
                         HorizontalDivider()
                     }
                 }
                 Spacer(modifier = Modifier.width(16.dp))
                 Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("Departing", style = MaterialTheme.typography.labelLarge)
+                    Text(
+                        text = "Departing",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
                     HorizontalDivider()
                     departure.forEach { time ->
-                        Text(text = time, modifier = Modifier.padding(vertical = 8.dp))
+                        Text(
+                            text = time,
+                            modifier = Modifier.padding(vertical = 8.dp),
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
                         HorizontalDivider()
                     }
                 }

--- a/app/src/main/java/com/example/cinet/feature/map/MapControls.kt
+++ b/app/src/main/java/com/example/cinet/feature/map/MapControls.kt
@@ -139,7 +139,7 @@ fun FilterMenu(
         ) {
             Surface(
                 shape = RoundedCornerShape(28.dp),
-                //color = MaterialTheme.colorScheme.secondary,
+                color = MaterialTheme.colorScheme.secondary,
                 tonalElevation = 6.dp,
             ) {
                 Column(
@@ -216,8 +216,8 @@ fun FilterMenu(
                                 },
                                 colors = SwitchDefaults.colors(
                                     checkedThumbColor = Color.White,
-                                    checkedTrackColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    uncheckedTrackColor = Color.DarkGray
+                                    checkedTrackColor = MaterialTheme.colorScheme.secondary,
+                                    uncheckedTrackColor = Color.White
                                 )
                             )
                         }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -146,6 +146,7 @@ private fun MainScaffold(
     var currentScreen by remember { mutableStateOf(Screen.Home) }
     var showAddClassOnCalendar by remember { mutableStateOf(false) }
     var showProfileEdit by remember { mutableStateOf(false) }
+    var profileOpenedFromHome by remember { mutableStateOf(false) }
 
     // Social sub-navigation stack
     var activeConversation by remember { mutableStateOf<Conversation?>(null) }
@@ -250,6 +251,7 @@ private fun MainScaffold(
                                 currentScreen = screen
                                 showCIView = false
                                 selectedNewsArticle = null
+                                profileOpenedFromHome = false
                                 // Tapping Social from any other tab OR while already on Social
                                 // always returns to the Messages (ConversationsListScreen) root.
                                 if (screen == Screen.Social) {
@@ -338,6 +340,19 @@ private fun MainScaffold(
                         },
                         onArticleClick = { article ->
                             selectedNewsArticle = article
+                        },
+                        onSocialClick = {
+                            currentScreen = Screen.Social
+                            activeConversation = null
+                            selectedProfile = null
+                            showNewConversation = false
+                            showSocialScreen = false
+                        },
+                        onNotificationClick = { currentScreen = Screen.Settings },
+                        onProfileClick = {
+                            profileOpenedFromHome = true
+                            selectedProfile = userProfile
+                            currentScreen = Screen.Settings
                         },
                         onNavigateToLocation = { locationName ->
                             val location = campusRegistry["academic"]?.find { it.name == locationName }
@@ -439,7 +454,13 @@ private fun MainScaffold(
                             user = displayProfile,
                             currentUserProfile = userProfile,
                             onOpenConversation = { activeConversation = it; currentScreen = Screen.Social },
-                            onBack = { selectedProfile = null },
+                            onBack = {
+                                selectedProfile = null
+                                if (profileOpenedFromHome) {
+                                    profileOpenedFromHome = false
+                                    currentScreen = Screen.Home
+                                }
+                            },
                             onEditProfile = { showProfileEdit = true },
                         )
                     } else {
@@ -453,7 +474,10 @@ private fun MainScaffold(
                                 authViewModel.updateSettings(dark, notify, theme)
                             },
                             userProfile = userProfile,
-                            onViewProfile = { selectedProfile = userProfile },
+                            onViewProfile = {
+                                profileOpenedFromHome = false
+                                selectedProfile = userProfile
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.cinet.CIViewScreen
-import com.example.cinet.NewsArticle
+import com.example.cinet.feature.home.news.CIViewScreen
+import com.example.cinet.feature.home.news.NewsArticle
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.model.UserProfile

--- a/app/src/main/java/com/example/cinet/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/cinet/ui/theme/Color.kt
@@ -3,14 +3,14 @@ package com.example.cinet.ui.theme
 import androidx.compose.ui.graphics.Color
 
 
-val CINetBlue = Color(0xFF0067A2)   // make it all greeeeen
+
 val CINetBackground = Color(0xFFE0E0E0)
 
-val CINetPrimaryLight = CINetBlue
+val CINetPrimaryLight = Color(0xFF0D8654)
 
 val CINetSecondaryLight = Color(0xFF009F64)
 
-val CINetTertiaryLight = Color.Black
+val CINetTertiaryLight = Color.White
 
 val CINetPrimaryDark = Color(0xFF006140)    // make it all greeeeen
 val CINetSecondaryDark = Color(0xFF006140)

--- a/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
@@ -85,7 +85,7 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
     return if (isDark) {
         darkColorScheme(
             primary = selectedTheme.dark,
-            secondary = CINetBlue,
+            secondary = selectedTheme.dark,
             tertiary = CINetTertiaryDark,
             secondaryContainer = selectedTheme.darkButton,
             background = Color(0xFF121212),
@@ -99,13 +99,13 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
     } else {
         lightColorScheme(
             primary = selectedTheme.light,
-            secondary = CINetBlue,
+            secondary = selectedTheme.light,
             tertiary = CINetTertiaryLight,
             secondaryContainer = selectedTheme.lightButton,
             background = CINetBackground,
             surface = Color.White,
-            onPrimary = Color.Black,
-            onSecondary = Color.Black,
+            onPrimary = Color.White,
+            onSecondary = Color.White,
             onTertiary = Color.White,
             onBackground = Color.Black,
             onSurface = Color.Black

--- a/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/cinet/ui/theme/Theme.kt
@@ -85,7 +85,7 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
     return if (isDark) {
         darkColorScheme(
             primary = selectedTheme.dark,
-            secondary = selectedTheme.dark,
+            secondary = selectedTheme.darkButton,
             tertiary = CINetTertiaryDark,
             secondaryContainer = selectedTheme.darkButton,
             background = Color(0xFF121212),
@@ -99,7 +99,7 @@ fun getDynamicColorScheme(selectedTheme: AppThemeColor, isDark: Boolean): ColorS
     } else {
         lightColorScheme(
             primary = selectedTheme.light,
-            secondary = selectedTheme.light,
+            secondary = selectedTheme.lightButton,
             tertiary = CINetTertiaryLight,
             secondaryContainer = selectedTheme.lightButton,
             background = CINetBackground,


### PR DESCRIPTION
Calendar and Home UI Update Summary

This update refines the Home and Calendar screens so the app has a more consistent visual style and cleaner layout.

Home Screen Changes
- Kept the original CI View - Latest News functionality.
- Preserved the horizontal scrolling news section and article click behavior.
- Updated the quick action buttons at the bottom of the Home screen to better match the Calendar quick action icon style.
- Removed extra event feed content from the Home screen so the layout stays focused on news and quick actions.

Calendar Screen Changes
- Updated the Calendar screen to better match the Home screen style.
- Merged the Day / Week / Month selector into the same main calendar grid banner.
- Reduced spacing between the major calendar sections so the page feels more compact.
- Removed the top CINET header text from the Calendar screen.
- Removed the two top-right Calendar screen buttons.
- Removed the Today/date banner.
- Removed the text: "Here's what's on your schedule".
- Made the calendar grid banner smaller and more compact.
- Made individual event banners smaller.
- Restored the three Calendar quick access icons at the bottom of the page and kept their original functionality.
- Fixed the event indicator dots in Month view so they no longer get cut off.
- Changed the default Calendar view to Month view.

Files Updated
- HomeScreen.kt
- CalendarScreen.kt
- CalendarHeader.kt
- CalendarModeViews.kt
- CalendarDailyAgendaCard.kt
- CalendarQuickAccessCards.kt
- CalendarViewModel.kt

Notes
- The Calendar screen functionality was preserved while adjusting the layout and styling.
- The Home screen news functionality was preserved while removing unnecessary event feed content.
- The Calendar quick access buttons still perform their original actions.
