### PR TITLE
Canvas api token patch upon sign out

### DIFF
--- a/app/src/main/java/com/example/cinet/app/MainActivity.kt
+++ b/app/src/main/java/com/example/cinet/app/MainActivity.kt
@@ -84,9 +84,7 @@ class MainActivity : ComponentActivity() {
             ) {
                 NavigationHandler(
                     authState = authState,
-                    onSignOut = {
-                        CanvasTokenStore(this@MainActivity).clear()
-                        authViewModel.signOut() },
+                    onSignOut = { signOutAndClearCanvasSession() },
                     onRetry = { authViewModel.retryProfileLoad() },
                     onSaveProfile = { nickname, major, minor, pronouns ->
                         authViewModel.saveProfile(nickname, major, minor, pronouns)
@@ -107,6 +105,14 @@ class MainActivity : ComponentActivity() {
         setIntent(intent)
         pendingConversationId = intent.getStringExtra(EXTRA_CONVERSATION_ID)
         pendingMapLocationName = intent.getStringExtra(EXTRA_OPEN_MAP_FOR_LOCATION)
+    }
+
+    // Clears Canvas access before signing out so the next user must reconnect Canvas.
+    private fun signOutAndClearCanvasSession() {
+        CanvasTokenStore(this).clear()
+        CanvasDisplaySettings.showCanvasInCalendar = false
+        CanvasMessagingSettings.showCanvasMessaging = false
+        authViewModel.signOut()
     }
 
     companion object {

--- a/app/src/main/java/com/example/cinet/data/remote/canvas/CanvasTokenStore.kt
+++ b/app/src/main/java/com/example/cinet/data/remote/canvas/CanvasTokenStore.kt
@@ -40,9 +40,9 @@ class CanvasTokenStore(context: Context) {
         prefs.edit().putString(KEY_TOKEN, rawToken.trim()).apply()
     }
 
-    /** Wipes the saved token (used by "Disconnect Canvas"). */
+    /** Wipes the saved token immediately so sign-out cannot reuse a stale Canvas session. */
     fun clear() {
-        prefs.edit().remove(KEY_TOKEN).apply()
+        prefs.edit().remove(KEY_TOKEN).commit()
     }
 
     /** True when a token is currently saved — used to drive the "Connected" UI state. */

--- a/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/calendarFiles/CalendarScreen.kt
@@ -555,6 +555,7 @@ fun CalendarScreen(
             onTopicChange = { sessionTopic = it },
             startTime = sessionStartTime,
             className = sessionClassName,
+            classItems = visibleClassItems,
             onClassNameChange = { sessionClassName = it },
             onPickStartTime = { openTimePicker(context) { picked -> sessionStartTime = picked } },
             onDismiss = { showStudySessionDialog = false; resetStudySessionForm() },

--- a/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
+++ b/app/src/main/java/com/example/cinet/feature/calendar/study/StudySessionDialog.kt
@@ -9,13 +9,11 @@ import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -23,11 +21,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.model.CampusRegistry
-import com.example.cinet.feature.calendar.calendarFiles.CalendarFirestoreRepository
 import com.example.cinet.feature.calendar.classEvent.ClassItem
 import com.example.cinet.feature.map.SearchBar
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,6 +35,7 @@ fun StudySessionDialog(
     onTopicChange: (String) -> Unit,
     startTime: String,
     className: String,
+    classItems: List<ClassItem>,
     onClassNameChange: (String) -> Unit,
     onPickStartTime: () -> Unit,
     onDismiss: () -> Unit,
@@ -51,18 +49,7 @@ fun StudySessionDialog(
     val textFieldState = rememberTextFieldState()
 
     var expanded by remember { mutableStateOf(false) }
-    var classList by remember { mutableStateOf<List<ClassItem>>(emptyList()) }
-    val scope = rememberCoroutineScope()
-    LaunchedEffect(Unit) {
-        scope.launch {
-            try {
-                classList = CalendarFirestoreRepository().loadClasses()
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
-    val validClass = classList.any { it.name == className }
+    val validClass = classItems.any { it.name == className }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(if (editingSession == null) "Add Study Session" else "Edit Study Session") },
@@ -93,7 +80,10 @@ fun StudySessionDialog(
                             .fillMaxWidth()
                             .menuAnchor(MenuAnchorType.PrimaryEditable)
                     )
-                    val filtering = classList.filter { it.name.contains(className, ignoreCase = true) }
+                    val filtering = classItems
+                        .filter { it.name.contains(className, ignoreCase = true) }
+                        .distinctBy { it.name }
+                        .sortedBy { it.name.lowercase() }
                     if (filtering.isNotEmpty()) {
                         ExposedDropdownMenu(
                             expanded = expanded,
@@ -183,6 +173,7 @@ fun StudySessionDialogCreatePreview() {
         onTopicChange = {},
         startTime = "",
         className = "",
+        classItems = emptyList(),
         onClassNameChange = {},
         onPickStartTime = {},
         onDismiss = {},
@@ -208,6 +199,7 @@ fun StudySessionDialogEditPreview() {
         onTopicChange = {},
         startTime = "3:00 PM",
         className = "",
+        classItems = emptyList(),
         onClassNameChange = {},
         onPickStartTime = {},
         onDismiss = {},

--- a/app/src/main/java/com/example/cinet/feature/messages/viewmodel/CanvasMessagingViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/messages/viewmodel/CanvasMessagingViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import com.example.cinet.data.remote.canvas.CanvasDisplaySettings
 
 /**
  * Holds the state of the Canvas messaging surface.

--- a/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
+++ b/app/src/main/java/com/example/cinet/feature/settings/UserSetting.kt
@@ -43,14 +43,12 @@ object AppSettings {
 @Composable
 fun SettingScreen(
     onBack: () -> Unit,
-    onSignOut: () -> Unit,
     isDarkMode: Boolean,
     notificationsEnabled: Boolean,
     selectedTheme: AppThemeColor,
     onSettingsChange: (Boolean, Boolean, AppThemeColor) -> Unit,
     userProfile: UserProfile? = null,
     onViewProfile: () -> Unit = {},
-    onOpenCanvas: () -> Unit = {},
     showHeader: Boolean = true,
     readReceiptsEnabled: Boolean = true,
     onReadReceiptsChange: (Boolean) -> Unit = {},
@@ -238,27 +236,6 @@ fun SettingScreen(
                 onCheckedChange = onReadReceiptsChange
             )
         }
-
         Spacer(modifier = Modifier.weight(1f))
-
-        // Canvas LMS sync entry
-        OutlinedButton(
-            onClick = onOpenCanvas,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 8.dp),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
-        ) {
-            Text("Canvas Sync")
-        }
-
-        // sign out button
-        OutlinedButton(
-            onClick = onSignOut,
-            modifier = Modifier.fillMaxWidth(),
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error)
-        ) {
-            Text("Sign out")
-        }
     }
 }

--- a/app/src/main/java/com/example/cinet/feature/settings/canvas/CanvasConnectionScreen.kt
+++ b/app/src/main/java/com/example/cinet/feature/settings/canvas/CanvasConnectionScreen.kt
@@ -7,20 +7,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -34,6 +21,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.cinet.data.remote.canvas.CanvasDisplaySettings
 import com.example.cinet.data.remote.canvas.CanvasMessagingSettings
 import com.example.cinet.feature.settings.canvas.viewmodel.CanvasSyncViewModel
+import androidx.compose.runtime.LaunchedEffect
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +34,10 @@ fun CanvasConnectionScreen(
     val state by viewModel.uiState.collectAsState()
     val showCanvasInCalendar = CanvasDisplaySettings.showCanvasInCalendar
     val showCanvasMessaging = CanvasMessagingSettings.showCanvasMessaging
+
+    LaunchedEffect(Unit) {
+        viewModel.refreshConnectionState()
+    }
 
     Scaffold(
         topBar = {
@@ -90,7 +82,7 @@ fun CanvasConnectionScreen(
                         text = if (state.hasToken)
                             "CINet pulls your starred Canvas courses, their assignments, calendar events, announcements, and to-dos."
                         else
-                            "Paste a Personal Access Token to let CINet pull your Canvas data into the calendar.",
+                            "Canvas is disconnected. Enter a valid Canvas access token to sync again.",
                         style = MaterialTheme.typography.bodySmall
                     )
                 }

--- a/app/src/main/java/com/example/cinet/feature/settings/canvas/viewmodel/CanvasSyncViewModel.kt
+++ b/app/src/main/java/com/example/cinet/feature/settings/canvas/viewmodel/CanvasSyncViewModel.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.example.cinet.data.remote.canvas.CanvasDisplaySettings
+import com.example.cinet.data.remote.canvas.CanvasMessagingSettings
 
 /**
  * Orchestrates the Canvas connection UI:
@@ -48,6 +50,24 @@ class CanvasSyncViewModel(application: Application) : AndroidViewModel(applicati
         _uiState.update { it.copy(tokenInput = newValue, statusMessage = null) }
     }
 
+    /** Re-checks the saved token whenever the Canvas screen opens. */
+    fun refreshConnectionState() {
+        if (tokenStore.hasToken()) {
+            _uiState.update {
+                it.copy(hasToken = true)
+            }
+        } else {
+            hideCanvasFeatures()
+
+            _uiState.update {
+                CanvasUiState(
+                    hasToken = false,
+                    statusMessage = DISCONNECTED_PROMPT
+                )
+            }
+        }
+    }
+
     /**
      * Saves the entered token, then probes /users/self to confirm it works.
      * Clears the input field afterwards so the secret isn't sitting in
@@ -55,27 +75,44 @@ class CanvasSyncViewModel(application: Application) : AndroidViewModel(applicati
      */
     fun onSaveAndTest() {
         val raw = _uiState.value.tokenInput.trim()
+
         if (raw.isEmpty()) {
             _uiState.update { it.copy(statusMessage = "Paste your Canvas token first.") }
             return
         }
-        _uiState.update { it.copy(isBusy = true, statusMessage = "Testing connection…") }
+
+        _uiState.update {
+            it.copy(
+                isBusy = true,
+                statusMessage = "Testing connection…"
+            )
+        }
+
         viewModelScope.launch {
             tokenStore.saveToken(raw)
-            // Probing is a network call — run off the main thread.
-            val result = withContext(Dispatchers.IO) { apiClient.probeAuth() }
+
+            // Probing is a network call, so run it off the main thread.
+            val result = withContext(Dispatchers.IO) {
+                apiClient.probeAuth()
+            }
+
             when (result) {
-                is CanvasAuthResult.Success -> _uiState.update {
-                    it.copy(
-                        isBusy = false,
-                        hasToken = true,
-                        tokenInput = "",
-                        statusMessage = "Connected as ${result.userName}."
-                    )
+                is CanvasAuthResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isBusy = false,
+                            hasToken = true,
+                            tokenInput = "",
+                            statusMessage = "Connected as ${result.userName}."
+                        )
+                    }
                 }
+
                 is CanvasAuthResult.Failure -> {
-                    // Token is bad — wipe it so subsequent runs don't hit Canvas with a dud.
+                    // Token is bad, so wipe it and hide Canvas-only features.
                     tokenStore.clear()
+                    hideCanvasFeatures()
+
                     _uiState.update {
                         it.copy(
                             isBusy = false,
@@ -117,15 +154,23 @@ class CanvasSyncViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
-    /** Removes the stored token and resets the UI to disconnected. */
+    /** Removes the stored token, hides Canvas data, and resets the UI to disconnected. */
     fun onDisconnect() {
         tokenStore.clear()
+        hideCanvasFeatures()
+
         _uiState.update {
             CanvasUiState(
                 hasToken = false,
-                statusMessage = "Canvas disconnected."
+                statusMessage = DISCONNECTED_PROMPT
             )
         }
+    }
+
+    // Hides Canvas-only app surfaces after the token is removed.
+    private fun hideCanvasFeatures() {
+        CanvasDisplaySettings.showCanvasInCalendar = false
+        CanvasMessagingSettings.showCanvasMessaging = false
     }
 
     private fun formatSummary(r: CanvasSyncResult): String {
@@ -139,6 +184,12 @@ class CanvasSyncViewModel(application: Application) : AndroidViewModel(applicati
         val skipNote = if (r.skipped.isNotEmpty()) " ${r.skipped.size} skipped." else ""
         return main + skipNote
     }
+
+    companion object {
+        private const val DISCONNECTED_PROMPT =
+            "Canvas is disconnected. Enter a valid Canvas access token to sync again."
+    }
+
 }
 
 /** UI state for the Canvas connection screen. */

--- a/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/example/cinet/navigation/AppTopBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -30,6 +31,8 @@ import androidx.compose.material3.TextButton
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.cinet.feature.social.ConversationTopBarState
+import androidx.compose.foundation.layout.RowScope
+
 
 
 // Draws the persistent page title bar used across the app.
@@ -40,19 +43,20 @@ internal fun AppTopBar(
     nickname: String = "",
     mapTopBarContent: (@Composable RowScope.() -> Unit)? = null,
     calendarTopBarContent: (@Composable RowScope.() -> Unit)? = null,
+    settingsTopBarActions: (@Composable RowScope.() -> Unit)? = null,
     onBack: () -> Unit,
     onFriendsClick: () -> Unit,
     onNewMessageClick: () -> Unit,
     onCanvasMessagesClick: () -> Unit,
-){
+    onSettingsCanvasClick: () -> Unit,
+    onSettingsSignOutClick: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.primary)
             .statusBarsPadding()
     ) {
-        val topBarHeight = if (mapTopBarContent != null) 70.dp else 60.dp
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -62,6 +66,7 @@ internal fun AppTopBar(
         ) {
             val newConversationTopBarState = state.newConversationTopBarState
             val conversationTopBarState = state.conversationTopBarState
+
             if (state.showBackButton) {
                 IconButton(onClick = onBack) {
                     Icon(
@@ -70,6 +75,7 @@ internal fun AppTopBar(
                         tint = Color.White
                     )
                 }
+
                 Spacer(modifier = Modifier.width(4.dp))
             }
 
@@ -146,6 +152,13 @@ internal fun AppTopBar(
                     onNewMessageClick = onNewMessageClick,
                     onCanvasMessagesClick = onCanvasMessagesClick
                 )
+            } else if (state.showSettingsActions) {
+                SettingsTopBarActions(
+                    onCanvasSyncClick = onSettingsCanvasClick,
+                    onSignOutClick = onSettingsSignOutClick
+                )
+            } else if (settingsTopBarActions != null) {
+                settingsTopBarActions()
             }
         }
     }
@@ -346,5 +359,32 @@ private fun SocialTopBarActions(
                 modifier = Modifier.size(32.dp)
             )
         }
+    }
+}
+
+// Shows the Canvas Sync and Sign Out actions used by the Settings page.
+@Composable
+private fun SettingsTopBarActions(
+    onCanvasSyncClick: () -> Unit,
+    onSignOutClick: () -> Unit,
+) {
+    IconButton(onClick = onCanvasSyncClick) {
+        Icon(
+            imageVector = Icons.Default.Sync,
+            contentDescription = "Canvas Sync",
+            tint = Color.White,
+            modifier = Modifier.size(32.dp)
+        )
+    }
+
+    Spacer(modifier = Modifier.width(12.dp))
+
+    IconButton(onClick = onSignOutClick) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Logout,
+            contentDescription = "Sign out",
+            tint = Color.White,
+            modifier = Modifier.size(32.dp)
+        )
     }
 }

--- a/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
+++ b/app/src/main/java/com/example/cinet/navigation/MainScaffold.kt
@@ -402,6 +402,10 @@ internal fun MainScaffold(
                     !showNewConversation &&
                     !showSocialScreen,
             showCanvasMessagesAction = showCanvasMessagesAction,
+            showSettingsActions = currentScreen == Screen.Settings &&
+                    !showCanvasScreen &&
+                    !showProfileEdit &&
+                    selectedProfile == null,
             pendingRequestCount = pendingRequestCount,
             isHomeScreen = currentScreen == Screen.Home &&
                     selectedNewsArticle == null &&
@@ -622,6 +626,8 @@ internal fun MainScaffold(
             showNewConversation = true
         },
         onTopBarCanvasMessagesClick = routeCallbacks.onShowCanvasInbox,
+        onSettingsCanvasClick = routeCallbacks.onOpenCanvas,
+        onSettingsSignOutClick = routeCallbacks.onSignOut,
         onMapBack = ::popBackStack,
         onMapFinishedLoading = {
             preSelectedMapLocation = null

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScaffoldContent.kt
@@ -30,6 +30,8 @@ internal fun NavigationScaffoldContent(
     onTopBarFriendsClick: () -> Unit,
     onTopBarCanvasMessagesClick: () -> Unit,
     onTopBarNewMessageClick: () -> Unit,
+    onSettingsCanvasClick: () -> Unit,
+    onSettingsSignOutClick: () -> Unit,
     onMapBack: () -> Unit,
     onMapFinishedLoading: () -> Unit,
     onRemoveExtraLocation: (CampusLocation) -> Unit,
@@ -68,7 +70,9 @@ internal fun NavigationScaffoldContent(
                 },
                 onFriendsClick = onTopBarFriendsClick,
                 onNewMessageClick = onTopBarNewMessageClick,
-                onCanvasMessagesClick = onTopBarCanvasMessagesClick
+                onCanvasMessagesClick = onTopBarCanvasMessagesClick,
+                onSettingsCanvasClick = onSettingsCanvasClick,
+                onSettingsSignOutClick = onSettingsSignOutClick
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/cinet/navigation/NavigationScreenRoute.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationScreenRoute.kt
@@ -84,11 +84,9 @@ internal fun NavigationScreenRoute(
             onSelectedProfileBack = callbacks.onSettingsSelectedProfileBack,
             onEditProfile = callbacks.onShowProfileEdit,
             onSettingsBack = { callbacks.onGoToScreen(Screen.Home) },
-            onSignOut = callbacks.onSignOut,
             onSettingsChange = callbacks.onSettingsChange,
             onReadReceiptsChange = callbacks.onReadReceiptsChange,
             onViewProfile = callbacks.onViewProfile,
-            onOpenCanvas = callbacks.onOpenCanvas,
         )
     }
 }

--- a/app/src/main/java/com/example/cinet/navigation/NavigationSettingsRoute.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationSettingsRoute.kt
@@ -25,11 +25,9 @@ internal fun NavigationSettingsRoute(
     onSelectedProfileBack: () -> Unit,
     onEditProfile: () -> Unit,
     onSettingsBack: () -> Unit,
-    onSignOut: () -> Unit,
     onSettingsChange: (Boolean, Boolean, AppThemeColor) -> Unit,
     onReadReceiptsChange: (Boolean) -> Unit,
     onViewProfile: () -> Unit,
-    onOpenCanvas: () -> Unit,
 ) {
     when {
         showCanvasScreen -> CanvasConnectionScreen(
@@ -63,14 +61,12 @@ internal fun NavigationSettingsRoute(
 
         else -> SettingScreen(
             onBack = onSettingsBack,
-            onSignOut = onSignOut,
             isDarkMode = userProfile.isDarkMode,
             notificationsEnabled = userProfile.notificationsEnabled,
             selectedTheme = AppSettings.selectedTheme,
             onSettingsChange = onSettingsChange,
             userProfile = userProfile,
             onViewProfile = onViewProfile,
-            onOpenCanvas = onOpenCanvas,
             showHeader = false,
             readReceiptsEnabled = userProfile.readReceiptsEnabled,
             onReadReceiptsChange = onReadReceiptsChange,

--- a/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
+++ b/app/src/main/java/com/example/cinet/navigation/NavigationTopBarState.kt
@@ -8,6 +8,7 @@ internal data class NavigationTopBarState(
     val showBackButton: Boolean,
     val showSocialActions: Boolean,
     val showCanvasMessagesAction: Boolean = false,
+    val showSettingsActions: Boolean = false,
     val pendingRequestCount: Int,
     val isHomeScreen: Boolean = false,
     val nickname: String = "",


### PR DESCRIPTION
Canvas token API patch:
- fixed the token sign out bug, now it tells user they need to enter a valid token and no longer shows sensitive info after the token is removed upon sign out

Study session event adding patch:
- fixing bug found in study session creation for classes, non-starred classes were still being displayed in the class selection drop down menu.