### PR TITLE
Profile clicking

### DIFF
--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -19,4 +19,6 @@ data class Conversation(
     // false = hidden (e.g. after unfriend). Defaults to true so legacy docs
     // without this field are treated as active.
     val active: Boolean = true,
+    // uid → "admin" | "member". Creator gets "admin". Empty for legacy DMs.
+    val roles: Map<String, String> = emptyMap(),
 )

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -756,18 +756,92 @@ class SocialRepository(
     ): Conversation {
         val docRef = db.collection("conversations").document()
 
+        // For group chats the creator (currentUid) is automatically admin.
+        val roles: Map<String, String> = if (isGroup) mapOf(currentUid to "admin") else emptyMap()
+
         val conversation = Conversation(
             id = docRef.id,
             participantIds = participantIds,
             participantNicknames = participantNicknames,
             isGroup = isGroup,
             groupName = groupName,
+            roles = roles,
         )
 
         Log.d("SocialRepository", "Creating new conversation: ${docRef.id}")
         docRef.set(conversation).await()
 
         return conversation
+    }
+
+    // ── Group management ────────────────────────────────────────────────────
+
+    /** Loads full UserProfile objects for every UID in [uids]. Used by GroupInfoSheet. */
+    suspend fun getConversationMemberProfiles(uids: List<String>): List<UserProfile> {
+        return uids.mapNotNull { uid ->
+            try {
+                db.collection("users").document(uid).get().await()
+                    .toObject(UserProfile::class.java)
+            } catch (_: Exception) { null }
+        }
+    }
+
+    /** Adds [member] to an existing group conversation. */
+    suspend fun addGroupMember(conversationId: String, member: UserProfile): Result<Unit> {
+        return try {
+            db.collection("conversations").document(conversationId)
+                .update(
+                    mapOf(
+                        "participantIds" to FieldValue.arrayUnion(member.uid),
+                        "participantNicknames.${member.uid}" to member.nickname,
+                    )
+                )
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "addGroupMember failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Removes [uid] from the group. Also clears their roles entry.
+     * Passing currentUid serves as "leave group."
+     */
+    suspend fun removeGroupMember(conversationId: String, uid: String): Result<Unit> {
+        return try {
+            db.collection("conversations").document(conversationId)
+                .update(
+                    mapOf(
+                        "participantIds" to FieldValue.arrayRemove(uid),
+                        "roles.$uid" to FieldValue.delete(),
+                    )
+                )
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "removeGroupMember failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Hard-deletes a single message. Admins can delete any message;
+     * callers are responsible for the permission check before calling.
+     */
+    suspend fun deleteMessage(conversationId: String, messageId: String): Result<Unit> {
+        return try {
+            db.collection("conversations")
+                .document(conversationId)
+                .collection("messages")
+                .document(messageId)
+                .delete()
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "deleteMessage failed: ${e.message}")
+            Result.failure(e)
+        }
     }
 
     /** Builds a message object using the current sender's profile data. */

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -844,6 +844,22 @@ class SocialRepository(
         }
     }
 
+    /**
+     * Promotes or demotes a member. Pass "admin" to promote, "member" to demote.
+     * Only the current admin should be calling this — enforce in the UI.
+     */
+    suspend fun updateMemberRole(conversationId: String, uid: String, role: String): Result<Unit> {
+        return try {
+            db.collection("conversations").document(conversationId)
+                .update("roles.$uid", role)
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "updateMemberRole failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
     /** Builds a message object using the current sender's profile data. */
     private fun buildMessage(
         sender: UserProfile,

--- a/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/profile/ProfileScreen.kt
@@ -2,6 +2,7 @@ package com.example.cinet.feature.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -58,6 +59,11 @@ fun ProfileScreen(
             }
         }
     }
+
+    // Intercept system back so it always calls onBack regardless of
+    // NavigationBackHandler's priority order — ensures returning to
+    // the conversation rather than home when opened from inside a chat.
+    BackHandler { onBack() }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -71,6 +71,9 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.material.icons.filled.Info
 
 /**
  * A file the user has selected but not yet sent.
@@ -88,6 +91,7 @@ fun ConversationScreen(
     onBack: () -> Unit,
     onNavigateToLocation: ((String) -> Unit)? = null,
     onNavigateToCoordinates: ((Double, Double, String, String) -> Unit)? = null,
+    onOpenProfile: ((UserProfile) -> Unit)? = null,
 ) {
     val repository = remember { SocialRepository() }
     val calendarRepository = remember { CalendarFirestoreRepository() }
@@ -126,6 +130,7 @@ fun ConversationScreen(
     var showEventInviteDialog by remember { mutableStateOf(false) }
     var showRemoveFriendDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
+    var showGroupInfo by remember { mutableStateOf(false) }
     var renameInput by remember { mutableStateOf("") }
     // Local override so rename is reflected immediately without re-navigation
     var displayGroupName by remember { mutableStateOf(conversation.groupName) }
@@ -133,6 +138,9 @@ fun ConversationScreen(
     var myStudySessions by remember { mutableStateOf<List<StudySession>>(emptyList()) }
     var myEvents by remember { mutableStateOf<List<EventItem>>(emptyList()) }
     var otherUserPhotoUrl by remember { mutableStateOf("") }
+    var otherUserProfile by remember { mutableStateOf<UserProfile?>(null) }
+    // For group chats: uid → UserProfile so message avatars can open the right profile
+    var memberProfiles by remember { mutableStateOf<Map<String, UserProfile>>(emptyMap()) }
     var currentUserPhotoUrl by remember { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
     var showSearchBar by remember { mutableStateOf(false) }
@@ -203,10 +211,14 @@ fun ConversationScreen(
 
     // Load both participants' photos on open
     LaunchedEffect(conversation.id) {
-        if (otherUid.isNotBlank()) {
+        if (conversation.isGroup) {
+            val profiles = repository.getConversationMemberProfiles(conversation.participantIds)
+            memberProfiles = profiles.associateBy { it.uid }
+        } else if (otherUid.isNotBlank()) {
             val otherSnapshot = FirebaseFirestore.getInstance()
                 .collection("users").document(otherUid).get().await()
             otherUserPhotoUrl = otherSnapshot.getString("photoUrl") ?: ""
+            otherUserProfile = otherSnapshot.toObject(UserProfile::class.java)
         }
         val currentSnapshot = FirebaseFirestore.getInstance()
             .collection("users").document(currentUid).get().await()
@@ -296,6 +308,25 @@ fun ConversationScreen(
     }
 
     // Rename group dialog
+    // Group Info bottom sheet
+    if (showGroupInfo && conversation.isGroup) {
+        GroupInfoSheet(
+            conversation = conversation,
+            currentUid = currentUid,
+            onDismiss = { showGroupInfo = false },
+            onRenameGroup = {
+                showGroupInfo = false
+                renameInput = displayGroupName
+                showRenameDialog = true
+            },
+            onLeaveGroup = {
+                showGroupInfo = false
+                onBack()
+            },
+            onOpenProfile = onOpenProfile,
+        )
+    }
+
     if (showRenameDialog) {
         AlertDialog(
             onDismissRequest = { showRenameDialog = false },
@@ -373,22 +404,8 @@ fun ConversationScreen(
                     }
                     Spacer(modifier = Modifier.width(12.dp))
 
-                    // Avatar — uses secondaryContainer for consistent green branding
-                    val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() && !conversation.isGroup }
-                    if (headerPhoto != null) {
-                        AsyncImage(
-                            model = ImageRequest.Builder(LocalContext.current)
-                                .data(headerPhoto)
-                                .crossfade(true)
-                                .build(),
-                            contentDescription = "Profile photo",
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .size(40.dp)
-                                .clip(CircleShape)
-                                .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
-                        )
-                    } else {
+                    if (conversation.isGroup) {
+                        // Group: avatar placeholder
                         Box(
                             modifier = Modifier
                                 .size(40.dp)
@@ -402,24 +419,14 @@ fun ConversationScreen(
                                 style = MaterialTheme.typography.titleMedium
                             )
                         }
-                    }
-
-                    Spacer(modifier = Modifier.width(10.dp))
-
-                    // Group name is tappable to rename; DM name is static
-                    if (conversation.isGroup) {
+                        Spacer(modifier = Modifier.width(10.dp))
                         Text(
                             text = conversationTitle,
                             style = MaterialTheme.typography.titleLarge,
                             fontWeight = FontWeight.SemiBold,
-                            modifier = Modifier
-                                .weight(1f)
-                                .clickable {
-                                    renameInput = displayGroupName
-                                    showRenameDialog = true
-                                }
+                            modifier = Modifier.weight(1f),
                         )
-                        // Search button for group chats
+                        // Search messages
                         IconButton(onClick = { showSearchBar = !showSearchBar }) {
                             Icon(
                                 imageVector = Icons.Default.Search,
@@ -427,47 +434,90 @@ fun ConversationScreen(
                                 tint = MaterialTheme.colorScheme.onPrimary,
                             )
                         }
+                        // Group info sheet
+                        IconButton(onClick = { showGroupInfo = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Info,
+                                contentDescription = "Group info",
+                                tint = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        }
                     } else {
-                        Text(
-                            text = conversationTitle,
-                            style = MaterialTheme.typography.titleLarge,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-
-                    // Remove Friend button — only for direct (non-group) conversations
-                    if (!conversation.isGroup && otherUid.isNotBlank()) {
-                        var expanded by remember { mutableStateOf(false) }
-                        Box {
-                            IconButton(onClick = { expanded = true }) {
-                                Icon(
-                                    Icons.Default.MoreVert,
-                                    contentDescription = "Remove Friend",
-                                    tint = MaterialTheme.colorScheme.onPrimary
+                        // DM: avatar + name — tappable to open the other user's ProfileScreen
+                        val headerPhoto = otherUserPhotoUrl.takeIf { it.isNotBlank() }
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .then(
+                                    if (otherUserProfile != null && onOpenProfile != null)
+                                        Modifier.clickable { onOpenProfile(otherUserProfile!!) }
+                                    else Modifier
+                                ),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            if (headerPhoto != null) {
+                                AsyncImage(
+                                    model = ImageRequest.Builder(LocalContext.current)
+                                        .data(headerPhoto)
+                                        .crossfade(true)
+                                        .build(),
+                                    contentDescription = "Profile photo",
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier
+                                        .size(40.dp)
+                                        .clip(CircleShape)
+                                        .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
                                 )
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .size(40.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                                        .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = conversationTitle.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                        style = MaterialTheme.typography.titleMedium
+                                    )
+                                }
                             }
-
-                            DropdownMenu(
-                                expanded = expanded,
-                                onDismissRequest = { expanded = false },
-                                offset = DpOffset(x = 0.dp, y = 4.dp)
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text("Search Message") },
-                                    leadingIcon = { Icon(Icons.Default.Search, "Search Message") },
-                                    onClick = {
-                                        expanded = false
-                                        showSearchBar = true
-                                    }
-                                )
-                                DropdownMenuItem(
-                                    text = { Text("Remove Friend") },
-                                    leadingIcon = { Icon(Icons.Default.PersonRemove, "Remove Friend") },
-                                    onClick = {
-                                        expanded = false
-                                        showRemoveFriendDialog = true
-                                    }
-                                )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                text = conversationTitle,
+                                style = MaterialTheme.typography.titleLarge,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        // DM MoreVert: search + remove friend
+                        if (otherUid.isNotBlank()) {
+                            var expanded by remember { mutableStateOf(false) }
+                            Box {
+                                IconButton(onClick = { expanded = true }) {
+                                    Icon(
+                                        Icons.Default.MoreVert,
+                                        contentDescription = "More options",
+                                        tint = MaterialTheme.colorScheme.onPrimary
+                                    )
+                                }
+                                DropdownMenu(
+                                    expanded = expanded,
+                                    onDismissRequest = { expanded = false },
+                                    offset = DpOffset(x = 0.dp, y = 4.dp)
+                                ) {
+                                    DropdownMenuItem(
+                                        text = { Text("Search Messages") },
+                                        leadingIcon = { Icon(Icons.Default.Search, null) },
+                                        onClick = { expanded = false; showSearchBar = true }
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Remove Friend") },
+                                        leadingIcon = { Icon(Icons.Default.PersonRemove, null) },
+                                        onClick = { expanded = false; showRemoveFriendDialog = true }
+                                    )
+                                }
                             }
                         }
                     }
@@ -568,6 +618,21 @@ fun ConversationScreen(
                             onNavigateToLocation = onNavigateToLocation,
                             onNavigateToCoordinates = onNavigateToCoordinates,
                             onPreviewImage = { previewMessage = it },
+                            onOpenSenderProfile = if (message.senderId != currentUid && onOpenProfile != null) {
+                                {
+                                    val profile = if (conversation.isGroup)
+                                        memberProfiles[message.senderId]
+                                    else
+                                        otherUserProfile
+                                    profile?.let { onOpenProfile(it) }
+                                }
+                            } else null,
+                            onDeleteMessage = if (
+                                conversation.roles[currentUid] == "admin" ||
+                                message.senderId == currentUid
+                            ) {
+                                { scope.launch { repository.deleteMessage(conversation.id, message.id) } }
+                            } else null,
                             onAccept = if (!alreadyResponded && message.senderId != currentUid &&
                                 (message.type == "study_invite" || message.type == "event_invite")) {
                                 {
@@ -861,6 +926,7 @@ fun ConversationScreen(
 }
 
 // Frontend team: restyle this bubble however you want
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MessageBubble(
     message: Message,
@@ -873,14 +939,49 @@ fun MessageBubble(
     onPreviewImage: ((Message) -> Unit)? = null,
     onAccept: (() -> Unit)? = null,
     onDecline: (() -> Unit)? = null,
+    onDeleteMessage: (() -> Unit)? = null,
+    onOpenSenderProfile: (() -> Unit)? = null,
 ) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog && onDeleteMessage != null) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete Message?") },
+            text = { Text("This will permanently remove the message for everyone.") },
+            confirmButton = {
+                Button(
+                    onClick = { showDeleteDialog = false; onDeleteMessage() },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(
+                if (onDeleteMessage != null)
+                    Modifier.combinedClickable(
+                        onClick = {},
+                        onLongClick = { showDeleteDialog = true }
+                    )
+                else Modifier
+            ),
         horizontalArrangement = if (isCurrentUser) Arrangement.End else Arrangement.Start,
         verticalAlignment = Alignment.Top
     ) {
         if (!isCurrentUser) {
             val photoUrl = message.senderPhotoUrl.takeIf { it.isNotBlank() }
+            val avatarClickModifier = if (onOpenSenderProfile != null)
+                Modifier.clickable { onOpenSenderProfile() }
+            else Modifier
             if (photoUrl != null) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
@@ -889,14 +990,14 @@ fun MessageBubble(
                         .build(),
                     contentDescription = "Profile photo",
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier
+                    modifier = avatarClickModifier
                         .size(36.dp)
                         .clip(CircleShape)
                         .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
                 )
             } else {
                 Box(
-                    modifier = Modifier
+                    modifier = avatarClickModifier
                         .size(36.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.secondaryContainer)

--- a/app/src/main/java/com/example/cinet/feature/social/GroupInfoSheet.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/GroupInfoSheet.kt
@@ -49,7 +49,10 @@ fun GroupInfoSheet(
     val repository = remember { SocialRepository() }
     val scope = rememberCoroutineScope()
 
-    val isAdmin = conversation.roles[currentUid] == "admin"
+    // Local copy of roles so promote/demote reflects immediately without
+    // waiting for a Firestore round-trip to update the parent Conversation.
+    var localRoles by remember { mutableStateOf(conversation.roles) }
+    val isAdmin = localRoles[currentUid] == "admin"
 
     // Load full UserProfile objects for each participant
     var members by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
@@ -173,7 +176,7 @@ fun GroupInfoSheet(
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     items(members, key = { it.uid }) { member ->
-                        val memberRole = conversation.roles[member.uid] ?: "member"
+                        val memberRole = localRoles[member.uid] ?: "member"
                         val isSelf = member.uid == currentUid
 
                         Row(
@@ -244,26 +247,44 @@ fun GroupInfoSheet(
                                 }
                             }
 
-                            // Admin can remove non-admin members (not themselves)
-                            if (isAdmin && !isSelf && memberRole != "admin") {
-                                IconButton(
-                                    onClick = {
-                                        removingUid = member.uid
-                                        scope.launch {
-                                            repository.removeGroupMember(conversation.id, member.uid)
-                                            members = members.filter { it.uid != member.uid }
-                                            removingUid = null
-                                        }
+                            // Admin actions on other members
+                            if (isAdmin && !isSelf) {
+                                // Promote / demote toggle
+                                TextButton(onClick = {
+                                    val newRole = if (memberRole == "admin") "member" else "admin"
+                                    // Update local state immediately so UI reflects the change
+                                    localRoles = localRoles.toMutableMap().also { it[member.uid] = newRole }
+                                    scope.launch {
+                                        repository.updateMemberRole(conversation.id, member.uid, newRole)
                                     }
-                                ) {
-                                    if (removingUid == member.uid) {
-                                        CircularProgressIndicator(modifier = Modifier.size(18.dp))
-                                    } else {
-                                        Icon(
-                                            Icons.Default.PersonRemove,
-                                            contentDescription = "Remove ${member.nickname}",
-                                            tint = MaterialTheme.colorScheme.error
-                                        )
+                                }) {
+                                    Text(
+                                        text = if (memberRole == "admin") "Demote" else "Make Admin",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                                // Remove — only for non-admins
+                                if (memberRole != "admin") {
+                                    IconButton(
+                                        onClick = {
+                                            removingUid = member.uid
+                                            scope.launch {
+                                                repository.removeGroupMember(conversation.id, member.uid)
+                                                members = members.filter { it.uid != member.uid }
+                                                removingUid = null
+                                            }
+                                        }
+                                    ) {
+                                        if (removingUid == member.uid) {
+                                            CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                                        } else {
+                                            Icon(
+                                                Icons.Default.PersonRemove,
+                                                contentDescription = "Remove ${member.nickname}",
+                                                tint = MaterialTheme.colorScheme.error
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/example/cinet/feature/social/GroupInfoSheet.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/GroupInfoSheet.kt
@@ -1,0 +1,386 @@
+package com.example.cinet.feature.social
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.cinet.data.model.Conversation
+import com.example.cinet.data.model.UserProfile
+import com.example.cinet.data.remote.SocialRepository
+import kotlinx.coroutines.launch
+
+/**
+ * Bottom sheet showing group members, roles, and admin actions.
+ *
+ * Admin actions: rename, add member, remove member.
+ * All members: leave group.
+ * Each member row opens their ProfileScreen via [onOpenProfile].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupInfoSheet(
+    conversation: Conversation,
+    currentUid: String,
+    onDismiss: () -> Unit,
+    onRenameGroup: () -> Unit,
+    onLeaveGroup: () -> Unit,
+    onOpenProfile: ((UserProfile) -> Unit)?,
+) {
+    val repository = remember { SocialRepository() }
+    val scope = rememberCoroutineScope()
+
+    val isAdmin = conversation.roles[currentUid] == "admin"
+
+    // Load full UserProfile objects for each participant
+    var members by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
+    var isLoadingMembers by remember { mutableStateOf(true) }
+    var showAddMemberSheet by remember { mutableStateOf(false) }
+    var showLeaveConfirm by remember { mutableStateOf(false) }
+    var removingUid by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(conversation.participantIds) {
+        isLoadingMembers = true
+        members = repository.getConversationMemberProfiles(conversation.participantIds)
+        isLoadingMembers = false
+    }
+
+    // Leave confirmation dialog
+    if (showLeaveConfirm) {
+        AlertDialog(
+            onDismissRequest = { showLeaveConfirm = false },
+            title = { Text("Leave Group?") },
+            text = { Text("You will no longer receive messages in \"${conversation.groupName}\".") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showLeaveConfirm = false
+                        scope.launch {
+                            repository.removeGroupMember(conversation.id, currentUid)
+                            onLeaveGroup()
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) { Text("Leave") }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { showLeaveConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+
+    // Add member sheet
+    if (showAddMemberSheet) {
+        AddMemberSheet(
+            conversation = conversation,
+            currentUid = currentUid,
+            onDismiss = { showAddMemberSheet = false },
+            onMemberAdded = { newMember ->
+                showAddMemberSheet = false
+                scope.launch {
+                    repository.addGroupMember(conversation.id, newMember)
+                    // Refresh list
+                    members = repository.getConversationMemberProfiles(
+                        conversation.participantIds + newMember.uid
+                    )
+                }
+            }
+        )
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            // Sheet title
+            Text(
+                text = conversation.groupName.ifBlank { "Group Chat" },
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(vertical = 12.dp)
+            )
+
+            HorizontalDivider()
+
+            // Admin actions
+            if (isAdmin) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = { onRenameGroup(); onDismiss() },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Rename Group")
+                }
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = { showAddMemberSheet = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.PersonAdd, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("Add Member")
+                }
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+            }
+
+            // Members header
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "${members.size} Members",
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+
+            if (isLoadingMembers) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(80.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f, fill = false),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(members, key = { it.uid }) { member ->
+                        val memberRole = conversation.roles[member.uid] ?: "member"
+                        val isSelf = member.uid == currentUid
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(8.dp))
+                                .clickable(enabled = !isSelf && onOpenProfile != null) {
+                                    onOpenProfile?.invoke(member)
+                                    onDismiss()
+                                }
+                                .padding(vertical = 8.dp, horizontal = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            // Avatar
+                            val photoUrl = member.photoUrl.takeIf { it.isNotBlank() }
+                            if (photoUrl != null) {
+                                AsyncImage(
+                                    model = ImageRequest.Builder(LocalContext.current)
+                                        .data(photoUrl).crossfade(true).build(),
+                                    contentDescription = null,
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .clip(CircleShape)
+                                        .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                                )
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .size(44.dp)
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.secondaryContainer)
+                                        .border(1.5.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = member.nickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                        style = MaterialTheme.typography.labelLarge
+                                    )
+                                }
+                            }
+
+                            Spacer(Modifier.width(12.dp))
+
+                            Column(modifier = Modifier.weight(1f)) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Text(
+                                        text = member.nickname + if (isSelf) " (You)" else "",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = if (memberRole == "admin") FontWeight.SemiBold else FontWeight.Normal
+                                    )
+                                    if (memberRole == "admin") {
+                                        Spacer(Modifier.width(6.dp))
+                                        Icon(
+                                            Icons.Default.Shield,
+                                            contentDescription = "Admin",
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.size(14.dp)
+                                        )
+                                    }
+                                }
+                                if (member.major.isNotBlank()) {
+                                    Text(
+                                        text = member.major,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+
+                            // Admin can remove non-admin members (not themselves)
+                            if (isAdmin && !isSelf && memberRole != "admin") {
+                                IconButton(
+                                    onClick = {
+                                        removingUid = member.uid
+                                        scope.launch {
+                                            repository.removeGroupMember(conversation.id, member.uid)
+                                            members = members.filter { it.uid != member.uid }
+                                            removingUid = null
+                                        }
+                                    }
+                                ) {
+                                    if (removingUid == member.uid) {
+                                        CircularProgressIndicator(modifier = Modifier.size(18.dp))
+                                    } else {
+                                        Icon(
+                                            Icons.Default.PersonRemove,
+                                            contentDescription = "Remove ${member.nickname}",
+                                            tint = MaterialTheme.colorScheme.error
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(8.dp))
+
+            // Leave group — always available (unless only member, but that's an edge case)
+            TextButton(
+                onClick = { showLeaveConfirm = true },
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Leave Group")
+            }
+        }
+    }
+}
+
+/**
+ * Sheet for admin to pick a friend to add to the group.
+ * Shows friends not already in the conversation.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddMemberSheet(
+    conversation: Conversation,
+    currentUid: String,
+    onDismiss: () -> Unit,
+    onMemberAdded: (UserProfile) -> Unit,
+) {
+    val repository = remember { SocialRepository() }
+    var friends by remember { mutableStateOf<List<UserProfile>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        repository.getFriends().onSuccess { allFriends ->
+            // Only show friends not already in the group
+            friends = allFriends.filter { it.uid !in conversation.participantIds }
+        }
+        isLoading = false
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Add Member",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            if (isLoading) {
+                Box(Modifier.fillMaxWidth().height(80.dp), Alignment.Center) {
+                    CircularProgressIndicator(Modifier.size(24.dp))
+                }
+            } else if (friends.isEmpty()) {
+                Text(
+                    text = "No friends available to add.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 16.dp)
+                )
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
+                    items(friends, key = { it.uid }) { friend ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onMemberAdded(friend) }
+                                .padding(vertical = 10.dp, horizontal = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            FriendAvatar(friend = friend, size = 44)
+                            Spacer(Modifier.width(12.dp))
+                            Column {
+                                Text(
+                                    friend.nickname,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                if (friend.major.isNotBlank()) {
+                                    Text(
+                                        friend.major,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -180,9 +180,14 @@ internal fun MainScaffold(
 
     val handleClearProfile = {
         selectedProfile = null
-        if (profileOpenedFromHome) {
+        // Only pop the back stack when there is no active conversation.
+        // If a profile was opened from inside a conversation, clearing it
+        // must return to the conversation — not navigate away from the screen.
+        if (profileOpenedFromHome && activeConversation == null) {
             profileOpenedFromHome = false
             popBackStack()
+        } else {
+            profileOpenedFromHome = false
         }
     }
 

--- a/app/src/main/java/com/example/cinet/navigation/NavigationBackHandler.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationBackHandler.kt
@@ -37,31 +37,25 @@ internal fun NavigationBackHandler(
     onHideProfileEdit: () -> Unit,
     onGoBack: () -> Unit,
 ) {
-    val isSubPageActive = activeConversation != null ||
-            selectedProfile != null ||
-            showNewConversation ||
-            showSocialScreen ||
-            showProfileEdit ||
-            showCanvasScreen ||
-            showAddClassOnCalendar ||
-            showCIView ||
-            selectedNewsArticle != null ||
-            showClubs ||
-            selectedClub != null
+    val socialBackStackActive = currentScreen == Screen.Social &&
+            (activeConversation != null || selectedProfile != null ||
+                    showNewConversation || showSocialScreen)
 
-    val isAtRoot = backStackSize <= 1 && !isSubPageActive
-
-    BackHandler(enabled = !isAtRoot) {
+    BackHandler(
+        enabled = backStackSize > 1 ||
+                socialBackStackActive ||
+                showProfileEdit ||
+                showCanvasScreen ||
+                showAddClassOnCalendar ||
+                showCIView ||
+                selectedNewsArticle != null ||
+                showClubs ||
+                selectedClub != null ||
+                selectedProfile != null
+    ) {
         when {
-            // Priority 1: Dialogs and deepest terminal screens
             showCanvasScreen -> onHideCanvas()
-            showProfileEdit -> onHideProfileEdit()
             showAddClassOnCalendar -> onHideAddClass()
-            
-            // Priority 2: Main content pages (Chat, Article, Club details)
-            // We clear the active conversation first to support "Profile -> Chat -> Back to Profile"
-            activeConversation != null -> onClearActiveConversation()
-            
             selectedNewsArticle != null -> {
                 if (selectedNewsArticle.title == "Study Rooms") {
                     onClearSelectedNewsArticle()
@@ -71,18 +65,17 @@ internal fun NavigationBackHandler(
                     onShowCIView()
                 }
             }
+            showCIView -> onHideCIView()
             selectedClub != null -> onClearSelectedClub()
-
-            // Priority 3: Detail views
+            showClubs -> onHideClubs()
+            // selectedProfile is checked BEFORE activeConversation so that
+            // pressing system-back while viewing a profile opened from inside
+            // a conversation returns to the conversation, not the list.
             selectedProfile != null -> onClearSelectedProfile()
-
-            // Priority 4: Functional sub-lists (New Chat, Friends List, News List, Clubs List)
+            activeConversation != null -> onClearActiveConversation()
             showNewConversation -> onHideNewConversation()
             showSocialScreen -> onHideSocialScreen()
-            showCIView -> onHideCIView()
-            showClubs -> onHideClubs()
-
-            // Priority 5: Global backstack (Tab history)
+            showProfileEdit -> onHideProfileEdit()
             else -> onGoBack()
         }
     }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationSocialRoute.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationSocialRoute.kt
@@ -1,5 +1,6 @@
 package com.example.cinet.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import com.example.cinet.data.model.Conversation
 import com.example.cinet.data.model.UserProfile
@@ -32,16 +33,17 @@ internal fun NavigationSocialRoute(
     onOpenFriends: () -> Unit,
     onSeedTimestamps: (List<String>) -> Unit,
 ) {
-    when {
-        // Priority 1: Active Chat (Chat is the "deepest" view in the social stack)
-        activeConversation != null -> ConversationScreen(
-            conversation = activeConversation,
-            onBack = onConversationBack,
-            onNavigateToLocation = onNavigateToLocation,
-            onNavigateToCoordinates = onNavigateToCoordinates
-        )
+    // Intercept system back when a profile is visible — ensures we return
+    // to the conversation (or wherever we came from) rather than letting
+    // NavigationBackHandler's fallback fire and go home.
+    if (selectedProfile != null) {
+        BackHandler { onProfileBack() }
+    }
 
-        // Priority 2: Profile view (can be opened from Friends list or indirectly from Home/Settings)
+    when {
+        // selectedProfile checked FIRST — lets tapping a user from inside a conversation
+        // navigate to their ProfileScreen without clearing the active conversation.
+        // Back press clears selectedProfile and returns to the conversation.
         selectedProfile != null -> ProfileScreen(
             user = if (selectedProfile.uid == userProfile.uid) userProfile else selectedProfile,
             currentUserProfile = userProfile,
@@ -50,20 +52,25 @@ internal fun NavigationSocialRoute(
             onEditProfile = onEditProfile,
         )
 
-        // Priority 3: Setup for a new conversation
+        activeConversation != null -> ConversationScreen(
+            conversation = activeConversation,
+            onBack = onConversationBack,
+            onNavigateToLocation = onNavigateToLocation,
+            onNavigateToCoordinates = onNavigateToCoordinates,
+            onOpenProfile = onOpenProfile,
+        )
+
         showNewConversation -> NewConversationScreen(
             currentUserProfile = userProfile,
             onBack = onNewConversationBack,
             onOpenConversation = onOpenConversationFromNew
         )
 
-        // Priority 4: Social (Friends List)
         showSocialScreen -> SocialScreen(
             onOpenProfile = onOpenProfile,
             onOpenConversation = onOpenConversationWithFriend
         )
 
-        // Root: Messages List
         else -> ConversationsListScreen(
             onOpenConversation = onOpenConversationFromList,
             onNewConversation = onNewConversation,


### PR DESCRIPTION
### Summary (went beyond being just profile clicking)

- added ability to click profile pictures to open a profile 
- made groups be able to look at who's in the group 
- able to leave group chats (it deletes the convo from `ConversationListScreen.kt`)
- admin rules implemented and the groupchat creator can assign admin access to others

**admin access gives the ability to:**
1. promote people to have that same access 
2. add people to the chat
3. remove people from the chat
4. change the name of the groupchat name

### Things to keep in mind 

- right now, the groupchat list is not updated until you go back to `ConversationListScreen`
- the chat creator can be removed from someone that is made an admin - this will be fixed/removed as a capability in a following commit and/or PR