### PR TITLE
Pinned messages and tweaks

### DIFF
--- a/app/src/main/java/com/example/cinet/data/model/Conversation.kt
+++ b/app/src/main/java/com/example/cinet/data/model/Conversation.kt
@@ -21,4 +21,6 @@ data class Conversation(
     val active: Boolean = true,
     // uid → "admin" | "member". Creator gets "admin". Empty for legacy DMs.
     val roles: Map<String, String> = emptyMap(),
+    // IDs of messages pinned by an admin. Max 3 shown; older pins fall off the banner.
+    val pinnedMessageIds: List<String> = emptyList(),
 )

--- a/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/SocialRepository.kt
@@ -828,15 +828,34 @@ class SocialRepository(
     /**
      * Hard-deletes a single message. Admins can delete any message;
      * callers are responsible for the permission check before calling.
+     *
+     * After deletion, re-queries the most recent remaining message and
+     * updates conversations/{id}.lastMessage so the list preview stays accurate.
      */
     suspend fun deleteMessage(conversationId: String, messageId: String): Result<Unit> {
         return try {
-            db.collection("conversations")
-                .document(conversationId)
-                .collection("messages")
-                .document(messageId)
-                .delete()
+            val conversationRef = db.collection("conversations").document(conversationId)
+            val messagesRef = conversationRef.collection("messages")
+
+            messagesRef.document(messageId).delete().await()
+
+            // Refresh lastMessage to the newest remaining message, or clear it if
+            // the conversation is now empty.
+            val remaining = messagesRef
+                .orderBy("createdAt", Query.Direction.DESCENDING)
+                .limit(1)
+                .get()
                 .await()
+
+            val newLastMessage = remaining.documents.firstOrNull()?.getString("content") ?: ""
+            val newLastSenderId = remaining.documents.firstOrNull()?.getString("senderId") ?: ""
+            conversationRef.update(
+                mapOf(
+                    "lastMessage" to newLastMessage,
+                    "lastSenderId" to newLastSenderId,
+                )
+            ).await()
+
             Result.success(Unit)
         } catch (e: Exception) {
             Log.e("SocialRepository", "deleteMessage failed: ${e.message}")
@@ -1032,6 +1051,32 @@ class SocialRepository(
     }
 
 
+    /** Pins a message. Only the most recent 3 pins are shown in the UI. */
+    suspend fun pinMessage(conversationId: String, messageId: String): Result<Unit> {
+        return try {
+            db.collection("conversations").document(conversationId)
+                .update("pinnedMessageIds", FieldValue.arrayUnion(messageId))
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "pinMessage failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    /** Removes a pin from a message. */
+    suspend fun unpinMessage(conversationId: String, messageId: String): Result<Unit> {
+        return try {
+            db.collection("conversations").document(conversationId)
+                .update("pinnedMessageIds", FieldValue.arrayRemove(messageId))
+                .await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("SocialRepository", "unpinMessage failed: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
     /** Vote casting for polls */
     suspend fun castVote(conversationId: String, messageId: String, selectedIndex: Int, currentUid: String) {
         val messageDocRef = db.collection("conversations")
@@ -1056,9 +1101,17 @@ class SocialRepository(
             }
             votedUids.add(currentUid)
 
+            // userVotes tracks which option each uid voted for: "uid1:0||uid2:2"
+            // This is separate from votedUids (which is just a presence set) so
+            // we can correctly restore the selected highlight after a recompose.
+            val userVotesString = metadata["userVotes"] as? String ?: ""
+            val userVoteEntries = userVotesString.split("||").filter { it.isNotBlank() }.toMutableList()
+            userVoteEntries.add("$currentUid:$selectedIndex")
+
             val updatedMetadata = metadata.toMutableMap().apply {
                 put("votes", voteCounts.joinToString("||"))
                 put("votedUids", votedUids.joinToString("||"))
+                put("userVotes", userVoteEntries.joinToString("||"))
             }
 
             transaction.update(messageDocRef, "metadata", updatedMetadata)

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -240,9 +240,7 @@ fun ConversationScreen(
                 onRemoveFriendClick = if (!conversation.isGroup && otherUid.isNotBlank()) {
                     { showRemoveFriendDialog = true }
                 } else null,
-                onPinnedClick = if (pinnedMessageIds.isNotEmpty()) {
-                    { showPinnedSheet = true }
-                } else null,
+                onPinnedClick = { showPinnedSheet = true },
             )
         )
     }

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationScreen.kt
@@ -74,6 +74,8 @@ import kotlinx.coroutines.tasks.await
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PushPin
 
 /**
  * A file the user has selected but not yet sent.
@@ -85,6 +87,7 @@ private data class PendingAttachment(
     val mimeType: String,
 )
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConversationScreen(
     conversation: Conversation,
@@ -212,12 +215,15 @@ fun ConversationScreen(
     }
 
     var showPollDialog by remember { mutableStateOf(false) }
+    var showPinnedSheet by remember { mutableStateOf(false) }
+    // Declared here (before the LaunchedEffect that keys on it) to avoid a forward reference.
+    var pinnedMessageIds by remember { mutableStateOf(conversation.pinnedMessageIds) }
 
     // Push the current conversation header into the persistent top bar.
     // Re-runs whenever title, photo, or interactive state changes so the bar stays in sync.
     LaunchedEffect(
         conversationTitle, otherUserPhotoUrl, otherUserProfile,
-        conversation.isGroup, showSearchBar, showGroupInfo
+        conversation.isGroup, showSearchBar, showGroupInfo, pinnedMessageIds
     ) {
         onTopBarStateChange(
             ConversationTopBarState(
@@ -233,6 +239,9 @@ fun ConversationScreen(
                 } else null,
                 onRemoveFriendClick = if (!conversation.isGroup && otherUid.isNotBlank()) {
                     { showRemoveFriendDialog = true }
+                } else null,
+                onPinnedClick = if (pinnedMessageIds.isNotEmpty()) {
+                    { showPinnedSheet = true }
                 } else null,
             )
         )
@@ -287,6 +296,20 @@ fun ConversationScreen(
                         val lastUpdated = doc.getTimestamp("lastUpdated")?.toDate()?.time ?: 0L
                         docId != conversation.id && lastUpdated > entryTime
                     }
+                }
+            }
+        onDispose { listener.remove() }
+    }
+
+    // Live pinned message IDs — re-read whenever an admin pins/unpins.
+    DisposableEffect(conversation.id) {
+        val listener = FirebaseFirestore.getInstance()
+            .collection("conversations")
+            .document(conversation.id)
+            .addSnapshotListener { snapshot, _ ->
+                if (snapshot != null) {
+                    @Suppress("UNCHECKED_CAST")
+                    pinnedMessageIds = (snapshot.get("pinnedMessageIds") as? List<String>) ?: emptyList()
                 }
             }
         onDispose { listener.remove() }
@@ -494,6 +517,188 @@ fun ConversationScreen(
                     }
                 }
 
+                // ── Pinned messages sheet ──────────────────────────────────────
+                if (showPinnedSheet) {
+                    val canUnpin = !conversation.isGroup || conversation.roles[currentUid] == "admin"
+                    // Resolve pinned IDs → Messages, newest pin first (like Discord).
+                    // IDs not found in the loaded message list are skipped gracefully.
+                    val resolvedPins: List<Message> = pinnedMessageIds
+                        .reversed()
+                        .mapNotNull { pid -> messages.firstOrNull { msg -> msg.id == pid } }
+
+                    ModalBottomSheet(
+                        onDismissRequest = { showPinnedSheet = false },
+                        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                    ) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            // Header
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.PushPin,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                Spacer(Modifier.width(10.dp))
+                                Text(
+                                    text = "Pinned Messages",
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
+                            HorizontalDivider()
+
+                            if (resolvedPins.isEmpty()) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(48.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "No pinned messages",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(bottom = 24.dp),
+                                    verticalArrangement = Arrangement.spacedBy(0.dp)
+                                ) {
+                                    items(resolvedPins) { pinned ->
+                                        Column(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clickable {
+                                                    showPinnedSheet = false
+                                                    val idx = messages.indexOfFirst { msg -> msg.id == pinned.id }
+                                                    if (idx >= 0) scope.launch { listState.animateScrollToItem(idx) }
+                                                }
+                                                .padding(horizontal = 16.dp, vertical = 12.dp)
+                                        ) {
+                                            // Sender row
+                                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                                val photoUrl = pinned.senderPhotoUrl.takeIf { it.isNotBlank() }
+                                                if (photoUrl != null) {
+                                                    AsyncImage(
+                                                        model = ImageRequest.Builder(LocalContext.current)
+                                                            .data(photoUrl).crossfade(true).build(),
+                                                        contentDescription = null,
+                                                        contentScale = ContentScale.Crop,
+                                                        modifier = Modifier
+                                                            .size(28.dp)
+                                                            .clip(CircleShape)
+                                                            .border(1.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                                                    )
+                                                } else {
+                                                    Box(
+                                                        modifier = Modifier
+                                                            .size(28.dp)
+                                                            .clip(CircleShape)
+                                                            .background(MaterialTheme.colorScheme.secondaryContainer)
+                                                            .border(1.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                                                        contentAlignment = Alignment.Center
+                                                    ) {
+                                                        Text(
+                                                            text = pinned.senderNickname.firstOrNull()?.uppercaseChar()?.toString() ?: "?",
+                                                            style = MaterialTheme.typography.labelSmall,
+                                                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                                        )
+                                                    }
+                                                }
+                                                Spacer(Modifier.width(8.dp))
+                                                Text(
+                                                    text = pinned.senderNickname,
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    fontWeight = FontWeight.SemiBold,
+                                                    color = MaterialTheme.colorScheme.primary,
+                                                )
+                                                Spacer(Modifier.width(6.dp))
+                                                pinned.createdAt?.let { date ->
+                                                    Text(
+                                                        text = SimpleDateFormat("M/d/yy h:mm a", Locale.getDefault()).format(date),
+                                                        style = MaterialTheme.typography.labelSmall,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    )
+                                                }
+                                                if (canUnpin) {
+                                                    Spacer(Modifier.weight(1f))
+                                                    IconButton(
+                                                        onClick = {
+                                                            scope.launch {
+                                                                repository.unpinMessage(conversation.id, pinned.id)
+                                                            }
+                                                        },
+                                                        modifier = Modifier.size(28.dp)
+                                                    ) {
+                                                        Icon(
+                                                            imageVector = Icons.Default.Close,
+                                                            contentDescription = "Unpin",
+                                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                            modifier = Modifier.size(16.dp)
+                                                        )
+                                                    }
+                                                }
+                                            }
+                                            Spacer(Modifier.height(6.dp))
+                                            // Message preview — images render inline, everything else as text
+                                            val isImage = pinned.type == "attachment" &&
+                                                    (pinned.metadata["mimeType"] as? String)?.startsWith("image/") == true
+                                            val imageUrl = pinned.metadata["url"] as? String
+
+                                            if (isImage && imageUrl != null) {
+                                                AsyncImage(
+                                                    model = ImageRequest.Builder(LocalContext.current)
+                                                        .data(imageUrl)
+                                                        .crossfade(true)
+                                                        .build(),
+                                                    contentDescription = pinned.metadata["fileName"] as? String ?: "Image",
+                                                    contentScale = ContentScale.Crop,
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .heightIn(max = 180.dp)
+                                                        .clip(RoundedCornerShape(8.dp))
+                                                )
+                                            } else {
+                                                Surface(
+                                                    shape = RoundedCornerShape(8.dp),
+                                                    color = MaterialTheme.colorScheme.surfaceVariant,
+                                                    modifier = Modifier.fillMaxWidth()
+                                                ) {
+                                                    Text(
+                                                        text = when (pinned.type) {
+                                                            "poll"           -> "📊 Poll: ${pinned.content}"
+                                                            "attachment"     -> "📎 ${pinned.metadata["fileName"] as? String ?: "Attachment"}"
+                                                            "location_share" -> "📍 ${pinned.metadata["locationName"] as? String ?: "Location"}"
+                                                            "study_invite"   -> "📚 Study invite"
+                                                            "event_invite"   -> "📅 Event invite"
+                                                            else             -> pinned.content
+                                                        },
+                                                        style = MaterialTheme.typography.bodyMedium,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                        modifier = Modifier.padding(10.dp),
+                                                        maxLines = 3,
+                                                        overflow = TextOverflow.Ellipsis,
+                                                    )
+                                                }
+                                            }
+                                        }
+                                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 LazyColumn(
                     state = listState,
                     modifier = Modifier
@@ -501,7 +706,7 @@ fun ConversationScreen(
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    items(displayedMessages) { message ->
+                    items(displayedMessages, key = { it.id }) { message ->
                         // Per-user check: has THIS user already accepted or declined?
                         // acceptedBy/declinedBy are comma-separated UIDs stored in metadata.
                         val acceptedBy = (message.metadata["acceptedBy"] as? List<*>)?.filterIsInstance<String>() ?: emptyList()
@@ -530,6 +735,13 @@ fun ConversationScreen(
                                 message.senderId == currentUid
                             ) {
                                 { scope.launch { repository.deleteMessage(conversation.id, message.id) } }
+                            } else null,
+                            onPinMessage = if (message.id !in pinnedMessageIds) {
+                                { scope.launch { repository.pinMessage(conversation.id, message.id) } }
+                            } else null,
+                            onUnpinMessage = if (message.id in pinnedMessageIds &&
+                                (!conversation.isGroup || conversation.roles[currentUid] == "admin")) {
+                                { scope.launch { repository.unpinMessage(conversation.id, message.id) } }
                             } else null,
                             readBy = message.readBy,
                             memberProfiles = memberProfiles,
@@ -859,7 +1071,7 @@ fun ConversationScreen(
 }
 
 // Frontend team: restyle this bubble however you want
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun MessageBubble(
     message: Message,
@@ -873,6 +1085,8 @@ fun MessageBubble(
     onAccept: (() -> Unit)? = null,
     onDecline: (() -> Unit)? = null,
     onDeleteMessage: (() -> Unit)? = null,
+    onPinMessage: (() -> Unit)? = null,
+    onUnpinMessage: (() -> Unit)? = null,
     onOpenSenderProfile: (() -> Unit)? = null,
     readBy: Map<String, Any> = emptyMap(),
     memberProfiles: Map<String, UserProfile> = emptyMap(),
@@ -880,8 +1094,11 @@ fun MessageBubble(
     isGroup: Boolean = false,
     onVoteSubmitted: ((messageId: String, selectedIndex: Int) -> Unit)? = null
 ) {
+    val hasContextActions = onDeleteMessage != null || onPinMessage != null || onUnpinMessage != null
+    var showContextSheet by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
 
+    // Delete confirmation dialog — opened from the context sheet
     if (showDeleteDialog && onDeleteMessage != null) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
@@ -901,14 +1118,68 @@ fun MessageBubble(
         )
     }
 
+    // Context sheet — long-press opens this; shows contextual actions for this bubble
+    if (showContextSheet) {
+        ModalBottomSheet(onDismissRequest = { showContextSheet = false }) {
+            Column(modifier = Modifier.padding(bottom = 24.dp)) {
+                Text(
+                    text = "Message options",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                if (onPinMessage != null) {
+                    ListItem(
+                        headlineContent = { Text("Pin message") },
+                        leadingContent = {
+                            Icon(Icons.Default.PushPin, contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary)
+                        },
+                        modifier = Modifier.clickable {
+                            showContextSheet = false
+                            onPinMessage()
+                        }
+                    )
+                }
+                if (onUnpinMessage != null) {
+                    ListItem(
+                        headlineContent = { Text("Unpin message") },
+                        leadingContent = {
+                            Icon(Icons.Default.PushPin, contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        },
+                        modifier = Modifier.clickable {
+                            showContextSheet = false
+                            onUnpinMessage()
+                        }
+                    )
+                }
+                if (onDeleteMessage != null) {
+                    ListItem(
+                        headlineContent = { Text("Delete message", color = MaterialTheme.colorScheme.error) },
+                        leadingContent = {
+                            Icon(Icons.Default.Delete, contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error)
+                        },
+                        modifier = Modifier.clickable {
+                            showContextSheet = false
+                            showDeleteDialog = true
+                        }
+                    )
+                }
+            }
+        }
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .then(
-                if (onDeleteMessage != null)
+                if (hasContextActions)
                     Modifier.combinedClickable(
                         onClick = {},
-                        onLongClick = { showDeleteDialog = true }
+                        onLongClick = { showContextSheet = true }
                     )
                 else Modifier
             ),
@@ -986,6 +1257,7 @@ fun MessageBubble(
                     message = message,
                     isCurrentUser = isCurrentUser,
                     onPreviewImage = onPreviewImage,
+                    onLongClick = if (hasContextActions) ({ showContextSheet = true }) else null,
                 )
             } else if (message.type == "poll") {
                 PollsBubble(
@@ -1425,11 +1697,13 @@ fun LocationShareBubble(
  *
  * Shape, alignment, and sizing are consistent with the rest of the bubble family.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AttachmentBubble(
     message: Message,
     isCurrentUser: Boolean,
     onPreviewImage: ((Message) -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val url      = message.metadata["url"]      as? String ?: ""
@@ -1462,9 +1736,10 @@ fun AttachmentBubble(
                 MaterialTheme.colorScheme.surfaceVariant,
             modifier = Modifier
                 .widthIn(min = 120.dp, max = 260.dp)
-                .clickable {
-                    if (onPreviewImage != null) onPreviewImage(message) else openUrl()
-                },
+                .combinedClickable(
+                    onClick = { if (onPreviewImage != null) onPreviewImage(message) else openUrl() },
+                    onLongClick = onLongClick,
+                ),
         ) {
             Column {
                 // Round bottom corners only when there's no caption below the image

--- a/app/src/main/java/com/example/cinet/feature/social/ConversationTopBarState.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/ConversationTopBarState.kt
@@ -9,4 +9,5 @@ data class ConversationTopBarState(
     val onSearchClick: () -> Unit,              // toggles in-conversation search bar
     val onInfoClick: (() -> Unit)?,             // group only — opens GroupInfoSheet
     val onRemoveFriendClick: (() -> Unit)?,     // DM only — triggers remove-friend confirmation
+    val onPinnedClick: (() -> Unit)? = null,    // non-null when any messages are pinned
 )

--- a/app/src/main/java/com/example/cinet/feature/social/NewConversationTopBarState.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/NewConversationTopBarState.kt
@@ -8,4 +8,5 @@ data class NewConversationTopBarState(
     val isActionLoading: Boolean,
     val onBackClick: () -> Unit,
     val onActionClick: () -> Unit,
+    val onPinnedClick: (() -> Unit)? = null,
 )

--- a/app/src/main/java/com/example/cinet/feature/social/Polls.kt
+++ b/app/src/main/java/com/example/cinet/feature/social/Polls.kt
@@ -99,12 +99,22 @@ fun PollsBubble(
             ?: emptyList()
     }
     val hasVotedServer = votedUids.contains(currentUid)
-    var localSelectedIndex by remember(message.id) { mutableIntStateOf(-1) }
-    val finalSelectedIndex = if (hasVotedServer) {
-        votedUids.indexOf(currentUid)
-    } else {
-        localSelectedIndex
+
+    // userVotes: "uid1:0||uid2:2" — maps each uid to the option index they chose.
+    // We look this up instead of using votedUids.indexOf(), which would give the
+    // voter's position in the list (wrong) rather than their actual option choice.
+    val serverVotedIndex = remember(message.metadata) {
+        (message.metadata["userVotes"] as? String)
+            ?.split("||")
+            ?.filter { it.isNotBlank() }
+            ?.firstOrNull { it.startsWith("$currentUid:") }
+            ?.substringAfter(":")
+            ?.toIntOrNull()
+            ?: -1
     }
+
+    var localSelectedIndex by remember(message.id) { mutableIntStateOf(-1) }
+    val finalSelectedIndex = if (hasVotedServer) serverVotedIndex else localSelectedIndex
 
     Card(
         shape = cardShape,
@@ -227,17 +237,17 @@ fun PollCreation(
                             .fillMaxWidth()
                             .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
                     )
-                        ExposedDropdownMenu(
-                            expanded = expanded,
-                            onDismissRequest = { expanded = false }
-                        ) {
-                            times.forEach { option ->
-                                DropdownMenuItem(
-                                    text = { Text(option) },
-                                    onClick = { duration = option; expanded = false }
-                                )
-                            }
+                    ExposedDropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        times.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(option) },
+                                onClick = { duration = option; expanded = false }
+                            )
                         }
+                    }
                 }
 
                 Button(
@@ -255,7 +265,7 @@ fun PollCreation(
                         //enabled = question.isNotBlank() && answers.all { it.isNotBlank() }
                     },
                     modifier = Modifier.align(Alignment.End)
-                    ) {
+                ) {
                     Text("Send")
                 }
             }
@@ -269,7 +279,7 @@ fun PollVoting(
     selectedIndex: Int,
     onVoteSelected: (Int) -> Unit
 ) {
-    val answers = remember {
+    val answers = remember(message.id) {
         (message.metadata["answers"] as? String)
             ?.split("||")
             ?.toMutableStateList()

--- a/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.TextButton
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
+import com.example.cinet.feature.map.MapTopBarControls
 import com.example.cinet.feature.social.ConversationTopBarState
 
 
@@ -58,16 +60,25 @@ internal fun AppTopBar(
         ) {
             val newConversationTopBarState = state.newConversationTopBarState
             val conversationTopBarState = state.conversationTopBarState
-            if (state.showBackButton) {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back",
-                        tint = Color.White
-                    )
+            val mapTopBarState = state.mapTopBarState
+            val calendarTopBarState = state.calendarTopBarState
+
+            // Map screen: MapTopBarControls is a RowScope extension that owns
+            // the entire remaining width (search bar + filter button). No title
+            // or separate action slot needed when it is active.
+            if (mapTopBarState != null) {
+                MapTopBarControls(state = mapTopBarState)
+            } else {
+                if (state.showBackButton) {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(4.dp))
                 }
-                Spacer(modifier = Modifier.width(4.dp))
-            }
 
             when {
                 conversationTopBarState != null -> {
@@ -111,19 +122,28 @@ internal fun AppTopBar(
                 }
             }
 
-            if (conversationTopBarState != null) {
-                ConversationTopBarActions(state = conversationTopBarState)
-            } else if (newConversationTopBarState != null) {
-                NewConversationTopBarAction(state = newConversationTopBarState)
-            } else if (state.showSocialActions) {
-                SocialTopBarActions(
-                    pendingRequestCount = state.pendingRequestCount,
-                    showCanvasMessages = state.showCanvasMessagesAction,
-                    onFriendsClick = onFriendsClick,
-                    onNewMessageClick = onNewMessageClick,
-                    onCanvasMessagesClick = onCanvasMessagesClick
-                )
+            // Right-side actions — one branch wins, in priority order.
+            when {
+                conversationTopBarState != null ->
+                    ConversationTopBarActions(state = conversationTopBarState)
+
+                newConversationTopBarState != null ->
+                    NewConversationTopBarAction(state = newConversationTopBarState)
+
+                state.showSocialActions ->
+                    SocialTopBarActions(
+                        pendingRequestCount = state.pendingRequestCount,
+                        showCanvasMessages = state.showCanvasMessagesAction,
+                        onFriendsClick = onFriendsClick,
+                        onNewMessageClick = onNewMessageClick,
+                        onCanvasMessagesClick = onCanvasMessagesClick
+                    )
+
+                // Restored: Calendar quick-access buttons (Classes / Study / Events).
+                calendarTopBarState != null ->
+                    CalendarTopBarActions(state = calendarTopBarState)
             }
+            } // end else (non-map screens)
         }
     }
 }
@@ -254,6 +274,20 @@ private fun ConversationTopBarActions(state: ConversationTopBarState) {
                 }
             }
         }
+    }
+}
+
+// Restored: Shows the Classes / Study / Events quick-access buttons on the Calendar screen.
+@Composable
+private fun CalendarTopBarActions(state: CalendarTopBarState) {
+    IconButton(onClick = state.onClassesClick) {
+        Icon(Icons.Default.School, contentDescription = "Classes", tint = Color.White)
+    }
+    IconButton(onClick = state.onStudyClick) {
+        Icon(Icons.Default.MenuBook, contentDescription = "Study", tint = Color.White)
+    }
+    IconButton(onClick = state.onEventsClick) {
+        Icon(Icons.Default.CalendarMonth, contentDescription = "Events", tint = Color.White)
     }
 }
 

--- a/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
@@ -7,8 +7,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,22 +21,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.TextButton
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
-import com.example.cinet.feature.map.MapTopBarControls
 import com.example.cinet.feature.social.ConversationTopBarState
-
 
 // Draws the persistent page title bar used across the app.
 @Composable
@@ -40,10 +38,15 @@ internal fun AppTopBar(
     state: NavigationTopBarState,
     isHomeScreen: Boolean = false,
     nickname: String = "",
+    mapTopBarContent: (@Composable RowScope.() -> Unit)? = null,
+    calendarTopBarContent: (@Composable RowScope.() -> Unit)? = null,
+    settingsTopBarActions: (@Composable RowScope.() -> Unit)? = null,
     onBack: () -> Unit,
     onFriendsClick: () -> Unit,
     onNewMessageClick: () -> Unit,
     onCanvasMessagesClick: () -> Unit,
+    onSettingsCanvasClick: () -> Unit = {},
+    onSettingsSignOutClick: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -60,25 +63,18 @@ internal fun AppTopBar(
         ) {
             val newConversationTopBarState = state.newConversationTopBarState
             val conversationTopBarState = state.conversationTopBarState
-            val mapTopBarState = state.mapTopBarState
-            val calendarTopBarState = state.calendarTopBarState
 
-            // Map screen: MapTopBarControls is a RowScope extension that owns
-            // the entire remaining width (search bar + filter button). No title
-            // or separate action slot needed when it is active.
-            if (mapTopBarState != null) {
-                MapTopBarControls(state = mapTopBarState)
-            } else {
-                if (state.showBackButton) {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                            tint = Color.White
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(4.dp))
+            if (state.showBackButton) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        tint = Color.White
+                    )
                 }
+
+                Spacer(modifier = Modifier.width(4.dp))
+            }
 
             when {
                 conversationTopBarState != null -> {
@@ -99,6 +95,25 @@ internal fun AppTopBar(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
                     )
+                }
+
+                calendarTopBarContent != null -> {
+                    Text(
+                        text = state.title,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 20.sp,
+                        lineHeight = 50.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    calendarTopBarContent()
+                }
+
+                mapTopBarContent != null -> {
+                    mapTopBarContent()
                 }
 
                 isHomeScreen -> {
@@ -122,7 +137,6 @@ internal fun AppTopBar(
                 }
             }
 
-            // Right-side actions — one branch wins, in priority order.
             when {
                 conversationTopBarState != null ->
                     ConversationTopBarActions(state = conversationTopBarState)
@@ -139,11 +153,15 @@ internal fun AppTopBar(
                         onCanvasMessagesClick = onCanvasMessagesClick
                     )
 
-                // Restored: Calendar quick-access buttons (Classes / Study / Events).
-                calendarTopBarState != null ->
-                    CalendarTopBarActions(state = calendarTopBarState)
+                state.showSettingsActions ->
+                    SettingsTopBarActions(
+                        onCanvasSyncClick = onSettingsCanvasClick,
+                        onSignOutClick = onSettingsSignOutClick
+                    )
+
+                settingsTopBarActions != null ->
+                    settingsTopBarActions()
             }
-            } // end else (non-map screens)
         }
     }
 }
@@ -186,8 +204,13 @@ private fun ConversationTopBarContent(
     val initial = state.title.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
 
     Row(
-        modifier = modifier
-            .then(if (state.onTitleClick != null) Modifier.clickable { state.onTitleClick.invoke() } else Modifier),
+        modifier = modifier.then(
+            if (state.onTitleClick != null) {
+                Modifier.clickable { state.onTitleClick.invoke() }
+            } else {
+                Modifier
+            }
+        ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (!state.isGroup && photoUrl != null) {
@@ -212,10 +235,17 @@ private fun ConversationTopBarContent(
                     .border(1.5.dp, Color.White.copy(alpha = 0.6f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Text(text = initial, color = Color.White, fontSize = 15.sp, fontWeight = FontWeight.Bold)
+                Text(
+                    text = initial,
+                    color = Color.White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold
+                )
             }
         }
+
         Spacer(modifier = Modifier.width(10.dp))
+
         Text(
             text = state.title,
             color = Color.White,
@@ -227,67 +257,100 @@ private fun ConversationTopBarContent(
     }
 }
 
-// Shows the action buttons for an open conversation (search, info, or more-options menu).
+// Shows the action buttons for an open conversation.
 @Composable
 private fun ConversationTopBarActions(state: ConversationTopBarState) {
     if (state.isGroup) {
-        // Group: PushPin (if pinned) + Search + Info
         if (state.onPinnedClick != null) {
             IconButton(onClick = state.onPinnedClick) {
-                Icon(Icons.Default.PushPin, contentDescription = "Pinned messages", tint = Color.White)
+                Icon(
+                    imageVector = Icons.Default.PushPin,
+                    contentDescription = "Pinned messages",
+                    tint = Color.White
+                )
             }
         }
+
         IconButton(onClick = state.onSearchClick) {
-            Icon(Icons.Default.Search, contentDescription = "Search messages", tint = Color.White)
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = "Search messages",
+                tint = Color.White
+            )
         }
+
         if (state.onInfoClick != null) {
             IconButton(onClick = state.onInfoClick) {
-                Icon(Icons.Default.Info, contentDescription = "Group info", tint = Color.White)
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = "Group info",
+                    tint = Color.White
+                )
             }
         }
     } else {
-        // DM: MoreVert dropdown — Pinned Messages, Search Messages, Remove Friend
         var expanded by remember { mutableStateOf(false) }
+
         Box {
             IconButton(onClick = { expanded = true }) {
-                Icon(Icons.Default.MoreVert, contentDescription = "More options", tint = Color.White)
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = "More options",
+                    tint = Color.White
+                )
             }
-            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
                 if (state.onPinnedClick != null) {
                     DropdownMenuItem(
                         text = { Text("Pinned Messages") },
-                        leadingIcon = { Icon(Icons.Default.PushPin, null) },
-                        onClick = { expanded = false; state.onPinnedClick.invoke() }
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.PushPin,
+                                contentDescription = null
+                            )
+                        },
+                        onClick = {
+                            expanded = false
+                            state.onPinnedClick.invoke()
+                        }
                     )
                 }
+
                 DropdownMenuItem(
                     text = { Text("Search Messages") },
-                    leadingIcon = { Icon(Icons.Default.Search, null) },
-                    onClick = { expanded = false; state.onSearchClick() }
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = null
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        state.onSearchClick()
+                    }
                 )
+
                 if (state.onRemoveFriendClick != null) {
                     DropdownMenuItem(
                         text = { Text("Remove Friend") },
-                        leadingIcon = { Icon(Icons.Default.PersonRemove, null) },
-                        onClick = { expanded = false; state.onRemoveFriendClick.invoke() }
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.PersonRemove,
+                                contentDescription = null
+                            )
+                        },
+                        onClick = {
+                            expanded = false
+                            state.onRemoveFriendClick.invoke()
+                        }
                     )
                 }
             }
         }
-    }
-}
-
-// Restored: Shows the Classes / Study / Events quick-access buttons on the Calendar screen.
-@Composable
-private fun CalendarTopBarActions(state: CalendarTopBarState) {
-    IconButton(onClick = state.onClassesClick) {
-        Icon(Icons.Default.School, contentDescription = "Classes", tint = Color.White)
-    }
-    IconButton(onClick = state.onStudyClick) {
-        Icon(Icons.Default.MenuBook, contentDescription = "Study", tint = Color.White)
-    }
-    IconButton(onClick = state.onEventsClick) {
-        Icon(Icons.Default.CalendarMonth, contentDescription = "Events", tint = Color.White)
     }
 }
 
@@ -341,6 +404,7 @@ private fun SocialTopBarActions(
 
         Spacer(modifier = Modifier.width(12.dp))
     }
+
     BadgedBox(
         badge = {
             if (pendingRequestCount > 0) {
@@ -369,5 +433,32 @@ private fun SocialTopBarActions(
                 modifier = Modifier.size(32.dp)
             )
         }
+    }
+}
+
+// Shows the Canvas Sync and Sign Out actions used by the Settings page.
+@Composable
+private fun SettingsTopBarActions(
+    onCanvasSyncClick: () -> Unit,
+    onSignOutClick: () -> Unit,
+) {
+    IconButton(onClick = onCanvasSyncClick) {
+        Icon(
+            imageVector = Icons.Default.Sync,
+            contentDescription = "Canvas Sync",
+            tint = Color.White,
+            modifier = Modifier.size(32.dp)
+        )
+    }
+
+    Spacer(modifier = Modifier.width(12.dp))
+
+    IconButton(onClick = onSignOutClick) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Logout,
+            contentDescription = "Sign out",
+            tint = Color.White,
+            modifier = Modifier.size(32.dp)
+        )
     }
 }

--- a/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
@@ -38,21 +38,17 @@ internal fun AppTopBar(
     state: NavigationTopBarState,
     isHomeScreen: Boolean = false,
     nickname: String = "",
-    mapTopBarContent: (@Composable RowScope.() -> Unit)? = null,
-    calendarTopBarContent: (@Composable RowScope.() -> Unit)? = null,
     onBack: () -> Unit,
     onFriendsClick: () -> Unit,
     onNewMessageClick: () -> Unit,
     onCanvasMessagesClick: () -> Unit,
-){
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primary)
             .statusBarsPadding()
     ) {
-        val topBarHeight = if (mapTopBarContent != null) 70.dp else 60.dp
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -92,25 +88,6 @@ internal fun AppTopBar(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
                     )
-                }
-
-                calendarTopBarContent != null -> {
-                    Text(
-                        text = state.title,
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 20.sp,
-                        lineHeight = 50.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
-                    )
-
-                    calendarTopBarContent()
-                }
-
-                mapTopBarContent != null -> {
-                    mapTopBarContent()
                 }
 
                 isHomeScreen -> {
@@ -234,7 +211,12 @@ private fun ConversationTopBarContent(
 @Composable
 private fun ConversationTopBarActions(state: ConversationTopBarState) {
     if (state.isGroup) {
-        // Group: Search + Info
+        // Group: PushPin (if pinned) + Search + Info
+        if (state.onPinnedClick != null) {
+            IconButton(onClick = state.onPinnedClick) {
+                Icon(Icons.Default.PushPin, contentDescription = "Pinned messages", tint = Color.White)
+            }
+        }
         IconButton(onClick = state.onSearchClick) {
             Icon(Icons.Default.Search, contentDescription = "Search messages", tint = Color.White)
         }
@@ -244,13 +226,20 @@ private fun ConversationTopBarActions(state: ConversationTopBarState) {
             }
         }
     } else {
-        // DM: MoreVert dropdown — Search Messages, Remove Friend
+        // DM: MoreVert dropdown — Pinned Messages, Search Messages, Remove Friend
         var expanded by remember { mutableStateOf(false) }
         Box {
             IconButton(onClick = { expanded = true }) {
                 Icon(Icons.Default.MoreVert, contentDescription = "More options", tint = Color.White)
             }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                if (state.onPinnedClick != null) {
+                    DropdownMenuItem(
+                        text = { Text("Pinned Messages") },
+                        leadingIcon = { Icon(Icons.Default.PushPin, null) },
+                        onClick = { expanded = false; state.onPinnedClick.invoke() }
+                    )
+                }
                 DropdownMenuItem(
                     text = { Text("Search Messages") },
                     leadingIcon = { Icon(Icons.Default.Search, null) },

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -236,6 +236,9 @@ internal fun MainScaffold(
             selectedClub != null -> selectedClub = null
             showClubs -> showClubs = false
             currentScreen == Screen.Social && selectedProfile != null -> selectedProfile = null
+            currentScreen == Screen.Social && showSocialScreen -> {
+                showSocialScreen = false
+            }
             currentScreen == Screen.Social && activeConversation != null -> {
                 activeConversation = null
                 conversationTopBarState = null

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -72,6 +72,9 @@ internal fun MainScaffold(
     var showSocialScreen by remember { mutableStateOf(false) }
     var newConversationTopBarState by remember { mutableStateOf<NewConversationTopBarState?>(null) }
     var conversationTopBarState by remember { mutableStateOf<ConversationTopBarState?>(null) }
+    // Restored: top-bar state pushed up from the Map and Calendar screens.
+    var mapTopBarState by remember { mutableStateOf<com.example.cinet.feature.map.MapTopBarState?>(null) }
+    var calendarTopBarState by remember { mutableStateOf<com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState?>(null) }
 
     var showCIView by remember { mutableStateOf(false) }
     var selectedNewsArticle by remember { mutableStateOf<NewsArticle?>(null) }
@@ -415,7 +418,10 @@ internal fun MainScaffold(
                 conversationTopBarState
             } else {
                 null
-            }
+            },
+            // Restored: pass map and calendar top-bar states through to AppTopBar.
+            mapTopBarState = if (currentScreen == Screen.Map) mapTopBarState else null,
+            calendarTopBarState = if (currentScreen == Screen.Calendar) calendarTopBarState else null,
         ),
         currentScreen = currentScreen,
         userProfile = userProfile,
@@ -642,6 +648,7 @@ internal fun MainScaffold(
             if (selectedClub != null) selectedClub = null else showClubs = false
         },
         onCanvasConversationClick = { selectedCanvasConversation = it },
-        onMapTopBarStateChanged = {},
+        onMapTopBarStateChanged = { mapTopBarState = it },
+        onCalendarTopBarStateChanged = { calendarTopBarState = it },
     )
 }

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -243,9 +243,6 @@ internal fun MainScaffold(
                     newConversationTopBarState = null
                 }
             }
-            currentScreen == Screen.Social && showSocialScreen -> {
-                showSocialScreen = false
-            }
             currentScreen == Screen.Settings && showCanvasScreen -> showCanvasScreen = false
             currentScreen == Screen.Settings && showProfileEdit -> showProfileEdit = false
             currentScreen == Screen.Settings && selectedProfile != null -> {
@@ -645,5 +642,6 @@ internal fun MainScaffold(
             if (selectedClub != null) selectedClub = null else showClubs = false
         },
         onCanvasConversationClick = { selectedCanvasConversation = it },
+        onMapTopBarStateChanged = {},
     )
 }

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -405,6 +405,10 @@ internal fun MainScaffold(
                     !showNewConversation &&
                     !showSocialScreen,
             showCanvasMessagesAction = showCanvasMessagesAction,
+            showSettingsActions = currentScreen == Screen.Settings &&
+                    !showCanvasScreen &&
+                    !showProfileEdit &&
+                    selectedProfile == null,
             pendingRequestCount = pendingRequestCount,
             isHomeScreen = currentScreen == Screen.Home &&
                     selectedNewsArticle == null &&
@@ -651,7 +655,7 @@ internal fun MainScaffold(
             if (selectedClub != null) selectedClub = null else showClubs = false
         },
         onCanvasConversationClick = { selectedCanvasConversation = it },
-        onMapTopBarStateChanged = { mapTopBarState = it },
-        onCalendarTopBarStateChanged = { calendarTopBarState = it },
+        onSettingsCanvasClick = routeCallbacks.onOpenCanvas,
+        onSettingsSignOutClick = routeCallbacks.onSignOut,
     )
 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationMapLayer.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationMapLayer.kt
@@ -9,12 +9,13 @@ import androidx.compose.ui.input.pointer.pointerInput
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.CampusMapScreen
 import com.example.cinet.feature.map.MapTopBarState
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 
-// Displays the campus map only when the navigation layer asks for the map screen.
+// Keeps the map alive in the composition and hides it when another page is active.
+// currentScreen controls visibility via alpha so the map composable is never destroyed
+// (avoids reload cost). Pointer input is blocked when hidden so touches don't leak through.
 @Composable
 internal fun NavigationMapLayer(
+    currentScreen: Screen,
     preSelectedLocation: CampusLocation?,
     autoRouteToPreSelectedLocation: Boolean,
     extraLocations: List<CampusLocation>,
@@ -24,7 +25,20 @@ internal fun NavigationMapLayer(
     onTopBarStateChanged: (MapTopBarState?) -> Unit,
 ) {
     Box(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer { alpha = if (currentScreen == Screen.Map) 1f else 0f }
+            .then(
+                if (currentScreen != Screen.Map) {
+                    Modifier.pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (true) { awaitPointerEvent() }
+                        }
+                    }
+                } else {
+                    Modifier
+                }
+            )
     ) {
         CampusMapScreen(
             onBack = onBack,
@@ -33,7 +47,7 @@ internal fun NavigationMapLayer(
             onFinishedLoading = onFinishedLoading,
             extraLocations = extraLocations,
             onRemoveExtraLocation = onRemoveExtraLocation,
-            onTopBarStateChanged = onTopBarStateChanged
+            onTopBarStateChanged = onTopBarStateChanged,
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationMapLayer.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationMapLayer.kt
@@ -5,14 +5,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.zIndex
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.CampusMapScreen
 import com.example.cinet.feature.map.MapTopBarState
 
-// Keeps the map alive in the composition and hides it when another page is active.
-// currentScreen controls visibility via alpha so the map composable is never destroyed
-// (avoids reload cost). Pointer input is blocked when hidden so touches don't leak through.
+// Keeps the map alive, but moves it behind other pages when Map is not active.
 @Composable
 internal fun NavigationMapLayer(
     currentScreen: Screen,
@@ -24,21 +22,15 @@ internal fun NavigationMapLayer(
     onRemoveExtraLocation: (CampusLocation) -> Unit,
     onTopBarStateChanged: (MapTopBarState?) -> Unit,
 ) {
+    val isMapVisible = currentScreen == Screen.Map
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .graphicsLayer { alpha = if (currentScreen == Screen.Map) 1f else 0f }
-            .then(
-                if (currentScreen != Screen.Map) {
-                    Modifier.pointerInput(Unit) {
-                        awaitPointerEventScope {
-                            while (true) { awaitPointerEvent() }
-                        }
-                    }
-                } else {
-                    Modifier
-                }
-            )
+            .zIndex(if (isMapVisible) 1f else 0f)
+            .graphicsLayer {
+                alpha = if (isMapVisible) 1f else 0f
+            }
     ) {
         CampusMapScreen(
             onBack = onBack,

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
@@ -20,6 +20,9 @@ import com.example.cinet.feature.map.MapTopBarState
 import androidx.compose.foundation.background
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.zIndex
+import androidx.compose.runtime.*
+import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarActions
+import com.example.cinet.feature.map.MapTopBarControls
 
 // Draws the scaffold, persistent top bar, bottom bar, map layer, and active page route.
 @Composable
@@ -39,10 +42,11 @@ internal fun NavigationScaffoldContent(
     onClubClick: (ClubItem) -> Unit,
     onClubsBack: () -> Unit,
     onCanvasConversationClick: (CanvasConversation) -> Unit,
-    onMapTopBarStateChanged: (MapTopBarState?) -> Unit,
-    // Restored: forwards CalendarScreen's top-bar state up to AppTopBar.
-    onCalendarTopBarStateChanged: (CalendarTopBarState?) -> Unit,
+    onSettingsCanvasClick: () -> Unit,
+    onSettingsSignOutClick: () -> Unit,
 ) {
+    var mapTopBarState by remember { mutableStateOf<MapTopBarState?>(null) }
+    var calendarTopBarState by remember { mutableStateOf<CalendarTopBarState?>(null) }
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
@@ -54,9 +58,25 @@ internal fun NavigationScaffoldContent(
                         !uiState.isShowingClubs &&
                         !uiState.isShowingCanvasInbox,
                 nickname = uiState.userProfile.nickname,
+                mapTopBarContent = if (uiState.currentScreen == Screen.Map && mapTopBarState != null) {
+                    {
+                        MapTopBarControls(state = mapTopBarState!!)
+                    }
+                } else {
+                    null
+                },
+                calendarTopBarContent = if (uiState.currentScreen == Screen.Calendar && calendarTopBarState != null) {
+                    {
+                        CalendarTopBarActions(state = calendarTopBarState!!)
+                    }
+                } else {
+                    null
+                },
                 onFriendsClick = onTopBarFriendsClick,
                 onNewMessageClick = onTopBarNewMessageClick,
-                onCanvasMessagesClick = onTopBarCanvasMessagesClick
+                onCanvasMessagesClick = onTopBarCanvasMessagesClick,
+                onSettingsCanvasClick = onSettingsCanvasClick,
+                onSettingsSignOutClick = onSettingsSignOutClick
             )
         },
         bottomBar = {
@@ -89,7 +109,7 @@ internal fun NavigationScaffoldContent(
                 onBack = onMapBack,
                 onFinishedLoading = onMapFinishedLoading,
                 onRemoveExtraLocation = onRemoveExtraLocation,
-                onTopBarStateChanged = onMapTopBarStateChanged,
+                onTopBarStateChanged = { mapTopBarState = it }
             )
 
             if (uiState.currentScreen != Screen.Map) {
@@ -120,7 +140,7 @@ internal fun NavigationScaffoldContent(
                         else -> NavigationScreenRoute(
                             uiState = uiState,
                             callbacks = routeCallbacks,
-                            onCalendarTopBarStateChanged = onCalendarTopBarStateChanged
+                            onCalendarTopBarStateChanged = { calendarTopBarState = it }
                         )
                     }
                 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
@@ -15,10 +15,7 @@ import com.example.cinet.data.remote.canvas.CanvasConversation
 import com.example.cinet.feature.clubs.ClubItem
 import com.example.cinet.feature.home.news.NewsArticle
 import com.example.cinet.feature.map.CampusLocation
-import com.example.cinet.feature.map.MapTopBarControls
 import com.example.cinet.feature.map.MapTopBarState
-import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarActions
-import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
 
 // Draws the scaffold, persistent top bar, bottom bar, map layer, and active page route.
 @Composable
@@ -38,9 +35,8 @@ internal fun NavigationScaffoldContent(
     onClubClick: (ClubItem) -> Unit,
     onClubsBack: () -> Unit,
     onCanvasConversationClick: (CanvasConversation) -> Unit,
+    onMapTopBarStateChanged: (MapTopBarState?) -> Unit,
 ) {
-    var mapTopBarState by remember { mutableStateOf<MapTopBarState?>(null) }
-    var calendarTopBarState by remember { mutableStateOf<CalendarTopBarState?>(null) }
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
@@ -52,20 +48,6 @@ internal fun NavigationScaffoldContent(
                         !uiState.isShowingClubs &&
                         !uiState.isShowingCanvasInbox,
                 nickname = uiState.userProfile.nickname,
-                mapTopBarContent = if (uiState.currentScreen == Screen.Map && mapTopBarState != null) {
-                    {
-                        MapTopBarControls(state = mapTopBarState!!)
-                    }
-                } else {
-                    null
-                },
-                calendarTopBarContent = if (uiState.currentScreen == Screen.Calendar && calendarTopBarState != null) {
-                    {
-                        CalendarTopBarActions(state = calendarTopBarState!!)
-                    }
-                } else {
-                    null
-                },
                 onFriendsClick = onTopBarFriendsClick,
                 onNewMessageClick = onTopBarNewMessageClick,
                 onCanvasMessagesClick = onTopBarCanvasMessagesClick
@@ -93,23 +75,19 @@ internal fun NavigationScaffoldContent(
                 .fillMaxSize()
                 .padding(contentPadding)
         ) {
-            if (uiState.currentScreen == Screen.Map) {
-                NavigationMapLayer(
-                    preSelectedLocation = uiState.preSelectedMapLocation,
-                    autoRouteToPreSelectedLocation = uiState.autoRouteToPreSelectedMapLocation,
-                    extraLocations = uiState.sharedLocations,
-                    onBack = onMapBack,
-                    onFinishedLoading = onMapFinishedLoading,
-                    onRemoveExtraLocation = onRemoveExtraLocation,
-                    onTopBarStateChanged = { mapTopBarState = it }
-                )
-            }
+            NavigationMapLayer(
+                currentScreen = uiState.currentScreen,
+                preSelectedLocation = uiState.preSelectedMapLocation,
+                autoRouteToPreSelectedLocation = uiState.autoRouteToPreSelectedMapLocation,
+                extraLocations = uiState.sharedLocations,
+                onBack = onMapBack,
+                onFinishedLoading = onMapFinishedLoading,
+                onRemoveExtraLocation = onRemoveExtraLocation,
+                onTopBarStateChanged = onMapTopBarStateChanged,
+            )
 
             if (uiState.currentScreen != Screen.Map) {
                 when {
-                    // Canvas messaging overlay takes precedence over news/clubs
-                    // because the user explicitly opened it from a home tile;
-                    // they expect to see it regardless of what was open before.
                     uiState.isShowingCanvasInbox -> NavigationCanvasMessagesRoute(
                         selectedConversation = uiState.selectedCanvasConversation,
                         onOpenConversation = onCanvasConversationClick
@@ -129,8 +107,7 @@ internal fun NavigationScaffoldContent(
 
                     else -> NavigationScreenRoute(
                         uiState = uiState,
-                        callbacks = routeCallbacks,
-                        onCalendarTopBarStateChanged = { calendarTopBarState = it }
+                        callbacks = routeCallbacks
                     )
                 }
             }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
@@ -17,6 +17,9 @@ import com.example.cinet.feature.home.news.NewsArticle
 import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.MapTopBarState
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.zIndex
 
 // Draws the scaffold, persistent top bar, bottom bar, map layer, and active page route.
 @Composable
@@ -90,29 +93,36 @@ internal fun NavigationScaffoldContent(
             )
 
             if (uiState.currentScreen != Screen.Map) {
-                when {
-                    uiState.isShowingCanvasInbox -> NavigationCanvasMessagesRoute(
-                        selectedConversation = uiState.selectedCanvasConversation,
-                        onOpenConversation = onCanvasConversationClick
-                    )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
+                        .zIndex(2f)
+                ) {
+                    when {
+                        uiState.isShowingCanvasInbox -> NavigationCanvasMessagesRoute(
+                            selectedConversation = uiState.selectedCanvasConversation,
+                            onOpenConversation = onCanvasConversationClick
+                        )
 
-                    uiState.isShowingNews -> NavigationNewsRoute(
-                        selectedNewsArticle = uiState.selectedNewsArticle,
-                        onArticleClick = onArticleClick,
-                        onBack = onNewsBack
-                    )
+                        uiState.isShowingNews -> NavigationNewsRoute(
+                            selectedNewsArticle = uiState.selectedNewsArticle,
+                            onArticleClick = onArticleClick,
+                            onBack = onNewsBack
+                        )
 
-                    uiState.isShowingClubs -> NavigationClubsRoute(
-                        selectedClub = uiState.selectedClub,
-                        onClubClick = onClubClick,
-                        onBack = onClubsBack
-                    )
+                        uiState.isShowingClubs -> NavigationClubsRoute(
+                            selectedClub = uiState.selectedClub,
+                            onClubClick = onClubClick,
+                            onBack = onClubsBack
+                        )
 
-                    else -> NavigationScreenRoute(
-                        uiState = uiState,
-                        callbacks = routeCallbacks,
-                        onCalendarTopBarStateChanged = onCalendarTopBarStateChanged
-                    )
+                        else -> NavigationScreenRoute(
+                            uiState = uiState,
+                            callbacks = routeCallbacks,
+                            onCalendarTopBarStateChanged = onCalendarTopBarStateChanged
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.example.cinet.data.remote.canvas.CanvasConversation
 import com.example.cinet.feature.clubs.ClubItem
 import com.example.cinet.feature.home.news.NewsArticle
+import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
 import com.example.cinet.feature.map.CampusLocation
 import com.example.cinet.feature.map.MapTopBarState
 
@@ -36,6 +37,8 @@ internal fun NavigationScaffoldContent(
     onClubsBack: () -> Unit,
     onCanvasConversationClick: (CanvasConversation) -> Unit,
     onMapTopBarStateChanged: (MapTopBarState?) -> Unit,
+    // Restored: forwards CalendarScreen's top-bar state up to AppTopBar.
+    onCalendarTopBarStateChanged: (CalendarTopBarState?) -> Unit,
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -107,7 +110,8 @@ internal fun NavigationScaffoldContent(
 
                     else -> NavigationScreenRoute(
                         uiState = uiState,
-                        callbacks = routeCallbacks
+                        callbacks = routeCallbacks,
+                        onCalendarTopBarStateChanged = onCalendarTopBarStateChanged
                     )
                 }
             }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
@@ -1,4 +1,5 @@
 package com.example.cinet.navigation
+
 import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
 import com.example.cinet.feature.map.MapTopBarState
 import com.example.cinet.feature.social.ConversationTopBarState
@@ -10,13 +11,12 @@ internal data class NavigationTopBarState(
     val showBackButton: Boolean,
     val showSocialActions: Boolean,
     val showCanvasMessagesAction: Boolean = false,
+    val showSettingsActions: Boolean = false,
     val pendingRequestCount: Int,
     val isHomeScreen: Boolean = false,
     val nickname: String = "",
     val newConversationTopBarState: NewConversationTopBarState? = null,
     val conversationTopBarState: ConversationTopBarState? = null,
-    // Restored: map search/filter controls shown in the top bar on the Map screen.
     val mapTopBarState: MapTopBarState? = null,
-    // Restored: Classes / Study / Events action buttons shown on the Calendar screen.
     val calendarTopBarState: CalendarTopBarState? = null,
 )

--- a/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
@@ -1,4 +1,6 @@
 package com.example.cinet.navigation
+import com.example.cinet.feature.calendar.calendarFiles.CalendarTopBarState
+import com.example.cinet.feature.map.MapTopBarState
 import com.example.cinet.feature.social.ConversationTopBarState
 import com.example.cinet.feature.social.NewConversationTopBarState
 
@@ -13,4 +15,8 @@ internal data class NavigationTopBarState(
     val nickname: String = "",
     val newConversationTopBarState: NewConversationTopBarState? = null,
     val conversationTopBarState: ConversationTopBarState? = null,
+    // Restored: map search/filter controls shown in the top bar on the Map screen.
+    val mapTopBarState: MapTopBarState? = null,
+    // Restored: Classes / Study / Events action buttons shown on the Calendar screen.
+    val calendarTopBarState: CalendarTopBarState? = null,
 )


### PR DESCRIPTION
### Summary

- ability to pin messages with a long hold down on the message
- for groupchats , an pin icon on the top right of `ConversationScreen.kt` shows a pinned message list when clicked (like discord)
- for one-on-one conversations, the pinned messages are in the 3 dotted column symbol top right
- deleting a message means that one the `ConversationListScreen.kt`, you wont see the old message that was deleted as the last message sent
- fixes to poll bugs

### Something to note
I had major regression issues to top bar navigation when implementing the pin icon persistency on the top right, i fixed them but something could have slipped my notice 