### PR TITLE
feat(messaging): attachment send with 2-step preview, image viewer, and captions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.browser:browser:1.8.0")
+    implementation("com.google.firebase:firebase-storage:22.0.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services")
     implementation(libs.okhttp)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -1,5 +1,8 @@
 package com.example.cinet.data.remote
 
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Log
 import com.example.cinet.feature.calendar.event.EventItem
 import com.example.cinet.feature.calendar.schedule.ScheduleItem
@@ -13,11 +16,13 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
+import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
 
 class SocialRepository(
     private val db: FirebaseFirestore = FirebaseFirestore.getInstance(),
     private val auth: FirebaseAuth = FirebaseAuth.getInstance(),
+    private val storage: FirebaseStorage = FirebaseStorage.getInstance(),
 ) {
 
     /** Returns the current signed-in user's uid. */
@@ -334,6 +339,53 @@ class SocialRepository(
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e("SocialRepository", "sendMessage failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Picks a file URI, uploads it to Firebase Storage at
+     *   conversations/{conversationId}/attachments/{messageId}
+     * then sends a Message with type="attachment" and metadata keys:
+     *   url, fileName, mimeType.
+     * The last-message preview is "📎 <fileName>".
+     */
+    suspend fun sendAttachment(
+        conversationId: String,
+        uri: Uri,
+        context: Context,
+    ): Result<Unit> {
+        return try {
+            val currentUser = getCurrentUserProfile()
+            // Reserve the Firestore doc ID first so we can use it as the Storage file name.
+            val messageId = db.collection("conversations")
+                .document(conversationId)
+                .collection("messages")
+                .document()
+                .id
+
+            val mimeType = context.contentResolver.getType(uri) ?: "application/octet-stream"
+            val fileName = resolveFileName(context, uri)
+
+            val downloadUrl = uploadToStorage(conversationId, messageId, uri)
+
+            val message = buildMessage(
+                sender = currentUser,
+                content = "📎 $fileName",
+                type = "attachment",
+                metadata = mapOf(
+                    "url"      to downloadUrl,
+                    "fileName" to fileName,
+                    "mimeType" to mimeType,
+                ),
+                overrideId = messageId,
+            )
+            saveMessage(conversationId, message)
+            updateConversationLastMessage(conversationId, "📎 $fileName")
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "sendAttachment failed: ${e.message}")
             Result.failure(e)
         }
     }
@@ -679,8 +731,9 @@ class SocialRepository(
         content: String,
         type: String,
         metadata: Map<String, String>,
+        overrideId: String? = null,
     ): Message {
-        val messageId = db.collection("conversations")
+        val messageId = overrideId ?: db.collection("conversations")
             .document()
             .id
 
@@ -789,5 +842,33 @@ class SocialRepository(
             time = time,
             location = location,
         )
+    }
+
+    /** Uploads [uri] to Storage and returns the HTTPS download URL. */
+    private suspend fun uploadToStorage(
+        conversationId: String,
+        messageId: String,
+        uri: Uri,
+    ): String {
+        val ref = storage.reference
+            .child("conversations/$conversationId/attachments/$messageId")
+        ref.putFile(uri).await()
+        return ref.downloadUrl.await().toString()
+    }
+
+    /**
+     * Resolves a human-readable file name from a content URI using
+     * [OpenableColumns.DISPLAY_NAME]. Falls back to "attachment" if the
+     * column is unavailable (e.g. a file:// URI without a name segment).
+     */
+    private fun resolveFileName(context: Context, uri: Uri): String {
+        var name = "attachment"
+        runCatching {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val col = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (col >= 0 && cursor.moveToFirst()) name = cursor.getString(col)
+            }
+        }
+        return name
     }
 }

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -277,6 +277,7 @@ class SocialRepository(
             )
 
             if (!isGroup) {
+                // DM path: find any existing active DM with exactly these participants.
                 val existingConversation = findExistingDirectConversation(participantIds)
                 if (existingConversation != null) {
                     Log.d(
@@ -284,6 +285,20 @@ class SocialRepository(
                         "Found existing conversation: ${existingConversation.id}"
                     )
                     return Result.success(existingConversation)
+                }
+            } else {
+                // Group path: deduplicate by exact participant set + group name.
+                // Without this check, network timeouts after a successful Firestore
+                // write let the creator tap "Create" again, producing a second group
+                // document. Creator ends up in G2 while other members reply in G1 —
+                // making replies appear "individual" from the creator's perspective.
+                val existingGroup = findExistingGroupConversation(participantIds, groupName)
+                if (existingGroup != null) {
+                    Log.d(
+                        "SocialRepository",
+                        "Found existing group conversation: ${existingGroup.id}"
+                    )
+                    return Result.success(existingGroup)
                 }
             }
 
@@ -347,13 +362,14 @@ class SocialRepository(
      * Picks a file URI, uploads it to Firebase Storage at
      *   conversations/{conversationId}/attachments/{messageId}
      * then sends a Message with type="attachment" and metadata keys:
-     *   url, fileName, mimeType.
-     * The last-message preview is "📎 <fileName>".
+     *   url, fileName, mimeType, caption.
+     * The last-message preview is the caption when provided, otherwise "📎 <fileName>".
      */
     suspend fun sendAttachment(
         conversationId: String,
         uri: Uri,
         context: Context,
+        caption: String = "",
     ): Result<Unit> {
         return try {
             val currentUser = getCurrentUserProfile()
@@ -369,19 +385,25 @@ class SocialRepository(
 
             val downloadUrl = uploadToStorage(conversationId, messageId, uri)
 
+            // Use the caption as the message content if provided so conversation list
+            // previews and search both show the caption text rather than just the filename.
+            val trimmedCaption = caption.trim()
+            val content = trimmedCaption.ifBlank { "📎 $fileName" }
+
             val message = buildMessage(
                 sender = currentUser,
-                content = "📎 $fileName",
+                content = content,
                 type = "attachment",
                 metadata = mapOf(
                     "url"      to downloadUrl,
                     "fileName" to fileName,
                     "mimeType" to mimeType,
+                    "caption"  to trimmedCaption,
                 ),
                 overrideId = messageId,
             )
             saveMessage(conversationId, message)
-            updateConversationLastMessage(conversationId, "📎 $fileName")
+            updateConversationLastMessage(conversationId, content)
 
             Result.success(Unit)
         } catch (e: Exception) {
@@ -697,6 +719,29 @@ class SocialRepository(
             .toObjects(Conversation::class.java)
             .firstOrNull {
                 !it.isGroup &&
+                        it.participantIds.size == participantIds.size &&
+                        it.participantIds.containsAll(participantIds)
+            }
+    }
+
+    /**
+     * Looks for an existing group conversation with exactly these participants and
+     * the same group name. Used to deduplicate group creation — if a Firestore write
+     * succeeds but the response times out, retrying would otherwise create a second
+     * identical group, splitting replies across two conversations.
+     */
+    private suspend fun findExistingGroupConversation(
+        participantIds: List<String>,
+        groupName: String,
+    ): Conversation? {
+        return db.collection("conversations")
+            .whereArrayContains("participantIds", currentUid)
+            .get()
+            .await()
+            .toObjects(Conversation::class.java)
+            .firstOrNull {
+                it.isGroup &&
+                        it.groupName.equals(groupName.trim(), ignoreCase = false) &&
                         it.participantIds.size == participantIds.size &&
                         it.participantIds.containsAll(participantIds)
             }

--- a/app/src/main/java/com/example/cinet/feature/calendar/classEvent/ClassDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/classEvent/ClassDialog.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.map.CampusLocation
-import com.example.cinet.feature.map.SearchLocationBar
+import com.example.cinet.feature.map.SearchBar
 
 @Composable
 fun ClassDialog(
@@ -161,7 +161,8 @@ fun ClassDialog(
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    SearchLocationBar(
+                    SearchBar(
+                        placeholderText = "Search Location",
                         textFieldState = textFieldState,
                         searchResults = academicNames,
                         onSearch = { query ->

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventInviteSenderDialog.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.core.time.openTimePicker
 import com.example.cinet.data.model.CampusRegistry
-import com.example.cinet.feature.map.SearchLocationBar
+import com.example.cinet.feature.map.SearchBar
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -158,7 +158,8 @@ fun EventInviteSenderDialog(
                         }
                         Spacer(modifier = Modifier.height(4.dp))
 
-                        SearchLocationBar(
+                        SearchBar(
+                            placeholderText = "Search Location",
                             textFieldState = locationTextFieldState,
                             searchResults = filteredLocationNames,
                             onSearch = { query ->

--- a/app/src/main/java/com/example/cinet/feature/calendar/event/EventItemDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/event/EventItemDialog.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.map.CampusLocation
-import com.example.cinet.feature.map.SearchLocationBar
+import com.example.cinet.feature.map.SearchBar
 
 // Category key → display label pairs shown as filter chips above the search bar.
 private val locationCategories = listOf(
@@ -106,7 +106,8 @@ fun EventItemDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 // Search bar — results come from the selected category only
-                SearchLocationBar(
+                SearchBar(
+                    placeholderText = "Search Location",
                     textFieldState = textFieldState,
                     searchResults = filteredNames,
                     onSearch = { query ->

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudyInviteDialog.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.core.time.openTimePicker
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.calendar.schedule.ScheduleItem
-import com.example.cinet.feature.map.SearchLocationBar
+import com.example.cinet.feature.map.SearchBar
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -169,7 +169,8 @@ fun StudyInviteDialog(
                     }
                     Spacer(modifier = Modifier.height(4.dp))
 
-                    SearchLocationBar(
+                    SearchBar(
+                        placeholderText = "Search Location",
                         textFieldState = locationTextFieldState,
                         searchResults = filteredLocationNames,
                         onSearch = { query ->

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.CampusRegistry
 import com.example.cinet.feature.map.CampusLocation
-import com.example.cinet.feature.map.SearchLocationBar
+import com.example.cinet.feature.map.SearchBar
 
 // Category key → display label pairs shown as filter chips above the search bar.
 private val locationCategories = listOf(
@@ -116,7 +116,8 @@ fun StudySessionDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 // Search bar — results come from the selected category only
-                SearchLocationBar(
+                SearchBar(
+                    placeholderText = "Search Location",
                     textFieldState = textFieldState,
                     searchResults = filteredNames,
                     onSearch = { query ->

--- a/app/src/main/java/com/example/cinet/feature/clubs/ClubsScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/clubs/ClubsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.feature.clubs
 
+import android.text.TextUtils.replace
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.clickable
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Groups
@@ -18,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.example.cinet.feature.map.SearchBar
 
 // clubs stuff - Zack
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,6 +35,7 @@ fun ClubsScreen(
     var clubs by remember { mutableStateOf<List<ClubItem>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
 
+    val textFieldState = rememberTextFieldState() // Search text field
     LaunchedEffect(Unit) {
         clubs = clubsRepository.fetchClubs()
         isLoading = false
@@ -127,16 +131,35 @@ fun ClubsScreen(
                     }
                 }
             } else {
-                LazyColumn(
+                val query = textFieldState.text.toString()
+                val filteredList = if (query.isBlank()) clubs else clubs.filter {
+                    it.title.contains(query, ignoreCase = true)
+                }
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(padding),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                        .padding(padding)
                 ) {
-                    items(clubs) { club ->
-                        ClubListItem(club = club) {
-                            onClubClick(club)
+                    Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        SearchBar(
+                            placeholderText = "Search clubs...",
+                            textFieldState = textFieldState,
+                            searchResults = emptyList(),
+                            onSearch = { query ->
+                                textFieldState.edit { replace(0, length, query) }
+                            }
+                        )
+                    }
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        items(filteredList) { club ->
+                            ClubListItem(club = club) {
+                                onClubClick(club)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/cinet/feature/map/MapControls.kt
+++ b/app/src/main/java/com/example/cinet/feature/map/MapControls.kt
@@ -88,7 +88,8 @@ fun MapControls(
         Spacer(modifier = Modifier.width(12.dp))
 
         Box(Modifier.weight(1f)) {
-            SearchLocationBar(
+            SearchBar(
+                placeholderText = "Search Location",
                 textFieldState = searchState.textFieldState,
                 searchResults = searchState.results,
                 onSearch = searchState.onSearch
@@ -139,7 +140,6 @@ fun FilterMenu(
         ) {
             Surface(
                 shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.secondary,
                 tonalElevation = 6.dp,
             ) {
                 Column(

--- a/app/src/main/java/com/example/cinet/feature/map/Search.kt
+++ b/app/src/main/java/com/example/cinet/feature/map/Search.kt
@@ -2,8 +2,11 @@ package com.example.cinet.feature.map
 
 import android.content.res.Configuration
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,8 +14,12 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,6 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
@@ -49,14 +59,22 @@ data class SearchState(
 /** Rounded search bar with an inline dropdown of matching location names. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchLocationBar(
+fun SearchBar(
+    placeholderText: String,
     textFieldState: TextFieldState,
     searchResults: List<String>,
     onSearch: (String) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     var isFocused by remember { mutableStateOf(false) }
-
+    val density = LocalDensity.current
+    val isKeyboardOpen = WindowInsets.ime.getBottom(density) > 0
+    LaunchedEffect(isKeyboardOpen) {
+        if (!isKeyboardOpen) {
+            isFocused = false
+            focusManager.clearFocus()
+        }
+    }
     val uniqueResults = remember(searchResults) { dedupeSearchResults(searchResults) }
     val showDropdown = isFocused && textFieldState.text.isNotEmpty() && uniqueResults.isNotEmpty()
 
@@ -66,11 +84,14 @@ fun SearchLocationBar(
         shadowElevation = 4.dp,
         modifier = Modifier
             .fillMaxWidth()
-            .imePadding()
             .padding(bottom = 8.dp)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = { focusManager.clearFocus() })
+            }
     ) {
         Column {
             SearchInputField(
+                placeholderText = placeholderText,
                 textFieldState = textFieldState,
                 onFocusChanged = { isFocused = it },
                 onSubmit = {
@@ -107,6 +128,7 @@ private fun dedupeSearchResults(results: List<String>): List<String> =
 /** Transparent single-line TextField used as the search input. */
 @Composable
 private fun SearchInputField(
+    placeholderText: String,
     textFieldState: TextFieldState,
     onFocusChanged: (Boolean) -> Unit,
     onSubmit: () -> Unit
@@ -114,7 +136,7 @@ private fun SearchInputField(
     TextField(
         value = textFieldState.text.toString(),
         onValueChange = { textFieldState.edit { replace(0, length, it) } },
-        placeholder = { Text("Search location..", color = Color.Gray) },
+        placeholder = { Text(placeholderText, color = Color.Gray) },
         singleLine = true,
         colors = TextFieldDefaults.colors(
             focusedContainerColor = Color.Transparent,
@@ -128,6 +150,13 @@ private fun SearchInputField(
             unfocusedPlaceholderColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
             focusedPlaceholderColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
         ),
+        leadingIcon = {
+            Icon(
+                Icons.Default.Search,
+                contentDescription = "Search",
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        },
         modifier = Modifier
             .fillMaxWidth()
             .onFocusChanged { onFocusChanged(it.isFocused) },
@@ -156,7 +185,8 @@ private fun SearchSuggestionItem(
 fun PreviewSearch() {
     CINetTheme(darkTheme = true) {
         val textFieldState = rememberTextFieldState()
-        SearchLocationBar(
+        SearchBar(
+            placeholderText = "Search Location",
             textFieldState = textFieldState,
             searchResults = listOf("Aliso Hall", "Bell Tower", "Student Union"),
             onSearch = {},

--- a/app/src/main/java/com/example/cinet/feature/map/ShareLocation.kt
+++ b/app/src/main/java/com/example/cinet/feature/map/ShareLocation.kt
@@ -1,14 +1,13 @@
 package com.example.cinet.feature.map
 
 import android.content.res.Configuration
+import android.text.TextUtils.replace
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -17,12 +16,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ShareLocation
 import androidx.compose.material3.BasicAlertDialog
@@ -31,7 +28,6 @@ import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SliderDefaults.Thumb
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,6 +48,7 @@ import com.example.cinet.data.remote.SocialRepository
 import com.example.cinet.feature.social.FriendSelectRow
 import com.example.cinet.ui.theme.CINetTheme
 import kotlinx.coroutines.launch
+import kotlin.collections.find
 
 
 /**
@@ -64,7 +61,10 @@ import kotlinx.coroutines.launch
 // -------------------- Location Sharing --------------------
 
 @Composable
-fun ShareLocation( friends: List<UserProfile>, location: CampusLocation ) {
+fun ShareLocation(
+    friends: List<UserProfile>,
+    location: CampusLocation
+) {
     var showDialog by remember { mutableStateOf(false) }
     Surface(
         onClick = { showDialog = true },
@@ -108,6 +108,8 @@ fun Share(friends: List<UserProfile>, location: CampusLocation, onDismiss: () ->
     var selectedIds by remember { mutableStateOf(setOf<String>()) }
     val currentUserId = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val lazyListState = rememberLazyListState()
+    val textFieldState = rememberTextFieldState()
+
     BasicAlertDialog(
         onDismissRequest = onDismiss
     ) {
@@ -132,9 +134,22 @@ fun Share(friends: List<UserProfile>, location: CampusLocation, onDismiss: () ->
                     color = MaterialTheme.colorScheme.onSecondary
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-
+                // Search bar for conversations
+                val query = textFieldState.text.toString()
+                val filteredFriends = if (query.isBlank()) friends else friends.filter {
+                    it.nickname.contains(query, ignoreCase = true)
+                }
+                SearchBar(
+                    placeholderText = "Search friends",
+                    textFieldState = textFieldState,
+                    searchResults = emptyList(),
+                    onSearch = { query ->
+                        textFieldState.edit { replace(0, length, query) }
+                    }
+                )
+                Spacer(modifier = Modifier.height(16.dp))
                 LazyColumn(state = lazyListState, modifier = Modifier.heightIn(max = 400.dp)) {
-                    items(friends) { friend ->
+                    items(filteredFriends) { friend ->
                         FriendSelectRow(
                             friend = friend,
                             isSelected = selectedIds.contains(friend.uid),

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PersonRemove
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -320,6 +321,14 @@ fun ConversationScreen(
                                 onDismissRequest = { expanded = false },
                                 offset = DpOffset(x = 0.dp, y = 4.dp)
                             ) {
+                                DropdownMenuItem(
+                                    text = { Text("Search Message") },
+                                    leadingIcon = { Icon(Icons.Default.Search, "Search Message") },
+                                    onClick = {
+                                        expanded = false
+                                        showRemoveFriendDialog = true
+                                    }
+                                )
                                 DropdownMenuItem(
                                     text = { Text("Remove Friend") },
                                     leadingIcon = { Icon(Icons.Default.PersonRemove, "Remove Friend") },

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -1,6 +1,11 @@
 package com.example.cinet.feature.social
 
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
@@ -16,7 +21,9 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.LocationOn
@@ -39,6 +46,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import android.app.DownloadManager
+import android.content.Intent
+import android.net.Uri as AndroidUri
+import android.os.Environment
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.cinet.data.model.Conversation
@@ -64,8 +77,27 @@ fun ConversationScreen(
     val repository = remember { SocialRepository() }
     val calendarRepository = remember { CalendarFirestoreRepository() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val listState = rememberLazyListState()
+    var isUploadingAttachment by remember { mutableStateOf(false) }
+
+    // File picker — any MIME type, consistent with the "images/files" spec
+    val attachmentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            isUploadingAttachment = true
+            scope.launch {
+                repository.sendAttachment(
+                    conversationId = conversation.id,
+                    uri = uri,
+                    context = context,
+                )
+                isUploadingAttachment = false
+            }
+        }
+    }
 
     var messages by remember { mutableStateOf<List<Message>>(emptyList()) }
     var conversationCount by remember { mutableIntStateOf(0) }
@@ -86,6 +118,8 @@ fun ConversationScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var showSearchBar by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
+    // null = preview closed; non-null = show full-screen image preview for this message
+    var previewMessage by remember { mutableStateOf<Message?>(null) }
 
     // Filtered messages — client-side only, no extra Firestore reads.
     // Matches text content for regular messages; falls back to invite
@@ -108,6 +142,10 @@ fun ConversationScreen(
                     "location_share" -> {
                         val loc = msg.metadata["locationName"] as? String ?: ""
                         loc.contains(q, ignoreCase = true)
+                    }
+                    "attachment" -> {
+                        val name = msg.metadata["fileName"] as? String ?: ""
+                        name.contains(q, ignoreCase = true)
                     }
                     else -> msg.content.contains(q, ignoreCase = true)
                 }
@@ -489,6 +527,7 @@ fun ConversationScreen(
                             currentUserPhotoUrl = currentUserPhotoUrl,
                             highlightQuery = searchQuery.trim(),
                             onNavigateToLocation = onNavigateToLocation,
+                            onPreviewImage = { previewMessage = it },
                             onAccept = if (!alreadyResponded && message.senderId != currentUid &&
                                 (message.type == "study_invite" || message.type == "event_invite")) {
                                 {
@@ -536,6 +575,14 @@ fun ConversationScreen(
 
                 val textFieldState = rememberTextFieldState()
 
+                // Show a slim progress bar while an attachment is uploading
+                if (isUploadingAttachment) {
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+
                 MessageBox(
                     state = textFieldState,
                     onSendMessage = {
@@ -549,6 +596,9 @@ fun ConversationScreen(
                     },
                     studySelected = { showStudyInviteDialog = true },
                     eventSelected = { showEventInviteDialog = true },
+                    onAttachmentClick = {
+                        if (!isUploadingAttachment) attachmentLauncher.launch("*/*")
+                    },
                     modifier = Modifier.imePadding()
                 )
             }
@@ -575,6 +625,23 @@ fun ConversationScreen(
             }
         }
     } // outer Box
+
+    // Dismiss preview on back gesture
+    BackHandler(enabled = previewMessage != null) { previewMessage = null }
+
+    // Full-screen image preview overlay
+    AnimatedVisibility(
+        visible = previewMessage != null,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        previewMessage?.let { msg ->
+            ImagePreviewOverlay(
+                message = msg,
+                onDismiss = { previewMessage = null },
+            )
+        }
+    }
 
     if (showStudyInviteDialog) {
         StudyInviteDialog(
@@ -694,6 +761,7 @@ fun MessageBubble(
     currentUserPhotoUrl: String = "",
     highlightQuery: String = "",
     onNavigateToLocation: ((String) -> Unit)? = null,
+    onPreviewImage: ((Message) -> Unit)? = null,
     onAccept: (() -> Unit)? = null,
     onDecline: (() -> Unit)? = null,
 ) {
@@ -763,6 +831,12 @@ fun MessageBubble(
                     message = message,
                     isCurrentUser = isCurrentUser,
                     onNavigateToLocation = onNavigateToLocation
+                )
+            } else if (message.type == "attachment") {
+                AttachmentBubble(
+                    message = message,
+                    isCurrentUser = isCurrentUser,
+                    onPreviewImage = onPreviewImage,
                 )
             } else {
                 val bubbleColor = if (isCurrentUser)
@@ -1091,6 +1165,242 @@ fun LocationShareBubble(
                 ) {
                     Text("View on Map")
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Renders an attachment message bubble.
+ *
+ * • Image MIME types  → inline [AsyncImage] (Coil), tap to open in system viewer
+ * • All other types   → compact file card with [AttachFile] icon, file name, and an
+ *                       "Open" button that fires [Intent.ACTION_VIEW]
+ *
+ * Shape, alignment, and sizing are consistent with the rest of the bubble family.
+ */
+@Composable
+fun AttachmentBubble(
+    message: Message,
+    isCurrentUser: Boolean,
+    onPreviewImage: ((Message) -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    val url      = message.metadata["url"]      as? String ?: ""
+    val fileName = message.metadata["fileName"] as? String ?: "attachment"
+    val mimeType = message.metadata["mimeType"] as? String ?: "application/octet-stream"
+
+    val cardShape = RoundedCornerShape(
+        topStart    = if (isCurrentUser) 16.dp else 4.dp,
+        topEnd      = if (isCurrentUser) 4.dp  else 16.dp,
+        bottomStart = 16.dp,
+        bottomEnd   = 16.dp,
+    )
+
+    fun openUrl() {
+        if (url.isBlank()) return
+        val intent = Intent(Intent.ACTION_VIEW, AndroidUri.parse(url)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(Intent.createChooser(intent, null))
+    }
+
+    if (mimeType.startsWith("image/")) {
+        // ── Image bubble — tap opens full-screen preview ──────────────────────────
+        Surface(
+            shape = cardShape,
+            color = if (isCurrentUser)
+                MaterialTheme.colorScheme.primary
+            else
+                MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier
+                .widthIn(min = 120.dp, max = 260.dp)
+                .clickable {
+                    if (onPreviewImage != null) onPreviewImage(message) else openUrl()
+                },
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(url)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = fileName,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 120.dp, max = 240.dp)
+                    .clip(cardShape),
+            )
+        }
+    } else {
+        // ── Generic file card ─────────────────────────────────────────────────────
+        Card(
+            shape = cardShape,
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+            modifier = Modifier.widthIn(min = 200.dp, max = 280.dp),
+        ) {
+            Column(modifier = Modifier.padding(12.dp)) {
+                // Header row — icon + "ATTACHMENT" label
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.AttachFile,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(15.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = "ATTACHMENT",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.75f),
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+                    thickness = 0.5.dp,
+                )
+                Spacer(Modifier.height(8.dp))
+                // File name — truncate long names with ellipsis at end
+                Text(
+                    text = fileName,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    maxLines = 2,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(10.dp))
+                // Open button
+                Button(
+                    onClick = { openUrl() },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AttachFile,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text("Open")
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Full-screen image preview overlay, shown when the user taps an image attachment.
+ *
+ * Layout (mirrors Discord's viewer):
+ *   • Near-black background — tap it to dismiss
+ *   • Image fills available space with ContentScale.Fit (no cropping)
+ *   • Floating top toolbar: [✕ close]  [filename]  [↓ download]
+ *
+ * Download uses DownloadManager so the file lands in the device's Downloads
+ * folder and a system notification confirms completion — no extra permissions
+ * needed on API 29+ (Android 10+).
+ */
+@Composable
+fun ImagePreviewOverlay(
+    message: Message,
+    onDismiss: () -> Unit,
+) {
+    val context  = LocalContext.current
+    val url      = message.metadata["url"]      as? String ?: ""
+    val fileName = message.metadata["fileName"] as? String ?: "image"
+    val mimeType = message.metadata["mimeType"] as? String ?: "image/*"
+
+    fun downloadImage() {
+        if (url.isBlank()) return
+        runCatching {
+            val request = DownloadManager.Request(AndroidUri.parse(url))
+                .setTitle(fileName)
+                .setDescription("Downloading via CINet")
+                .setNotificationVisibility(
+                    DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED
+                )
+                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+                .setMimeType(mimeType)
+            val dm = context.getSystemService(DownloadManager::class.java)
+            dm.enqueue(request)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xF0000000)) // ~94 % opaque black
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onDismiss,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Image — consume clicks so tapping the photo doesn't dismiss the overlay
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(url)
+                .crossfade(true)
+                .build(),
+            contentDescription = fileName,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 64.dp) // clear space for toolbar at top
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = { /* consume — don't dismiss */ },
+                ),
+        )
+
+        // ── Floating top toolbar ─────────────────────────────────────────────────
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .background(Color(0x88000000)) // translucent black scrim
+                .padding(horizontal = 4.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Close
+            IconButton(onClick = onDismiss) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close preview",
+                    tint = Color.White,
+                )
+            }
+
+            // Filename — truncated in the middle of the toolbar
+            Text(
+                text = fileName,
+                color = Color.White,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 4.dp),
+            )
+
+            // Download
+            IconButton(onClick = { downloadImage() }) {
+                Icon(
+                    imageVector = Icons.Default.Download,
+                    contentDescription = "Download image",
+                    tint = Color.White,
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -1334,22 +1334,22 @@ fun AttachmentBubble(
                         color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.75f),
                     )
                 }
-                Spacer(Modifier.height(6.dp))
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
-                    thickness = 0.5.dp,
-                )
-                Spacer(Modifier.height(8.dp))
-                // File name — truncate long names with ellipsis at end
+                // File name sits directly under the label, above the divider
+                Spacer(Modifier.height(2.dp))
                 Text(
                     text = fileName,
                     style = MaterialTheme.typography.bodySmall,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                     maxLines = 2,
-                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    overflow = TextOverflow.Ellipsis,
                 )
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(6.dp))
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+                    thickness = 0.5.dp,
+                )
+                Spacer(Modifier.height(8.dp))
                 // Open button
                 Button(
                     onClick = { openUrl() },

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -50,6 +50,7 @@ import android.app.DownloadManager
 import android.content.Intent
 import android.net.Uri as AndroidUri
 import android.os.Environment
+import android.provider.OpenableColumns
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.AsyncImage
@@ -68,6 +69,16 @@ import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
+/**
+ * A file the user has selected but not yet sent.
+ * Shown as a preview above the message box (2-step send flow).
+ */
+private data class PendingAttachment(
+    val uri: AndroidUri,
+    val fileName: String,
+    val mimeType: String,
+)
+
 @Composable
 fun ConversationScreen(
     conversation: Conversation,
@@ -81,21 +92,25 @@ fun ConversationScreen(
     val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val listState = rememberLazyListState()
     var isUploadingAttachment by remember { mutableStateOf(false) }
+    // Holds a picked file that hasn't been sent yet — shown as a preview
+    // above the message box. Cleared on send or on the user pressing X.
+    var pendingAttachment by remember { mutableStateOf<PendingAttachment?>(null) }
 
-    // File picker — any MIME type, consistent with the "images/files" spec
+    // File picker — resolves metadata client-side, stores as pending so the
+    // user sees a preview before the file is actually uploaded or sent.
     val attachmentLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         if (uri != null) {
-            isUploadingAttachment = true
-            scope.launch {
-                repository.sendAttachment(
-                    conversationId = conversation.id,
-                    uri = uri,
-                    context = context,
-                )
-                isUploadingAttachment = false
+            val mimeType = context.contentResolver.getType(uri) ?: "application/octet-stream"
+            var fileName = "attachment"
+            runCatching {
+                context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                    val col = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (col >= 0 && cursor.moveToFirst()) fileName = cursor.getString(col)
+                }
             }
+            pendingAttachment = PendingAttachment(uri, fileName, mimeType)
         }
     }
 
@@ -575,7 +590,22 @@ fun ConversationScreen(
 
                 val textFieldState = rememberTextFieldState()
 
-                // Show a slim progress bar while an attachment is uploading
+                // ── Step 1: pending attachment preview ───────────────────────────
+                // Shown after the user picks a file but before they tap Send.
+                AnimatedVisibility(
+                    visible = pendingAttachment != null,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    pendingAttachment?.let { pa ->
+                        PendingAttachmentPreview(
+                            attachment = pa,
+                            onCancel = { pendingAttachment = null },
+                        )
+                    }
+                }
+
+                // Upload progress bar — shown only during the actual upload
                 if (isUploadingAttachment) {
                     LinearProgressIndicator(
                         modifier = Modifier.fillMaxWidth(),
@@ -583,21 +613,45 @@ fun ConversationScreen(
                     )
                 }
 
+                // ── Step 2: send ─────────────────────────────────────────────────
+                // If a pending attachment exists, Send uploads + sends it.
+                // Otherwise Send behaves as normal text send.
                 MessageBox(
                     state = textFieldState,
                     onSendMessage = {
-                        val content = textFieldState.text.toString().trim()
-                        if (content.isNotBlank()) {
+                        val pa = pendingAttachment
+                        if (pa != null) {
+                            val caption = textFieldState.text.toString().trim()
+                            pendingAttachment = null
+                            textFieldState.clearText()
+                            isUploadingAttachment = true
                             scope.launch {
-                                repository.sendMessage(conversation.id, content)
-                                textFieldState.clearText()
+                                repository.sendAttachment(
+                                    conversationId = conversation.id,
+                                    uri = pa.uri,
+                                    context = context,
+                                    caption = caption,
+                                )
+                                isUploadingAttachment = false
+                            }
+                        } else {
+                            val content = textFieldState.text.toString().trim()
+                            if (content.isNotBlank()) {
+                                scope.launch {
+                                    repository.sendMessage(conversation.id, content)
+                                    textFieldState.clearText()
+                                }
                             }
                         }
                     },
                     studySelected = { showStudyInviteDialog = true },
                     eventSelected = { showEventInviteDialog = true },
                     onAttachmentClick = {
-                        if (!isUploadingAttachment) attachmentLauncher.launch("*/*")
+                        // Don't allow picking a new file while one is already
+                        // staged or being uploaded
+                        if (pendingAttachment == null && !isUploadingAttachment) {
+                            attachmentLauncher.launch("*/*")
+                        }
                     },
                     modifier = Modifier.imePadding()
                 )
@@ -1189,6 +1243,7 @@ fun AttachmentBubble(
     val url      = message.metadata["url"]      as? String ?: ""
     val fileName = message.metadata["fileName"] as? String ?: "attachment"
     val mimeType = message.metadata["mimeType"] as? String ?: "application/octet-stream"
+    val caption  = message.metadata["caption"]  as? String ?: ""
 
     val cardShape = RoundedCornerShape(
         topStart    = if (isCurrentUser) 16.dp else 4.dp,
@@ -1219,18 +1274,38 @@ fun AttachmentBubble(
                     if (onPreviewImage != null) onPreviewImage(message) else openUrl()
                 },
         ) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(url)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = fileName,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 120.dp, max = 240.dp)
-                    .clip(cardShape),
-            )
+            Column {
+                // Round bottom corners only when there's no caption below the image
+                val imageShape = if (caption.isNotBlank()) RoundedCornerShape(
+                    topStart    = if (isCurrentUser) 16.dp else 4.dp,
+                    topEnd      = if (isCurrentUser) 4.dp  else 16.dp,
+                    bottomStart = 0.dp,
+                    bottomEnd   = 0.dp,
+                ) else cardShape
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(url)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = fileName,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 120.dp, max = 240.dp)
+                        .clip(imageShape),
+                )
+                if (caption.isNotBlank()) {
+                    Text(
+                        text = caption,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isCurrentUser)
+                            MaterialTheme.colorScheme.onPrimary
+                        else
+                            MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                    )
+                }
+            }
         }
     } else {
         // ── Generic file card ─────────────────────────────────────────────────────
@@ -1290,6 +1365,20 @@ fun AttachmentBubble(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text("Open")
+                }
+                // Caption — shown below the Open button when the sender added one
+                if (caption.isNotBlank()) {
+                    Spacer(Modifier.height(6.dp))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.15f),
+                        thickness = 0.5.dp,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        text = caption,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
                 }
             }
         }
@@ -1400,6 +1489,93 @@ fun ImagePreviewOverlay(
                     imageVector = Icons.Default.Download,
                     contentDescription = "Download image",
                     tint = Color.White,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Preview card shown above the message box after the user picks a file
+ * but before they tap Send (the 2-step attachment send flow).
+ *
+ * • Images  → thumbnail (loaded from the local URI via Coil) + filename
+ * • Files   → AttachFile icon + filename
+ * • ✕ button cancels the pending attachment without sending anything
+ */
+@Composable
+private fun PendingAttachmentPreview(
+    attachment: PendingAttachment,
+    onCancel: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 4.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (attachment.mimeType.startsWith("image/")) {
+                // Thumbnail loaded directly from the local URI — no network needed
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(attachment.uri)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = attachment.fileName,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(10.dp)),
+                )
+            } else {
+                // Generic file icon in a small container
+                Box(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(MaterialTheme.colorScheme.secondaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AttachFile,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = attachment.fileName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = if (attachment.mimeType.startsWith("image/")) "Image · tap ➤ to send"
+                    else "File · tap ➤ to send",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f),
+                )
+            }
+
+            // Cancel — clears the pending attachment without sending
+            IconButton(onClick = onCancel) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Cancel attachment",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -1,5 +1,8 @@
 package com.example.cinet.feature.social
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -14,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MoreVert
@@ -26,9 +30,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -76,6 +84,44 @@ fun ConversationScreen(
     var otherUserPhotoUrl by remember { mutableStateOf("") }
     var currentUserPhotoUrl by remember { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
+    var showSearchBar by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    // Filtered messages — client-side only, no extra Firestore reads.
+    // Matches text content for regular messages; falls back to invite
+    // title/class fields and location name for structured bubble types.
+    val displayedMessages by remember {
+        derivedStateOf {
+            val q = searchQuery.trim()
+            if (q.isBlank()) messages
+            else messages.filter { msg ->
+                when (msg.type) {
+                    "study_invite" -> {
+                        val cls  = msg.metadata["className"] as? String ?: ""
+                        val topic = msg.metadata["topic"]    as? String ?: ""
+                        cls.contains(q, ignoreCase = true) || topic.contains(q, ignoreCase = true)
+                    }
+                    "event_invite" -> {
+                        val name = msg.metadata["name"] as? String ?: ""
+                        name.contains(q, ignoreCase = true)
+                    }
+                    "location_share" -> {
+                        val loc = msg.metadata["locationName"] as? String ?: ""
+                        loc.contains(q, ignoreCase = true)
+                    }
+                    else -> msg.content.contains(q, ignoreCase = true)
+                }
+            }
+        }
+    }
+
+    // When the query changes and results exist, jump to the first match.
+    LaunchedEffect(searchQuery) {
+        if (searchQuery.isNotBlank() && displayedMessages.isNotEmpty()) {
+            val firstIndex = messages.indexOfFirst { it.id == displayedMessages.first().id }
+            if (firstIndex >= 0) listState.animateScrollToItem(firstIndex)
+        }
+    }
 
     // Returns true if the same invite was sent in this conversation within
     // the last 5 minutes, preventing accidental double-sends.
@@ -296,6 +342,14 @@ fun ConversationScreen(
                                     showRenameDialog = true
                                 }
                         )
+                        // Search button for group chats
+                        IconButton(onClick = { showSearchBar = !showSearchBar }) {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = "Search messages",
+                                tint = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        }
                     } else {
                         Text(
                             text = conversationTitle,
@@ -326,7 +380,7 @@ fun ConversationScreen(
                                     leadingIcon = { Icon(Icons.Default.Search, "Search Message") },
                                     onClick = {
                                         expanded = false
-                                        showRemoveFriendDialog = true
+                                        showSearchBar = true
                                     }
                                 )
                                 DropdownMenuItem(
@@ -344,6 +398,77 @@ fun ConversationScreen(
 
                 HorizontalDivider()
 
+                // ── Search bar — animates in/out below the header divider ──────
+                AnimatedVisibility(
+                    visible = showSearchBar,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    val matchCount = displayedMessages.size
+                    val totalCount = messages.size
+                    Column {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            OutlinedTextField(
+                                value = searchQuery,
+                                onValueChange = { searchQuery = it },
+                                placeholder = { Text("Search messages…") },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.Search,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                },
+                                trailingIcon = {
+                                    if (searchQuery.isNotEmpty()) {
+                                        IconButton(onClick = { searchQuery = "" }) {
+                                            Icon(
+                                                imageVector = Icons.Default.Close,
+                                                contentDescription = "Clear search",
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                },
+                                singleLine = true,
+                                modifier = Modifier.weight(1f),
+                                shape = RoundedCornerShape(24.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = MaterialTheme.colorScheme.primary,
+                                ),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            // Dismiss search entirely
+                            IconButton(onClick = {
+                                showSearchBar = false
+                                searchQuery = ""
+                            }) {
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = "Close search",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        // Match count pill — only shown when query is active
+                        if (searchQuery.isNotBlank()) {
+                            Text(
+                                text = if (matchCount == 0) "No results"
+                                else "$matchCount of $totalCount message${if (totalCount != 1) "s" else ""}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(start = 20.dp, bottom = 4.dp),
+                            )
+                        }
+                        HorizontalDivider()
+                    }
+                }
+
                 LazyColumn(
                     state = listState,
                     modifier = Modifier
@@ -351,7 +476,7 @@ fun ConversationScreen(
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    items(messages) { message ->
+                    items(displayedMessages) { message ->
                         // Per-user check: has THIS user already accepted or declined?
                         // acceptedBy/declinedBy are comma-separated UIDs stored in metadata.
                         val acceptedBy = (message.metadata["acceptedBy"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
@@ -362,6 +487,7 @@ fun ConversationScreen(
                             isCurrentUser = message.senderId == currentUid,
                             currentUid = currentUid,
                             currentUserPhotoUrl = currentUserPhotoUrl,
+                            highlightQuery = searchQuery.trim(),
                             onNavigateToLocation = onNavigateToLocation,
                             onAccept = if (!alreadyResponded && message.senderId != currentUid &&
                                 (message.type == "study_invite" || message.type == "event_invite")) {
@@ -566,6 +692,7 @@ fun MessageBubble(
     isCurrentUser: Boolean,
     currentUid: String = "",
     currentUserPhotoUrl: String = "",
+    highlightQuery: String = "",
     onNavigateToLocation: ((String) -> Unit)? = null,
     onAccept: (() -> Unit)? = null,
     onDecline: (() -> Unit)? = null,
@@ -657,10 +784,41 @@ fun MessageBubble(
                     color = bubbleColor,
                 ) {
                     Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                        // Build an AnnotatedString that bolds + backgrounds any
+                        // portion of the text matching the current search query.
+                        val annotated = remember(message.content, highlightQuery, textColor) {
+                            buildAnnotatedString {
+                                if (highlightQuery.isBlank()) {
+                                    append(message.content)
+                                } else {
+                                    val lower = message.content.lowercase()
+                                    val query = highlightQuery.lowercase()
+                                    var cursor = 0
+                                    while (cursor < message.content.length) {
+                                        val hit = lower.indexOf(query, cursor)
+                                        if (hit == -1) {
+                                            append(message.content.substring(cursor))
+                                            break
+                                        }
+                                        append(message.content.substring(cursor, hit))
+                                        withStyle(
+                                            SpanStyle(
+                                                background = Color(0xFFFFEB3B),
+                                                color = Color.Black,
+                                                fontWeight = FontWeight.Bold,
+                                            )
+                                        ) {
+                                            append(message.content.substring(hit, hit + query.length))
+                                        }
+                                        cursor = hit + query.length
+                                    }
+                                }
+                            }
+                        }
                         Text(
-                            text = message.content,
+                            text = annotated,
                             style = MaterialTheme.typography.bodyMedium,
-                            color = textColor
+                            color = textColor,
                         )
                     }
                 }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -17,10 +17,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -158,16 +162,20 @@ fun ConversationsListScreen(
             } else {
                 val query = textFieldState.text.toString()
                 val filteredConversations = remember(query, conversations) {
-                    if(query.isBlank()) conversations
+                    if (query.isBlank()) conversations
                     else conversations.filter { conversation ->
-                        if(conversation.isGroup) {
+                        // Match by conversation/group name
+                        val nameMatch = if (conversation.isGroup) {
                             conversation.groupName.contains(query, ignoreCase = true)
                         } else {
                             conversation.participantNicknames
-                                .filterKeys { it != currentUid}
+                                .filterKeys { it != currentUid }
                                 .values
-                                .any {it.contains(query, ignoreCase = true)}
+                                .any { it.contains(query, ignoreCase = true) }
                         }
+                        // Also match against the latest message preview
+                        val messageMatch = conversation.lastMessage.contains(query, ignoreCase = true)
+                        nameMatch || messageMatch
                     }
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -194,6 +202,7 @@ fun ConversationsListScreen(
                             conversation = conversation,
                             currentUid = currentUid,
                             hasUnread = hasUnread,
+                            highlightQuery = query.trim(),
                             onClick = { onOpenConversation(conversation) }
                         )
                         HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
@@ -210,6 +219,7 @@ private fun ConversationListItem(
     currentUid: String,
     onClick: () -> Unit,
     hasUnread: Boolean = false,
+    highlightQuery: String = "",
 ) {
     val displayName = if (conversation.isGroup) {
         conversation.groupName.ifBlank { "Group Chat" }
@@ -263,20 +273,48 @@ private fun ConversationListItem(
         Spacer(modifier = Modifier.width(12.dp))
 
         Column(modifier = Modifier.weight(1f)) {
+            // Helper: build an AnnotatedString that yellow-highlights every occurrence
+            // of [query] in [text], case-insensitively. Falls back to plain text when
+            // query is blank — same performance as before.
+            @Composable
+            fun highlighted(text: String): androidx.compose.ui.text.AnnotatedString =
+                remember(text, highlightQuery) {
+                    buildAnnotatedString {
+                        if (highlightQuery.isBlank()) {
+                            append(text)
+                        } else {
+                            val lower = text.lowercase()
+                            val q = highlightQuery.lowercase()
+                            var cursor = 0
+                            while (cursor < text.length) {
+                                val hit = lower.indexOf(q, cursor)
+                                if (hit == -1) { append(text.substring(cursor)); break }
+                                append(text.substring(cursor, hit))
+                                withStyle(SpanStyle(
+                                    background = Color(0xFFFFEB3B),
+                                    color = Color.Black,
+                                    fontWeight = FontWeight.Bold,
+                                )) { append(text.substring(hit, hit + q.length)) }
+                                cursor = hit + q.length
+                            }
+                        }
+                    }
+                }
+
             Text(
-                text = displayName,
+                text = highlighted(displayName),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             if (conversation.lastMessage.isNotBlank()) {
                 Text(
-                    text = conversation.lastMessage,
+                    text = highlighted(conversation.lastMessage),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -43,7 +43,6 @@ fun ConversationsListScreen(
     onOpenConversation: (Conversation) -> Unit,
     onNewConversation: () -> Unit,
     onOpenFriends: () -> Unit,
-    sessionStartTime: Long = 0L,
     // Maps conversationId -> timestamp when it was last opened this session.
     // A message arriving AFTER that timestamp shows a dot even for opened convos.
     openedConversationTimestamps: Map<String, Long> = emptyMap(),
@@ -63,6 +62,10 @@ fun ConversationsListScreen(
             .addSnapshotListener { snapshot, _ ->
                 if (snapshot != null) {
                     conversations = snapshot.toObjects(Conversation::class.java)
+                        // active=false means the conversation was deactivated (e.g. after
+                        // unfriending). Don't show these — they caused duplicate "User A"
+                        // rows alongside group chats, confusing which thread to reply in.
+                        .filter { it.active }
                         .sortedByDescending { it.lastUpdated?.time ?: 0L }
                     isLoading = false
                 }
@@ -191,11 +194,12 @@ fun ConversationsListScreen(
                 }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(filteredConversations, key = { it.id }) { conversation ->
-                        // Baseline: the later of sessionStartTime or when this convo
-                        // was last opened. A message after that timestamp = unread.
+                        // A dot appears when the last message arrived after the last time
+                        // this conversation was opened. openedAt is loaded from SharedPrefs
+                        // so dots survive app restarts and only clear when the conversation
+                        // is actually opened — not just because the list was viewed.
                         val openedAt = openedConversationTimestamps[conversation.id] ?: 0L
-                        val baseline = maxOf(sessionStartTime, openedAt)
-                        val hasUnread = (conversation.lastUpdated?.time ?: 0L) > baseline &&
+                        val hasUnread = (conversation.lastUpdated?.time ?: 0L) > openedAt &&
                                 conversation.lastMessage.isNotBlank() &&
                                 conversation.lastSenderId != currentUid
                         ConversationListItem(

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.feature.social
 
+import android.text.TextUtils.replace
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.People
@@ -24,6 +26,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.remote.SocialRepository
+import com.example.cinet.feature.map.SearchBar
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import java.text.SimpleDateFormat
@@ -67,7 +70,8 @@ fun ConversationsListScreen(
     LaunchedEffect(Unit) {
         repository.getPendingRequests().onSuccess { pendingRequestCount = it.size }
     }
-
+    // Required for searching
+    val textFieldState = rememberTextFieldState()
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -152,8 +156,33 @@ fun ConversationsListScreen(
                     }
                 }
             } else {
+                val query = textFieldState.text.toString()
+                val filteredConversations = remember(query, conversations) {
+                    if(query.isBlank()) conversations
+                    else conversations.filter { conversation ->
+                        if(conversation.isGroup) {
+                            conversation.groupName.contains(query, ignoreCase = true)
+                        } else {
+                            conversation.participantNicknames
+                                .filterKeys { it != currentUid}
+                                .values
+                                .any {it.contains(query, ignoreCase = true)}
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Box(modifier = Modifier.padding(8.dp)) {
+                    SearchBar(
+                        placeholderText = "Search conversations...",
+                        textFieldState = textFieldState,
+                        searchResults = emptyList(),
+                        onSearch = { query ->
+                            textFieldState.edit { replace(0, length, query) }
+                        }
+                    )
+                }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(conversations, key = { it.id }) { conversation ->
+                    items(filteredConversations, key = { it.id }) { conversation ->
                         // Baseline: the later of sessionStartTime or when this convo
                         // was last opened. A message after that timestamp = unread.
                         val openedAt = openedConversationTimestamps[conversation.id] ?: 0L

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationsListScreen.kt
@@ -46,6 +46,10 @@ fun ConversationsListScreen(
     // Maps conversationId -> timestamp when it was last opened this session.
     // A message arriving AFTER that timestamp shows a dot even for opened convos.
     openedConversationTimestamps: Map<String, Long> = emptyMap(),
+    // Called once on fresh install / emulator wipe when openedConversationTimestamps
+    // is empty but conversations already exist. Seeds all conversation IDs with "now"
+    // so existing threads don't incorrectly appear unread after a data clear.
+    onSeedTimestamps: (List<String>) -> Unit = {},
 ) {
     val currentUid = FirebaseAuth.getInstance().currentUser?.uid ?: ""
     val repository = remember { SocialRepository() }
@@ -53,6 +57,20 @@ fun ConversationsListScreen(
     var conversations by remember { mutableStateOf<List<Conversation>>(emptyList()) }
     var pendingRequestCount by remember { mutableIntStateOf(0) }
     var isLoading by remember { mutableStateOf(true) }
+
+    // Fresh-install / emulator-wipe guard. If openedConversationTimestamps is empty
+    // when conversations first arrive, it means SharedPrefs was cleared (wipe, reinstall,
+    // or first launch with pre-existing Firestore data). Seed every loaded conversation
+    // with "now" so none of them show a stale unread dot.
+    // hasSeeded ensures we only do this once per composition lifecycle — we don't want
+    // to wipe dots for genuinely new messages that arrive after the initial load.
+    var hasSeeded by remember { mutableStateOf(false) }
+    LaunchedEffect(conversations) {
+        if (!hasSeeded && conversations.isNotEmpty() && openedConversationTimestamps.isEmpty()) {
+            onSeedTimestamps(conversations.map { it.id })
+            hasSeeded = true
+        }
+    }
 
     // Real-time listener — updates automatically when messages arrive
     DisposableEffect(currentUid) {

--- a/app/src/main/java/com/example/cinet/feature/social/MessageBox.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/MessageBox.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.DropdownMenu
@@ -46,6 +47,7 @@ fun MessageBox(
     onSendMessage: () -> Unit,
     studySelected: () -> Unit,
     eventSelected: () -> Unit,
+    onAttachmentClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var showMenu by remember { mutableStateOf(false) }
@@ -75,7 +77,8 @@ fun MessageBox(
                 expanded = showMenu,
                 onDismiss = { showMenu = false },
                 onStudyClick = studySelected,
-                onEventClick = eventSelected
+                onEventClick = eventSelected,
+                onAttachmentClick = onAttachmentClick,
             )
         }
         // Message bar section
@@ -131,30 +134,39 @@ fun AddAttachment(
     expanded: Boolean,
     onStudyClick: () -> Unit,
     onEventClick: () -> Unit,
+    onAttachmentClick: () -> Unit,
     onDismiss: () -> Unit
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        offset = DpOffset(x = 0.dp, y = -8.dp)
     ) {
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = onDismiss,
-            offset = DpOffset(x = 0.dp, y = -8.dp)
-        ) {
-            DropdownMenuItem(
-                text = { Text("Study Invite")},
-                leadingIcon = { Icon(Icons.Default.School, "Study Invite") },
-                onClick = {
-                    onStudyClick()
-                    onDismiss()
-                }
-            )
-            DropdownMenuItem(
-                text = { Text("Event Invite")},
-                leadingIcon = { Icon(Icons.Default.Event, "Event Invite") },
-                onClick = {
-                    onEventClick()
-                    onDismiss()
-                }
-            )
-        }
+        DropdownMenuItem(
+            text = { Text("Study Invite")},
+            leadingIcon = { Icon(Icons.Default.School, "Study Invite") },
+            onClick = {
+                onStudyClick()
+                onDismiss()
+            }
+        )
+        DropdownMenuItem(
+            text = { Text("Event Invite")},
+            leadingIcon = { Icon(Icons.Default.Event, "Event Invite") },
+            onClick = {
+                onEventClick()
+                onDismiss()
+            }
+        )
+        DropdownMenuItem(
+            text = { Text("Attach File") },
+            leadingIcon = { Icon(Icons.Default.AttachFile, contentDescription = "Attach File") },
+            onClick = {
+                onAttachmentClick()
+                onDismiss()
+            }
+        )
+    }
 }
 
 @Preview(showBackground = true, showSystemUi = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -170,7 +182,8 @@ fun PreviewMessageBox() {
                 state = textFieldState,
                 onSendMessage = { },
                 studySelected = { },
-                eventSelected = { }
+                eventSelected = { },
+                onAttachmentClick = { },
             )
         }
     }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -2,6 +2,7 @@ package com.example.cinet.navigation
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -26,8 +27,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.feature.home.news.CIViewScreen
@@ -64,7 +68,6 @@ import kotlinx.coroutines.tasks.await
 import java.util.Calendar
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
-import androidx.compose.ui.platform.LocalDensity
 import java.util.Locale
 
 enum class Screen(val label: String, val icon: ImageVector) {
@@ -339,8 +342,7 @@ private fun MainScaffold(
                                 showClubs = false
                                 selectedClub = null
                                 profileOpenedFromHome = false
-                                // Tapping Social from any other tab OR while already on Social
-                                // always returns to the Messages (ConversationsListScreen) root.
+
                                 if (screen == Screen.Social) {
                                     activeConversation = null
                                     selectedProfile = null
@@ -348,7 +350,6 @@ private fun MainScaffold(
                                     showSocialScreen = false
                                 }
 
-                                // makes the settings button on the nav bar only open the settings
                                 if (screen == Screen.Settings) {
                                     selectedProfile = null
                                     showProfileEdit = false
@@ -390,104 +391,117 @@ private fun MainScaffold(
             }
         }
     ) { innerPadding ->
+
+        val contentPadding = if (isShowingNews || hideBottomBarForConversationTyping) {
+            PaddingValues(0.dp)
+        } else {
+            innerPadding
+        }
+
+        // Outer container holds both the always-rendered map layer and all other screens on top
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(
-                    if (isShowingNews || hideBottomBarForConversationTyping) {
-                        androidx.compose.foundation.layout.PaddingValues(0.dp)
-                    } else {
-                        innerPadding
-                    }
-                )
+                .padding(contentPadding)
         ) {
-            if (isShowingNews) {
-                CIViewScreen(
-                    selectedArticleUrl = selectedNewsArticle?.url,
-                    selectedArticleTitle = selectedNewsArticle?.title,
-                    onArticleClick = { selectedNewsArticle = it },
-                    onBack = {
-                        if (selectedNewsArticle?.title == "Study Rooms") {
-                            selectedNewsArticle = null
-                            showCIView = false
-                        } else if (selectedNewsArticle != null) {
-                            selectedNewsArticle = null
-                            showCIView = true
-                        } else {
-                            showCIView = false
-                        }
-                    }
-                )
-            } else if (isShowingClubs) {
-                ClubsScreen(
-                    selectedClubUrl = selectedClub?.url,
-                    selectedClubTitle = selectedClub?.title,
-                    onClubClick = { selectedClub = it },
-                    onBack = {
-                        if (selectedClub != null) {
-                            selectedClub = null
-                        } else {
-                            showClubs = false
-                        }
-                    }
-                )
-            } else {
-                when (currentScreen) {
-                    Screen.Home -> HomeScreen(
-                        nickname = userProfile.nickname,
-                        scheduleItems = calendarScheduleItems,
-                        manualUpcomingEventsItems = manualUpcomingEventsItems,
-                        displayUpcomingEventsItems = displayUpcomingEventsItems,
-                        onUpdateSchedule = { },
-                        onUpdateEvents = {
-                            manualUpcomingEventsItems = it
-                            saveItems("event_items", it)
-                        },
-                        onMapClick = { currentScreen = Screen.Map },
-                        onSettingsClick = { currentScreen = Screen.Settings },
-                        onCalendarClick = { currentScreen = Screen.Calendar },
-                        onAddClassClick = {
-                            showAddClassOnCalendar = true
-                            currentScreen = Screen.Calendar
-                        },
-                        onClubsClick = { showClubs = true },
-                        onCIViewClick = { article ->
-                            if (article != null) {
-                                selectedNewsArticle = article
-                            } else {
-                                showCIView = true
-                            }
-                        },
-                        onArticleClick = { article ->
-                            selectedNewsArticle = article
-                        },
-                        onSocialClick = {
-                            currentScreen = Screen.Social
-                            activeConversation = null
-                            selectedProfile = null
-                            showNewConversation = false
-                            showSocialScreen = false
-                        },
-                        onNotificationClick = { currentScreen = Screen.Settings },
-                        onProfileClick = {
-                            profileOpenedFromHome = true
-                            selectedProfile = userProfile
-                            currentScreen = Screen.Settings
-                        },
-                        onNavigateToLocation = { locationName ->
-                            val location = campusRegistry.values.flatten()
-                                .find { it.name.equals(locationName, ignoreCase = true) }
 
-                            preSelectedMapLocation = location
-                            autoRouteToPreSelectedMapLocation = false
-                            currentScreen = Screen.Map
+            // ---- MAP LAYER (always in composition, hidden when not active) ----
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { alpha = if (currentScreen == Screen.Map) 1f else 0f }
+                    .then(
+                        if (currentScreen != Screen.Map)
+                            Modifier.pointerInput(Unit) { /* block all touches when hidden */ }
+                        else Modifier
+                    )
+            ) {
+                CampusMapScreen(
+                    onBack = { currentScreen = Screen.Home },
+                    preSelectedLocation = preSelectedMapLocation,
+                    autoRouteToPreSelectedLocation = autoRouteToPreSelectedMapLocation,
+                    onFinishedLoading = {
+                        preSelectedMapLocation = null
+                        autoRouteToPreSelectedMapLocation = false
+                    }
+                )
+            }
+
+            // ---- ALL OTHER SCREENS (rendered on top of the map layer) ----
+            if (currentScreen != Screen.Map) {
+                if (isShowingNews) {
+                    CIViewScreen(
+                        selectedArticleUrl = selectedNewsArticle?.url,
+                        selectedArticleTitle = selectedNewsArticle?.title,
+                        onArticleClick = { selectedNewsArticle = it },
+                        onBack = {
+                            if (selectedNewsArticle?.title == "Study Rooms") {
+                                selectedNewsArticle = null
+                                showCIView = false
+                            } else if (selectedNewsArticle != null) {
+                                selectedNewsArticle = null
+                                showCIView = true
+                            } else {
+                                showCIView = false
+                            }
                         }
                     )
-
-                    Screen.Social -> when {
-                        activeConversation != null -> ConversationScreen(
-                            conversation = activeConversation!!,
-                            onBack = { activeConversation = null },
+                } else if (isShowingClubs) {
+                    ClubsScreen(
+                        selectedClubUrl = selectedClub?.url,
+                        selectedClubTitle = selectedClub?.title,
+                        onClubClick = { selectedClub = it },
+                        onBack = {
+                            if (selectedClub != null) {
+                                selectedClub = null
+                            } else {
+                                showClubs = false
+                            }
+                        }
+                    )
+                } else {
+                    when (currentScreen) {
+                        Screen.Home -> HomeScreen(
+                            nickname = userProfile.nickname,
+                            scheduleItems = calendarScheduleItems,
+                            manualUpcomingEventsItems = manualUpcomingEventsItems,
+                            displayUpcomingEventsItems = displayUpcomingEventsItems,
+                            onUpdateSchedule = { },
+                            onUpdateEvents = {
+                                manualUpcomingEventsItems = it
+                                saveItems("event_items", it)
+                            },
+                            onMapClick = { currentScreen = Screen.Map },
+                            onSettingsClick = { currentScreen = Screen.Settings },
+                            onCalendarClick = { currentScreen = Screen.Calendar },
+                            onAddClassClick = {
+                                showAddClassOnCalendar = true
+                                currentScreen = Screen.Calendar
+                            },
+                            onClubsClick = { showClubs = true },
+                            onCIViewClick = { article ->
+                                if (article != null) {
+                                    selectedNewsArticle = article
+                                } else {
+                                    showCIView = true
+                                }
+                            },
+                            onArticleClick = { article ->
+                                selectedNewsArticle = article
+                            },
+                            onSocialClick = {
+                                currentScreen = Screen.Social
+                                activeConversation = null
+                                selectedProfile = null
+                                showNewConversation = false
+                                showSocialScreen = false
+                            },
+                            onNotificationClick = { currentScreen = Screen.Settings },
+                            onProfileClick = {
+                                profileOpenedFromHome = true
+                                selectedProfile = userProfile
+                                currentScreen = Screen.Settings
+                            },
                             onNavigateToLocation = { locationName ->
                                 val location = campusRegistry.values.flatten()
                                     .find { it.name.equals(locationName, ignoreCase = true) }
@@ -498,127 +512,135 @@ private fun MainScaffold(
                             }
                         )
 
-                        selectedProfile != null -> ProfileScreen(
-                            user = if (selectedProfile!!.uid == userProfile.uid) {
+                        Screen.Social -> when {
+                            activeConversation != null -> ConversationScreen(
+                                conversation = activeConversation!!,
+                                onBack = { activeConversation = null },
+                                onNavigateToLocation = { locationName ->
+                                    val location = campusRegistry.values.flatten()
+                                        .find { it.name.equals(locationName, ignoreCase = true) }
+
+                                    preSelectedMapLocation = location
+                                    autoRouteToPreSelectedMapLocation = false
+                                    currentScreen = Screen.Map
+                                }
+                            )
+
+                            selectedProfile != null -> ProfileScreen(
+                                user = if (selectedProfile!!.uid == userProfile.uid) {
+                                    userProfile
+                                } else {
+                                    selectedProfile!!
+                                },
+                                currentUserProfile = userProfile,
+                                onOpenConversation = { activeConversation = it },
+                                onBack = { selectedProfile = null },
+                                onEditProfile = { showProfileEdit = true },
+                            )
+
+                            showNewConversation -> NewConversationScreen(
+                                currentUserProfile = userProfile,
+                                onBack = { showNewConversation = false },
+                                onOpenConversation = {
+                                    showNewConversation = false
+                                    activeConversation = it
+                                }
+                            )
+
+                            showSocialScreen -> SocialScreen(
+                                onOpenProfile = { selectedProfile = it },
+                                onOpenConversation = { friend ->
+                                    socialScope.launch {
+                                        socialRepository.getOrCreateConversation(
+                                            participantIds = listOf(userProfile.uid, friend.uid),
+                                            participantNicknames = mapOf(
+                                                userProfile.uid to userProfile.nickname,
+                                                friend.uid to friend.nickname
+                                            )
+                                        ).onSuccess {
+                                            showSocialScreen = false
+                                            activeConversation = it
+                                        }
+                                    }
+                                }
+                            )
+
+                            else -> {
+                                LaunchedEffect(Unit) {
+                                    sharedPrefs.edit()
+                                        .putLong("last_conversations_visit", System.currentTimeMillis())
+                                        .apply()
+                                }
+
+                                ConversationsListScreen(
+                                    onOpenConversation = {
+                                        openedConversationTimestamps =
+                                            openedConversationTimestamps + (it.id to System.currentTimeMillis())
+                                        activeConversation = it
+                                    },
+                                    onNewConversation = { showNewConversation = true },
+                                    onOpenFriends = { showSocialScreen = true },
+                                    sessionStartTime = lastConversationsVisit,
+                                    openedConversationTimestamps = openedConversationTimestamps,
+                                )
+                            }
+                        }
+
+                        Screen.Map -> { /* handled by the always-rendered map layer above */ }
+
+                        Screen.Calendar -> CalendarScreen(
+                            onBack = {
+                                currentScreen = Screen.Home
+                                showAddClassOnCalendar = false
+                            },
+                            initialShowClassDialog = showAddClassOnCalendar
+                        )
+
+                        Screen.Settings -> if (showProfileEdit) {
+                            ProfileEditScreen(
+                                onBack = { showProfileEdit = false },
+                                onSaved = { authViewModel.silentReloadProfile() },
+                            )
+                        } else if (selectedProfile != null) {
+                            val displayProfile = if (selectedProfile!!.uid == userProfile.uid) {
                                 userProfile
                             } else {
                                 selectedProfile!!
-                            },
-                            currentUserProfile = userProfile,
-                            onOpenConversation = { activeConversation = it },
-                            onBack = { selectedProfile = null },
-                            onEditProfile = { showProfileEdit = true },
-                        )
-
-                        showNewConversation -> NewConversationScreen(
-                            currentUserProfile = userProfile,
-                            onBack = { showNewConversation = false },
-                            onOpenConversation = {
-                                showNewConversation = false
-                                activeConversation = it
-                            }
-                        )
-
-                        showSocialScreen -> SocialScreen(
-                            onOpenProfile = { selectedProfile = it },
-                            onOpenConversation = { friend ->
-                                socialScope.launch {
-                                    socialRepository.getOrCreateConversation(
-                                        participantIds = listOf(userProfile.uid, friend.uid),
-                                        participantNicknames = mapOf(
-                                            userProfile.uid to userProfile.nickname,
-                                            friend.uid to friend.nickname
-                                        )
-                                    ).onSuccess {
-                                        showSocialScreen = false
-                                        activeConversation = it
-                                    }
-                                }
-                            }
-                        )
-
-                        else -> {
-                            LaunchedEffect(Unit) {
-                                sharedPrefs.edit()
-                                    .putLong("last_conversations_visit", System.currentTimeMillis())
-                                    .apply()
                             }
 
-                            ConversationsListScreen(
+                            ProfileScreen(
+                                user = displayProfile,
+                                currentUserProfile = userProfile,
                                 onOpenConversation = {
-                                    openedConversationTimestamps =
-                                        openedConversationTimestamps + (it.id to System.currentTimeMillis())
                                     activeConversation = it
+                                    currentScreen = Screen.Social
                                 },
-                                onNewConversation = { showNewConversation = true },
-                                onOpenFriends = { showSocialScreen = true },
-                                sessionStartTime = lastConversationsVisit,
-                                openedConversationTimestamps = openedConversationTimestamps,
+                                onBack = {
+                                    selectedProfile = null
+                                    if (profileOpenedFromHome) {
+                                        profileOpenedFromHome = false
+                                        currentScreen = Screen.Home
+                                    }
+                                },
+                                onEditProfile = { showProfileEdit = true },
+                            )
+                        } else {
+                            SettingScreen(
+                                onBack = { currentScreen = Screen.Home },
+                                onSignOut = onSignOut,
+                                isDarkMode = userProfile.isDarkMode,
+                                notificationsEnabled = userProfile.notificationsEnabled,
+                                selectedTheme = AppSettings.selectedTheme,
+                                onSettingsChange = { dark, notify, theme ->
+                                    authViewModel.updateSettings(dark, notify, theme)
+                                },
+                                userProfile = userProfile,
+                                onViewProfile = {
+                                    profileOpenedFromHome = false
+                                    selectedProfile = userProfile
+                                },
                             )
                         }
-                    }
-
-                    Screen.Map -> CampusMapScreen(
-                        onBack = { currentScreen = Screen.Home },
-                        preSelectedLocation = preSelectedMapLocation,
-                        autoRouteToPreSelectedLocation = autoRouteToPreSelectedMapLocation,
-                        onFinishedLoading = {
-                            preSelectedMapLocation = null
-                            autoRouteToPreSelectedMapLocation = false
-                        }
-                    )
-
-                    Screen.Calendar -> CalendarScreen(
-                        onBack = {
-                            currentScreen = Screen.Home
-                            showAddClassOnCalendar = false
-                        },
-                        initialShowClassDialog = showAddClassOnCalendar
-                    )
-
-                    Screen.Settings -> if (showProfileEdit) {
-                        ProfileEditScreen(
-                            onBack = { showProfileEdit = false },
-                            onSaved = { authViewModel.silentReloadProfile() },
-                        )
-                    } else if (selectedProfile != null) {
-                        val displayProfile = if (selectedProfile!!.uid == userProfile.uid) {
-                            userProfile
-                        } else {
-                            selectedProfile!!
-                        }
-
-                        ProfileScreen(
-                            user = displayProfile,
-                            currentUserProfile = userProfile,
-                            onOpenConversation = {
-                                activeConversation = it
-                                currentScreen = Screen.Social
-                            },
-                            onBack = { selectedProfile = null
-                                if (profileOpenedFromHome) {
-                                    profileOpenedFromHome = false
-                                    currentScreen = Screen.Home
-                                }
-                                     },
-                            onEditProfile = { showProfileEdit = true },
-                        )
-                    } else {
-                        SettingScreen(
-                            onBack = { currentScreen = Screen.Home },
-                            onSignOut = onSignOut,
-                            isDarkMode = userProfile.isDarkMode,
-                            notificationsEnabled = userProfile.notificationsEnabled,
-                            selectedTheme = AppSettings.selectedTheme,
-                            onSettingsChange = { dark, notify, theme ->
-                                authViewModel.updateSettings(dark, notify, theme)
-                            },
-                            userProfile = userProfile,
-                            onViewProfile = {
-                                profileOpenedFromHome = false
-                                selectedProfile = userProfile
-                            },
-                        )
                     }
                 }
             }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -176,15 +176,18 @@ private fun MainScaffold(
         context.getSharedPreferences("cinet_prefs", android.content.Context.MODE_PRIVATE)
     }
 
-    var lastConversationsVisit by remember {
+    var openedConversationTimestamps by remember {
+        // Persisted per-conversation open timestamps so unread dots survive app restarts.
+        // Each entry is stored as "opened_conv_{id}" -> Long in cinet_prefs.
+        // A dot disappears when the user opens that conversation, and stays gone across
+        // relaunches unless a genuinely new message arrives after the stored timestamp.
         mutableStateOf(
-            sharedPrefs.getLong("last_conversations_visit", 0L).let { saved ->
-                if (saved == 0L) System.currentTimeMillis() else saved
-            }
+            sharedPrefs.all
+                .filter { it.key.startsWith("opened_conv_") }
+                .mapKeys { it.key.removePrefix("opened_conv_") }
+                .mapValues { (it.value as? Long) ?: 0L }
         )
     }
-
-    var openedConversationTimestamps by remember { mutableStateOf(mapOf<String, Long>()) }
 
     LaunchedEffect(initialConversationId) {
         val id = initialConversationId ?: return@LaunchedEffect
@@ -199,8 +202,13 @@ private fun MainScaffold(
 
             if (conversation != null) {
                 currentScreen = Screen.Social
+                val now = System.currentTimeMillis()
                 openedConversationTimestamps =
-                    openedConversationTimestamps + (conversation.id to System.currentTimeMillis())
+                    openedConversationTimestamps + (conversation.id to now)
+                // Persist so the dot stays gone after the app is restarted.
+                sharedPrefs.edit()
+                    .putLong("opened_conv_${conversation.id}", now)
+                    .apply()
                 activeConversation = conversation
                 onConversationOpened()
             }
@@ -566,21 +574,19 @@ private fun MainScaffold(
                             )
 
                             else -> {
-                                LaunchedEffect(Unit) {
-                                    sharedPrefs.edit()
-                                        .putLong("last_conversations_visit", System.currentTimeMillis())
-                                        .apply()
-                                }
-
                                 ConversationsListScreen(
                                     onOpenConversation = {
+                                        val now = System.currentTimeMillis()
                                         openedConversationTimestamps =
-                                            openedConversationTimestamps + (it.id to System.currentTimeMillis())
+                                            openedConversationTimestamps + (it.id to now)
+                                        // Persist so the dot stays gone across app restarts.
+                                        sharedPrefs.edit()
+                                            .putLong("opened_conv_${it.id}", now)
+                                            .apply()
                                         activeConversation = it
                                     },
                                     onNewConversation = { showNewConversation = true },
                                     onOpenFriends = { showSocialScreen = true },
-                                    sessionStartTime = lastConversationsVisit,
                                     openedConversationTimestamps = openedConversationTimestamps,
                                 )
                             }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationHandler.kt
@@ -588,6 +588,22 @@ private fun MainScaffold(
                                     onNewConversation = { showNewConversation = true },
                                     onOpenFriends = { showSocialScreen = true },
                                     openedConversationTimestamps = openedConversationTimestamps,
+                                    // On fresh install or emulator wipe SharedPrefs is empty,
+                                    // so every conversation would incorrectly show as unread.
+                                    // Seed all existing conversation IDs with "now" so only
+                                    // genuinely new messages (arriving after this moment)
+                                    // produce dots going forward.
+                                    onSeedTimestamps = { ids ->
+                                        val now = System.currentTimeMillis()
+                                        val seeded = ids.associateWith { now }
+                                        openedConversationTimestamps =
+                                            openedConversationTimestamps + seeded
+                                        val editor = sharedPrefs.edit()
+                                        ids.forEach { id ->
+                                            editor.putLong("opened_conv_$id", now)
+                                        }
+                                        editor.apply()
+                                    },
                                 )
                             }
                         }


### PR DESCRIPTION
### Summary

- Implements the full attachment sending flow for CINet chat — file/image picker, pre-send preview, upload to Firebase Storage, inline rendering in the conversation, and a full-screen image viewer with download.
-  `send-attachments`  was pulled from `searching` and will be pulling both its own changes along with `searching` changes into dev